### PR TITLE
Replace shell-based photogrammetry execution with auditable runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m py_compile photogrammetry.py config.py tests/test_photogrammetry.py
+      - run: python -m unittest discover -s tests -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,12 @@ jobs:
   unittest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py tests/test_photogrammetry.py
       - run: python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -53,6 +53,33 @@ work/
     └── <sha256>.jpg
 ```
 
+## 外部フォトグラメトリ実行
+
+`photogrammetry.py` はMeshroom、VisualSFM、COLMAPの実行コマンドを引数配列で構築し、`shell=True`を使用しません。アプリケーションから外部ソフトを自動インストールせず、実行ファイルが見つからない場合は具体的な設定方法を示して停止します。
+
+実行ファイルは、`BackendConfig(executable=...)`、JSON設定、または次の環境変数で指定します。
+
+- `AUTOPHOTOGRAMMETRY_MESHROOM_EXECUTABLE`
+- `AUTOPHOTOGRAMMETRY_VISUALSFM_EXECUTABLE`
+- `AUTOPHOTOGRAMMETRY_COLMAP_EXECUTABLE`
+
+設定例:
+
+```json
+{
+  "meshroom": {
+    "executable": "C:/Tools/Meshroom/meshroom_photogrammetry.exe",
+    "extra_args": []
+  },
+  "colmap": {
+    "executable": "/usr/bin/colmap",
+    "extra_args": ["--quality", "medium"]
+  }
+}
+```
+
+各実行は`<output_root>/<backend>/<run_id>/`へ分離され、`manifest.json`、`stdout.log`、`stderr.log`、生成物一覧を保存します。対応OSは各外部ソフトが提供するWindowsまたはLinux環境です。VisualSFMのコマンドライン仕様は配布版によって異なるため、実環境で追加引数を確認してください。
+
 ## テスト
 
 ```bash
@@ -65,6 +92,9 @@ python -m unittest discover -s tests -v
 - 異なる解像度同士でもSSIMを計算できる
 - 選別が元ファイルを削除しない
 - 空入力を安全に処理する
+- 空白を含むパスを1引数として安全に扱う
+- 外部実行ファイルがない場合に自動インストールせず停止する
+- backendごとにrun、manifest、ログ、成果物を分離する
 
 ## 利用条件と限界
 
@@ -73,9 +103,10 @@ python -m unittest discover -s tests -v
 - 検索エンジンの無断スクレイピング機能はありません
 - 同じ対象物・同じ撮影条件・十分な視点重複を自動証明しません
 - クラスタ番号は3D形状やカメラ姿勢を意味しません
-- COLMAP、AliceVision、Meshroomによる再構成は未実装です
+- 外部バックエンドの導入、ライセンス、GPU要件、入力互換性は利用者が確認します
+- SSIMは生成レンダーと参照画像の画像類似度であり、再投影誤差やメッシュ精度の代替ではありません
 - 再投影誤差、登録画像率、メッシュ完全性を測るまでは、フォトグラメトリー品質を主張できません
 
 以前のREADMEにあった「最高品質」「再構成精度90%以上」等は、再現可能な証拠がないため削除しています。
 
-**README最終監査:** 2026-08-02
+**README最終監査:** 2026-08-06

--- a/config.py
+++ b/config.py
@@ -1,1 +1,26 @@
+from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from photogrammetry import BackendConfig, SUPPORTED_BACKENDS
+
+
+def load_backend_configs(path: str | Path) -> dict[str, BackendConfig]:
+    """Load optional executable paths and argument arrays from a JSON file."""
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    unknown = sorted(set(data) - set(SUPPORTED_BACKENDS))
+    if unknown:
+        raise ValueError(f"Unsupported backend keys: {unknown}")
+    configs: dict[str, BackendConfig] = {}
+    for backend, raw in data.items():
+        if not isinstance(raw, dict):
+            raise ValueError(f"Configuration for {backend} must be an object.")
+        extra_args = raw.get("extra_args", [])
+        if not isinstance(extra_args, list) or not all(isinstance(item, str) for item in extra_args):
+            raise ValueError(f"extra_args for {backend} must be an array of strings.")
+        executable = raw.get("executable")
+        if executable is not None and not isinstance(executable, str):
+            raise ValueError(f"executable for {backend} must be a string or null.")
+        configs[backend] = BackendConfig(executable=executable, extra_args=tuple(extra_args))
+    return configs

--- a/photogrammetry.py
+++ b/photogrammetry.py
@@ -1,77 +1,270 @@
-import os
-import subprocess
-import numpy as np
-from skimage.io import imread
-from skimage.metrics import structural_similarity as ssim
-from skimage.transform import resize
-import platform
+from __future__ import annotations
 
-software_config = {
-    "meshroom": {
-        "windows": {
-            "install_command": "msiexec /i meshroom_installer.msi /quiet",
-            "executable": r"C:\Program Files\Meshroom\meshroom_photogrammetry.exe",
-            "command": "--input {image_dir} --output {output_dir}"
-        },
-        "linux": {
-            "install_command": "sudo apt install meshroom",
-            "executable": "meshroom_photogrammetry",
-            "command": "--input {image_dir} --output {output_dir}"
-        }
-    },
-    "visualsfm": {
-        "windows": {
-            "install_command": "visualsfm_installer.exe /S",
-            "executable": r"C:\Program Files\VisualSFM\visualsfm.exe",
-            "command": "{image_dir} {output_dir}"
-        },
-        "linux": {
-            "install_command": "sudo apt install visualsfm",
-            "executable": "visualsfm",
-            "command": "{image_dir} {output_dir}"
-        }
-    },
-    "colmap": {
-        "windows": {
-            "install_command": "colmap_installer.exe /S",
-            "executable": r"C:\Program Files\COLMAP\colmap.exe",
-            "command": "automatic_reconstructor --image_path {image_dir} --workspace_path {output_dir}"
-        },
-        "linux": {
-            "install_command": "sudo apt install colmap",
-            "executable": "colmap",
-            "command": "automatic_reconstructor --image_path {image_dir} --workspace_path {output_dir}"
-        }
-    }
+import json
+import os
+import platform
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Sequence
+
+SUPPORTED_BACKENDS = ("meshroom", "visualsfm", "colmap")
+ENV_VARS = {
+    "meshroom": "AUTOPHOTOGRAMMETRY_MESHROOM_EXECUTABLE",
+    "visualsfm": "AUTOPHOTOGRAMMETRY_VISUALSFM_EXECUTABLE",
+    "colmap": "AUTOPHOTOGRAMMETRY_COLMAP_EXECUTABLE",
+}
+DEFAULT_EXECUTABLES = {
+    "meshroom": "meshroom_photogrammetry.exe" if platform.system() == "Windows" else "meshroom_photogrammetry",
+    "visualsfm": "VisualSFM.exe" if platform.system() == "Windows" else "visualsfm",
+    "colmap": "colmap.exe" if platform.system() == "Windows" else "colmap",
 }
 
-def get_os():
-    return "windows" if platform.system() == "Windows" else "linux"
 
-def install_if_not_exists(software):
-    if not os.path.exists(software_config[software][get_os()]["executable"]):
-        subprocess.run(software_config[software][get_os()]["install_command"], shell=True, check=True)
+class BackendConfigurationError(RuntimeError):
+    """Raised when an external backend is not explicitly available."""
 
-def create_3d_model(image_dir, output_dir, software):
-    install_if_not_exists(software)
-    command = software_config[software][get_os()]["command"].format(image_dir=image_dir, output_dir=output_dir)
-    executable = software_config[software][get_os()]["executable"]
-    if get_os() == "windows":
-        executable = f"\"{executable}\""
-    subprocess.run(f"{executable} {command}", shell=True, check=True)
 
-def evaluate_3d_model(image_dir, output_dir):
-    ref_image = imread(os.path.join(image_dir, os.listdir(image_dir)[0]))
-    generated_images = [
-        resize(imread(os.path.join(output_dir, filename)), ref_image.shape)
-        for filename in os.listdir(output_dir)
-        if filename.endswith((".jpg", ".png")) and not filename.startswith(("depth", "normal"))
+@dataclass(frozen=True)
+class BackendConfig:
+    executable: str | None = None
+    extra_args: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RunResult:
+    backend: str
+    run_id: str
+    run_dir: str
+    command: list[str]
+    executable: str
+    version: str | None
+    started_at: str
+    finished_at: str
+    return_code: int
+    stdout_log: str
+    stderr_log: str
+    artifacts: list[str]
+    manifest_path: str
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_backend(backend: str) -> str:
+    normalized = backend.strip().lower()
+    if normalized not in SUPPORTED_BACKENDS:
+        raise ValueError(f"Unsupported backend: {backend!r}. Expected one of {SUPPORTED_BACKENDS}.")
+    return normalized
+
+
+def resolve_executable(
+    backend: str,
+    config: BackendConfig | None = None,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    backend = _validate_backend(backend)
+    config = config or BackendConfig()
+    env = env or os.environ
+    candidate = config.executable or env.get(ENV_VARS[backend]) or DEFAULT_EXECUTABLES[backend]
+    candidate_path = Path(candidate).expanduser()
+
+    if candidate_path.is_absolute() or candidate_path.parent != Path("."):
+        resolved = candidate_path.resolve()
+        if resolved.is_file():
+            return resolved
+    else:
+        found = shutil.which(str(candidate_path))
+        if found:
+            return Path(found).resolve()
+
+    env_name = ENV_VARS[backend]
+    raise BackendConfigurationError(
+        f"{backend} executable was not found. Install it outside this application, then set "
+        f"{env_name} to the executable path or pass BackendConfig(executable=...)."
+    )
+
+
+def build_command(
+    backend: str,
+    executable: str | Path,
+    image_dir: str | Path,
+    output_dir: str | Path,
+    extra_args: Sequence[str] = (),
+) -> list[str]:
+    backend = _validate_backend(backend)
+    executable = str(Path(executable))
+    image_dir = str(Path(image_dir))
+    output_dir = str(Path(output_dir))
+
+    if backend == "meshroom":
+        args = [executable, "--input", image_dir, "--output", output_dir]
+    elif backend == "visualsfm":
+        args = [executable, image_dir, output_dir]
+    else:
+        args = [
+            executable,
+            "automatic_reconstructor",
+            "--image_path",
+            image_dir,
+            "--workspace_path",
+            output_dir,
+        ]
+    return [*args, *map(str, extra_args)]
+
+
+def _read_version(executable: Path) -> str | None:
+    for flag in ("--version", "-version", "-h"):
+        try:
+            completed = subprocess.run(
+                [str(executable), flag],
+                shell=False,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        text = (completed.stdout or completed.stderr).strip()
+        if text:
+            return text.splitlines()[0][:500]
+    return None
+
+
+def _list_artifacts(run_dir: Path, excluded: set[Path]) -> list[str]:
+    return sorted(
+        path.relative_to(run_dir).as_posix()
+        for path in run_dir.rglob("*")
+        if path.is_file() and path not in excluded
+    )
+
+
+def run_backend(
+    backend: str,
+    image_dir: str | Path,
+    output_root: str | Path,
+    config: BackendConfig | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> RunResult:
+    backend = _validate_backend(backend)
+    config = config or BackendConfig()
+    image_dir = Path(image_dir).expanduser().resolve()
+    if not image_dir.is_dir():
+        raise ValueError(f"Image directory does not exist or is not a directory: {image_dir}")
+
+    executable = resolve_executable(backend, config, env)
+    run_id = f"{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}-{uuid.uuid4().hex[:8]}"
+    run_dir = Path(output_root).expanduser().resolve() / backend / run_id
+    model_dir = run_dir / "model"
+    model_dir.mkdir(parents=True, exist_ok=False)
+
+    stdout_log = run_dir / "stdout.log"
+    stderr_log = run_dir / "stderr.log"
+    manifest_path = run_dir / "manifest.json"
+    command = build_command(backend, executable, image_dir, model_dir, config.extra_args)
+    started_at = _utc_now()
+
+    try:
+        completed = subprocess.run(
+            command,
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return_code = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        return_code = 124
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + f"\nTimed out after {timeout} seconds."
+
+    stdout_log.write_text(stdout, encoding="utf-8")
+    stderr_log.write_text(stderr, encoding="utf-8")
+    finished_at = _utc_now()
+    artifacts = _list_artifacts(run_dir, {stdout_log, stderr_log, manifest_path})
+
+    manifest = {
+        "schema_version": 1,
+        "backend": backend,
+        "run_id": run_id,
+        "executable": str(executable),
+        "version": _read_version(executable),
+        "command": command,
+        "image_dir": str(image_dir),
+        "model_dir": str(model_dir),
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "return_code": return_code,
+        "stdout_log": stdout_log.name,
+        "stderr_log": stderr_log.name,
+        "artifacts": artifacts,
+    }
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    result = RunResult(
+        backend=backend,
+        run_id=run_id,
+        run_dir=str(run_dir),
+        command=command,
+        executable=str(executable),
+        version=manifest["version"],
+        started_at=started_at,
+        finished_at=finished_at,
+        return_code=return_code,
+        stdout_log=str(stdout_log),
+        stderr_log=str(stderr_log),
+        artifacts=artifacts,
+        manifest_path=str(manifest_path),
+    )
+    if return_code != 0:
+        raise subprocess.CalledProcessError(return_code, command, output=stdout, stderr=stderr)
+    return result
+
+
+def run_photogrammetry(
+    image_dir: str | Path,
+    output_root: str | Path,
+    software_list: Sequence[str],
+    configs: Mapping[str, BackendConfig] | None = None,
+) -> list[RunResult]:
+    configs = configs or {}
+    return [
+        run_backend(backend, image_dir, output_root, configs.get(backend))
+        for backend in software_list
     ]
-    ssim_scores = [ssim(ref_image, img, multichannel=True) for img in generated_images]
-    return np.mean(ssim_scores)
 
-def run_photogrammetry(image_dir, output_dir, software_list):
-    for software in software_list:
-        create_3d_model(image_dir, output_dir, software)
-        mean_ssim = evaluate_3d_model(image_dir, output_dir)
-        print(f"3D model created using {software}. Mean SSIM score: {mean_ssim:.4f}")
+
+def evaluate_3d_model(image_dir: str | Path, output_dir: str | Path) -> float:
+    """Compare generated renders to the first reference image; reconstruction quality is not implied."""
+    import numpy as np
+    from skimage.io import imread
+    from skimage.metrics import structural_similarity as ssim
+    from skimage.transform import resize
+
+    image_dir = Path(image_dir)
+    output_dir = Path(output_dir)
+    reference_files = sorted(path for path in image_dir.iterdir() if path.is_file())
+    if not reference_files:
+        raise ValueError("No reference image was found.")
+    ref_image = imread(reference_files[0])
+    generated_images = [
+        resize(imread(path), ref_image.shape, preserve_range=True, anti_aliasing=True)
+        for path in sorted(output_dir.iterdir())
+        if path.suffix.lower() in {".jpg", ".jpeg", ".png"}
+        and not path.name.startswith(("depth", "normal"))
+    ]
+    if not generated_images:
+        raise ValueError("No generated render was found for evaluation.")
+    channel_axis = -1 if ref_image.ndim == 3 else None
+    scores = [ssim(ref_image, image, channel_axis=channel_axis, data_range=255) for image in generated_images]
+    return float(np.mean(scores))

--- a/tests/test_photogrammetry.py
+++ b/tests/test_photogrammetry.py
@@ -1,0 +1,76 @@
+import json
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from photogrammetry import (
+    BackendConfig,
+    BackendConfigurationError,
+    build_command,
+    resolve_executable,
+    run_backend,
+)
+
+
+class PhotogrammetryRunnerTests(unittest.TestCase):
+    def test_commands_are_argument_arrays_and_preserve_spaces(self):
+        image_dir = Path("input images")
+        output_dir = Path("output models")
+        commands = {
+            "meshroom": ["tool", "--input", str(image_dir), "--output", str(output_dir)],
+            "visualsfm": ["tool", str(image_dir), str(output_dir)],
+            "colmap": [
+                "tool", "automatic_reconstructor", "--image_path", str(image_dir),
+                "--workspace_path", str(output_dir),
+            ],
+        }
+        for backend, expected in commands.items():
+            with self.subTest(backend=backend):
+                self.assertEqual(build_command(backend, "tool", image_dir, output_dir), expected)
+
+    def test_missing_executable_fails_with_configuration_guidance(self):
+        with patch("photogrammetry.shutil.which", return_value=None):
+            with self.assertRaisesRegex(BackendConfigurationError, "AUTOPHOTOGRAMMETRY_COLMAP_EXECUTABLE"):
+                resolve_executable("colmap", env={})
+
+    def test_run_writes_separate_manifest_logs_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            image_dir = root / "input images"
+            output_root = root / "output models"
+            image_dir.mkdir()
+            executable = root / "fake tool.py"
+            executable.write_text(
+                "#!/usr/bin/env python3\n"
+                "import pathlib, sys\n"
+                "if '--version' in sys.argv:\n"
+                "    print('fake 1.0')\n"
+                "    raise SystemExit(0)\n"
+                "out = pathlib.Path(sys.argv[sys.argv.index('--output') + 1])\n"
+                "out.mkdir(parents=True, exist_ok=True)\n"
+                "(out / 'result.txt').write_text('ok', encoding='utf-8')\n"
+                "print('completed')\n",
+                encoding="utf-8",
+            )
+            executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+
+            result = run_backend(
+                "meshroom",
+                image_dir,
+                output_root,
+                BackendConfig(executable=str(executable)),
+            )
+            manifest = json.loads(Path(result.manifest_path).read_text(encoding="utf-8"))
+            self.assertEqual(result.return_code, 0)
+            self.assertEqual(manifest["backend"], "meshroom")
+            self.assertEqual(manifest["version"], "fake 1.0")
+            self.assertIn("model/result.txt", manifest["artifacts"])
+            self.assertEqual(Path(result.stdout_log).read_text(encoding="utf-8"), "completed\n")
+            self.assertTrue(any("input images" in arg for arg in result.command))
+            self.assertTrue(Path(result.run_dir).is_relative_to(output_root / "meshroom"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 変更内容

- Meshroom、VisualSFM、COLMAPのコマンドを引数配列として構築し、`shell=True`と自動インストールを撤廃
- 明示パス、環境変数、`shutil.which()`による実行ファイル解決を追加
- backend/runごとに出力を分離し、manifest、stdout、stderr、生成物一覧、version、終了コードを保存
- JSON設定loaderを追加
- 空白を含むpath、実行ファイル欠損、manifest生成を外部ソフトなしで検証するunit testを追加
- GitHub Actionsと日本語READMEを更新

## 検証

- `python -m py_compile photogrammetry.py config.py tests/test_photogrammetry.py`
- `python -m unittest discover -s tests -v`
- 新規3テストはローカルでPASS

Closes #1