### PR TITLE
Add reproducible video-to-Gaussian-Splat pipeline helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,24 +21,32 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
-      - name: Temporary Cabo single-take fixture evidence
+      - name: Temporary Cabo video evidence
         run: |
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq ffmpeg
-          mkdir -p /tmp/evidence /tmp/frames /tmp/selected
+          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected
           curl --fail --location --retry 3 --output /tmp/cabo.webm \
             https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
           echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
-          ffprobe -v error -show_entries format=duration,size:stream=codec_name,width,height -of json /tmp/cabo.webm | tee /tmp/evidence/ffprobe.json
+          ffprobe -v error -show_entries format=duration,size,format_name:stream=codec_name,width,height -of json /tmp/cabo.webm | tee /tmp/evidence/ffprobe.json
           ffmpeg -hide_banner -i /tmp/cabo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
           grep -oE 'pts_time:[0-9.]+' /tmp/scene.log | tee /tmp/evidence/scene-cut-candidates.txt || true
-          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=3 -q:v 2 /tmp/frames/frame-%06d.jpg
-          echo "frames_3fps=$(find /tmp/frames -type f -name 'frame-*.jpg' | wc -l)"
+          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=2 -q:v 2 /tmp/frames2/frame-%06d.jpg
+          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=3 -q:v 2 /tmp/frames3/frame-%06d.jpg
+          echo "frames_2fps=$(find /tmp/frames2 -type f -name 'frame-*.jpg' | wc -l)"
+          echo "frames_3fps=$(find /tmp/frames3 -type f -name 'frame-*.jpg' | wc -l)"
           python - <<'PY'
           import json
           from pathlib import Path
-          from video_pipeline import VideoSource, probe_video, select_video_frames, write_source_manifest
+          from video_pipeline import (
+              VideoSource,
+              frame_timestamp_records,
+              probe_video,
+              select_video_frames,
+              write_source_manifest,
+          )
 
           source = VideoSource(
               title="Diving in Cabo San Lucas",
@@ -50,7 +58,11 @@ jobs:
               target="ship wreck near Land's End, Cabo San Lucas, Mexico",
           )
           write_source_manifest("/tmp/cabo.webm", source, probe_video("/tmp/cabo.webm"), "/tmp/evidence/source-manifest.json")
-          frames = sorted(Path("/tmp/frames").glob("frame-*.jpg"))
+          frames = sorted(Path("/tmp/frames3").glob("frame-*.jpg"))
+          Path("/tmp/evidence/frame-timestamps.json").write_text(
+              json.dumps(frame_timestamp_records(frames, fps=3), indent=2) + "\n",
+              encoding="utf-8",
+          )
           stats = select_video_frames(frames, "/tmp/selected")
           Path("/tmp/evidence/frame-selection.json").write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
           print(json.dumps({key: value for key, value in stats.items() if key != "selected_paths"}, sort_keys=True))
@@ -61,6 +73,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cabo-single-take-evidence
+          name: cabo-video-evidence
           path: /tmp/evidence
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq ffmpeg colmap
-          mkdir -p /tmp/evidence /tmp/frames /tmp/selected /tmp/colmap_images /tmp/sparse /tmp/models_txt
+          mkdir -p /tmp/evidence /tmp/frames /tmp/selected /tmp/sparse /tmp/models_txt
 
           media_url='https://upload.wikimedia.org/wikipedia/commons/transcoded/3/34/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm.1080p.vp9.webm'
           expected_sha256='c9723df1af171d40a5bf1f9530aa3ea881c6f95252ef3f2004f0f1013ab92e30'
@@ -37,35 +37,30 @@ jobs:
           test "$actual_sha256" = "$expected_sha256"
           ffprobe -v error -show_entries format=duration,size,format_name:stream=codec_name,width,height -of json /tmp/huejotzingo.webm | tee /tmp/evidence/ffprobe.json
 
-          ffmpeg -hide_banner -loglevel error -i /tmp/huejotzingo.webm -vf fps=1 -q:v 2 /tmp/frames/frame-%06d.jpg
+          ffmpeg -hide_banner -loglevel error -i /tmp/huejotzingo.webm \
+            -vf 'fps=1/3,scale=1024:-2' -q:v 2 /tmp/frames/frame-%06d.jpg
           python - <<'PY'
           import json
-          import math
-          import shutil
           from pathlib import Path
           from video_pipeline import frame_timestamp_records, select_video_frames
 
           frames = sorted(Path('/tmp/frames').glob('frame-*.jpg'))
           Path('/tmp/evidence/frame-timestamps.json').write_text(
-              json.dumps(frame_timestamp_records(frames, fps=1), indent=2) + '\n',
+              json.dumps(frame_timestamp_records(frames, fps=1/3), indent=2) + '\n',
               encoding='utf-8',
           )
           stats = select_video_frames(frames, '/tmp/selected')
           Path('/tmp/evidence/frame-selection.json').write_text(json.dumps(stats, indent=2) + '\n', encoding='utf-8')
-
           selected = sorted(Path('/tmp/selected').glob('*.jpg'))
-          stride = max(1, math.ceil(len(selected) / 80))
-          colmap_input = selected[::stride]
-          for path in colmap_input:
-              shutil.copy2(path, Path('/tmp/colmap_images') / path.name)
           input_record = {
+              'sampling_interval_seconds': 3,
               'extracted_frames': len(frames),
               'selected_frames': len(selected),
-              'temporal_stride': stride,
-              'colmap_input_frames': len(colmap_input),
+              'colmap_input_frames': len(selected),
+              'frame_width': 1024,
               'sift_max_image_size': 1024,
               'sift_max_num_features': 4096,
-              'frames': [path.name for path in colmap_input],
+              'frames': [path.name for path in selected],
           }
           Path('/tmp/evidence/colmap-input.json').write_text(json.dumps(input_record, indent=2) + '\n', encoding='utf-8')
           print(json.dumps({key: value for key, value in input_record.items() if key != 'frames'}, sort_keys=True))
@@ -75,7 +70,7 @@ jobs:
           set +e
           colmap feature_extractor \
             --database_path /tmp/colmap.db \
-            --image_path /tmp/colmap_images \
+            --image_path /tmp/selected \
             --ImageReader.single_camera 1 \
             --SiftExtraction.use_gpu 0 \
             --SiftExtraction.max_image_size 1024 \
@@ -89,7 +84,7 @@ jobs:
           matcher_rc=$?
           colmap mapper \
             --database_path /tmp/colmap.db \
-            --image_path /tmp/colmap_images \
+            --image_path /tmp/selected \
             --output_path /tmp/sparse \
             > /tmp/evidence/colmap-mapper.log 2>&1
           mapper_rc=$?
@@ -119,8 +114,7 @@ jobs:
           input_names = input_record['frames']
           models = []
           model_root = Path('/tmp/models_txt')
-          model_dirs = sorted(model_root.iterdir(), key=lambda p: int(p.name)) if model_root.exists() else []
-          for model_dir in model_dirs:
+          for model_dir in sorted(model_root.iterdir(), key=lambda p: int(p.name)) if model_root.exists() else []:
               images_path = model_dir / 'images.txt'
               points_path = model_dir / 'points3D.txt'
               if not images_path.exists():
@@ -131,11 +125,11 @@ jobs:
                   metadata = raw_lines[index].strip()
                   if metadata:
                       registered.append(metadata.split(maxsplit=9)[-1])
-              points = 0
-              if points_path.exists():
-                  points = sum(1 for line in points_path.read_text().splitlines() if line.strip() and not line.startswith('#'))
-              analyzer_path = Path(f'/tmp/evidence/colmap-model-{model_dir.name}-analyzer.txt')
-              analyzer = analyzer_path.read_text() if analyzer_path.exists() else ''
+              points = sum(
+                  1 for line in points_path.read_text().splitlines()
+                  if line.strip() and not line.startswith('#')
+              ) if points_path.exists() else 0
+              analyzer = Path(f'/tmp/evidence/colmap-model-{model_dir.name}-analyzer.txt').read_text()
               error_match = re.search(r'Mean reprojection error:\s*([0-9.eE+-]+)px', analyzer)
               models.append({
                   'model_id': int(model_dir.name),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq ffmpeg colmap
-          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected /tmp/sparse /tmp/model_txt
+          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected /tmp/colmap_images /tmp/sparse /tmp/model_txt
           curl --fail --location --retry 3 --output /tmp/cabo.webm \
             https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
           echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
@@ -39,6 +39,7 @@ jobs:
           echo "frames_3fps=$(find /tmp/frames3 -type f -name 'frame-*.jpg' | wc -l)"
           python - <<'PY'
           import json
+          import shutil
           from pathlib import Path
           from video_pipeline import (
               VideoSource,
@@ -66,6 +67,21 @@ jobs:
           stats = select_video_frames(frames, "/tmp/selected")
           Path("/tmp/evidence/frame-selection.json").write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
           print(json.dumps({key: value for key, value in stats.items() if key != "selected_paths"}, sort_keys=True))
+
+          selected = sorted(Path("/tmp/selected").glob("*.jpg"))
+          colmap_input = selected[::2]
+          for path in colmap_input:
+              shutil.copy2(path, Path("/tmp/colmap_images") / path.name)
+          Path("/tmp/evidence/colmap-input.json").write_text(
+              json.dumps({
+                  "source_selected_frames": len(selected),
+                  "stride": 2,
+                  "colmap_input_frames": len(colmap_input),
+                  "frames": [path.name for path in colmap_input],
+              }, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          print(f"colmap_input_frames={len(colmap_input)}")
           PY
           ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm \
             -vf "fps=1/10,scale=320:-1,tile=4x4:padding=4:margin=4" \
@@ -75,7 +91,7 @@ jobs:
           set +e
           colmap feature_extractor \
             --database_path /tmp/colmap.db \
-            --image_path /tmp/selected \
+            --image_path /tmp/colmap_images \
             --ImageReader.single_camera 1 \
             --SiftExtraction.use_gpu 0 \
             > /tmp/evidence/colmap-feature-extractor.log 2>&1
@@ -87,7 +103,7 @@ jobs:
           matcher_rc=$?
           colmap mapper \
             --database_path /tmp/colmap.db \
-            --image_path /tmp/selected \
+            --image_path /tmp/colmap_images \
             --output_path /tmp/sparse \
             > /tmp/evidence/colmap-mapper.log 2>&1
           mapper_rc=$?
@@ -107,7 +123,7 @@ jobs:
           import re
           from pathlib import Path
 
-          selected = sorted(path.name for path in Path('/tmp/selected').glob('*.jpg'))
+          selected = sorted(path.name for path in Path('/tmp/colmap_images').glob('*.jpg'))
           image_lines = [line.rstrip('\n') for line in Path('/tmp/model_txt/images.txt').read_text().splitlines() if not line.startswith('#')]
           registered = []
           for index in range(0, len(image_lines), 2):

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,89 +21,173 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
-      - name: Temporary Huejotzingo single-take gate
+
+      - name: Temporary Huejotzingo COLMAP evidence
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg
-          mkdir -p /tmp/evidence
-          python - <<'PY'
-          import json
-          from pathlib import Path
-          import requests
+          sudo apt-get install -y -qq ffmpeg colmap
+          mkdir -p /tmp/evidence /tmp/frames /tmp/selected /tmp/colmap_images /tmp/sparse /tmp/models_txt
 
-          headers = {"User-Agent": "AutoPhotogrammetry/0.1 (https://github.com/KAFKA2306/AutoPhotogrammetry)"}
-          title = "File:Vista del Ex Convento de San Miguel Arcángel, Huejotzingo, desde un dron.webm"
-          response = requests.get(
-              "https://commons.wikimedia.org/w/api.php",
-              params={
-                  "action": "query",
-                  "format": "json",
-                  "titles": title,
-                  "prop": "videoinfo",
-                  "viprop": "url|size|derivatives",
-              },
-              headers=headers,
-              timeout=60,
-          )
-          response.raise_for_status()
-          data = response.json()
-          Path("/tmp/evidence/commons-videoinfo.json").write_text(json.dumps(data, indent=2) + "\n")
-          page = next(iter(data["query"]["pages"].values()))
-          info = page["videoinfo"][0]
-          candidates = [
-              item for item in info.get("derivatives", [])
-              if item.get("width") == 1920 and item.get("height") == 1080 and "webm" in item.get("src", "")
-          ]
-          if not candidates:
-              raise SystemExit("No 1920x1080 WebM derivative found")
-          chosen = min(candidates, key=lambda item: int(item.get("bandwidth", 10**12)))
-          Path("/tmp/evidence/media-source.json").write_text(json.dumps({
-              "source_page": "https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm",
-              "original_url": info["url"],
-              "original_size": info["size"],
-              "derivative": chosen,
-          }, indent=2) + "\n")
-          with requests.get(chosen["src"], headers=headers, stream=True, timeout=120) as media:
-              media.raise_for_status()
-              with open("/tmp/huejotzingo.webm", "wb") as output:
-                  for chunk in media.iter_content(1024 * 1024):
-                      if chunk:
-                          output.write(chunk)
-          print(f"derivative_url={chosen['src']}")
-          print(f"downloaded_bytes={Path('/tmp/huejotzingo.webm').stat().st_size}")
-          PY
-          echo "sha256=$(sha256sum /tmp/huejotzingo.webm | cut -d' ' -f1)" | tee /tmp/evidence/sha256.txt
+          media_url='https://upload.wikimedia.org/wikipedia/commons/transcoded/3/34/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm.1080p.vp9.webm'
+          expected_sha256='c9723df1af171d40a5bf1f9530aa3ea881c6f95252ef3f2004f0f1013ab92e30'
+          curl --fail --location --retry 3 --user-agent 'AutoPhotogrammetry/0.1 (https://github.com/KAFKA2306/AutoPhotogrammetry)' --output /tmp/huejotzingo.webm "$media_url"
+          actual_sha256=$(sha256sum /tmp/huejotzingo.webm | cut -d' ' -f1)
+          printf 'expected_sha256=%s\nactual_sha256=%s\n' "$expected_sha256" "$actual_sha256" | tee /tmp/evidence/source-hash.txt
+          test "$actual_sha256" = "$expected_sha256"
           ffprobe -v error -show_entries format=duration,size,format_name:stream=codec_name,width,height -of json /tmp/huejotzingo.webm | tee /tmp/evidence/ffprobe.json
-          ffmpeg -hide_banner -i /tmp/huejotzingo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
-          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log | tee /tmp/evidence/scene-cut-candidates.txt || true
+
+          ffmpeg -hide_banner -loglevel error -i /tmp/huejotzingo.webm -vf fps=1 -q:v 2 /tmp/frames/frame-%06d.jpg
           python - <<'PY'
           import json
-          from video_pipeline import VideoSource, probe_video, write_source_manifest
+          import math
+          import shutil
+          from pathlib import Path
+          from video_pipeline import frame_timestamp_records, select_video_frames
 
-          source_info = json.load(open("/tmp/evidence/media-source.json"))
-          source = VideoSource(
-              title="Vista del Ex Convento de San Miguel Arcángel, Huejotzingo, desde un dron",
-              source_page=source_info["source_page"],
-              media_url=source_info["derivative"]["src"],
-              author="Luisalvaz",
-              license="CC0 1.0",
-              license_url="https://creativecommons.org/publicdomain/zero/1.0/",
-              target="Ex Convento de San Miguel Arcángel, Huejotzingo, Puebla, Mexico",
+          frames = sorted(Path('/tmp/frames').glob('frame-*.jpg'))
+          Path('/tmp/evidence/frame-timestamps.json').write_text(
+              json.dumps(frame_timestamp_records(frames, fps=1), indent=2) + '\n',
+              encoding='utf-8',
           )
-          write_source_manifest(
-              "/tmp/huejotzingo.webm",
-              source,
-              probe_video("/tmp/huejotzingo.webm"),
-              "/tmp/evidence/source-manifest.json",
+          stats = select_video_frames(frames, '/tmp/selected')
+          Path('/tmp/evidence/frame-selection.json').write_text(
+              json.dumps(stats, indent=2) + '\n', encoding='utf-8'
           )
+
+          selected = sorted(Path('/tmp/selected').glob('*.jpg'))
+          stride = max(1, math.ceil(len(selected) / 160))
+          colmap_input = selected[::stride]
+          for path in colmap_input:
+              shutil.copy2(path, Path('/tmp/colmap_images') / path.name)
+          input_record = {
+              'extracted_frames': len(frames),
+              'selected_frames': len(selected),
+              'temporal_stride': stride,
+              'colmap_input_frames': len(colmap_input),
+              'frames': [path.name for path in colmap_input],
+          }
+          Path('/tmp/evidence/colmap-input.json').write_text(
+              json.dumps(input_record, indent=2) + '\n', encoding='utf-8'
+          )
+          print(json.dumps({
+              'extracted_frames': len(frames),
+              'selected_frames': len(selected),
+              'temporal_stride': stride,
+              'colmap_input_frames': len(colmap_input),
+          }, sort_keys=True))
           PY
-          ffmpeg -hide_banner -loglevel error -i /tmp/huejotzingo.webm \
-            -vf "fps=1/10,scale=320:-1,tile=6x4:padding=4:margin=4" \
-            -frames:v 1 /tmp/evidence/contact-sheet.jpg
+
+          colmap -h | head -40 | tee /tmp/evidence/colmap-version.txt
+          set +e
+          colmap feature_extractor \
+            --database_path /tmp/colmap.db \
+            --image_path /tmp/colmap_images \
+            --ImageReader.single_camera 1 \
+            --SiftExtraction.use_gpu 0 \
+            > /tmp/evidence/colmap-feature-extractor.log 2>&1
+          feature_rc=$?
+          colmap sequential_matcher \
+            --database_path /tmp/colmap.db \
+            --SiftMatching.use_gpu 0 \
+            > /tmp/evidence/colmap-sequential-matcher.log 2>&1
+          matcher_rc=$?
+          colmap mapper \
+            --database_path /tmp/colmap.db \
+            --image_path /tmp/colmap_images \
+            --output_path /tmp/sparse \
+            > /tmp/evidence/colmap-mapper.log 2>&1
+          mapper_rc=$?
+          set -e
+
+          model_count=$(find /tmp/sparse -mindepth 1 -maxdepth 1 -type d | wc -l)
+          {
+            echo "feature_extractor_return_code=$feature_rc"
+            echo "sequential_matcher_return_code=$matcher_rc"
+            echo "mapper_return_code=$mapper_rc"
+            echo "submodel_count=$model_count"
+          } | tee /tmp/evidence/colmap-status.txt
+
+          for model_dir in $(find /tmp/sparse -mindepth 1 -maxdepth 1 -type d | sort -V); do
+            model_id=$(basename "$model_dir")
+            mkdir -p "/tmp/models_txt/$model_id"
+            colmap model_analyzer --path "$model_dir" | tee "/tmp/evidence/colmap-model-${model_id}-analyzer.txt"
+            colmap model_converter \
+              --input_path "$model_dir" \
+              --output_path "/tmp/models_txt/$model_id" \
+              --output_type TXT
+          done
+
+          python - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          input_record = json.loads(Path('/tmp/evidence/colmap-input.json').read_text())
+          input_names = input_record['frames']
+          models = []
+          for model_dir in sorted(Path('/tmp/models_txt').iterdir(), key=lambda p: int(p.name)) if Path('/tmp/models_txt').exists() else []:
+              images_path = model_dir / 'images.txt'
+              points_path = model_dir / 'points3D.txt'
+              if not images_path.exists():
+                  continue
+              raw_lines = [line for line in images_path.read_text().splitlines() if not line.startswith('#')]
+              registered = []
+              for index in range(0, len(raw_lines), 2):
+                  metadata = raw_lines[index].strip()
+                  if metadata:
+                      registered.append(metadata.split(maxsplit=9)[-1])
+              points = 0
+              if points_path.exists():
+                  points = sum(
+                      1 for line in points_path.read_text().splitlines()
+                      if line.strip() and not line.startswith('#')
+                  )
+              analyzer_path = Path(f'/tmp/evidence/colmap-model-{model_dir.name}-analyzer.txt')
+              analyzer = analyzer_path.read_text() if analyzer_path.exists() else ''
+              error_match = re.search(r'Mean reprojection error:\s*([0-9.eE+-]+)px', analyzer)
+              models.append({
+                  'model_id': int(model_dir.name),
+                  'registered_images': len(registered),
+                  'registration_rate': len(registered) / len(input_names) if input_names else 0.0,
+                  'sparse_points': points,
+                  'mean_reprojection_error_px': float(error_match.group(1)) if error_match else None,
+                  'registered_names': registered,
+              })
+
+          models.sort(key=lambda item: item['registered_images'], reverse=True)
+          dominant = models[0] if models else None
+          summary = {
+              'input_images': len(input_names),
+              'submodel_count': len(models),
+              'models': models,
+              'dominant_registered_images': dominant['registered_images'] if dominant else 0,
+              'dominant_registration_rate': dominant['registration_rate'] if dominant else 0.0,
+              'dominant_sparse_points': dominant['sparse_points'] if dominant else 0,
+              'dominant_mean_reprojection_error_px': dominant['mean_reprojection_error_px'] if dominant else None,
+              'dominant_failed_images': sorted(set(input_names) - set(dominant['registered_names'])) if dominant else input_names,
+          }
+          Path('/tmp/evidence/colmap-models.json').write_text(
+              json.dumps(summary, indent=2) + '\n', encoding='utf-8'
+          )
+          print(json.dumps({
+              'input_images': summary['input_images'],
+              'submodel_count': summary['submodel_count'],
+              'dominant_registered_images': summary['dominant_registered_images'],
+              'dominant_registration_rate': summary['dominant_registration_rate'],
+              'dominant_sparse_points': summary['dominant_sparse_points'],
+              'dominant_mean_reprojection_error_px': summary['dominant_mean_reprojection_error_px'],
+          }, sort_keys=True))
+          PY
+
+          if [ "$feature_rc" -ne 0 ] || [ "$matcher_rc" -ne 0 ] || [ "$mapper_rc" -ne 0 ] || [ "$model_count" -eq 0 ]; then
+            echo 'COLMAP did not produce a sparse model' >&2
+            exit 1
+          fi
+
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: huejotzingo-single-take-gate
+          name: huejotzingo-colmap-evidence
           path: /tmp/evidence
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           )
 
           selected = sorted(Path('/tmp/selected').glob('*.jpg'))
-          stride = max(1, math.ceil(len(selected) / 160))
+          stride = max(1, math.ceil(len(selected) / 80))
           colmap_input = selected[::stride]
           for path in colmap_input:
               shutil.copy2(path, Path('/tmp/colmap_images') / path.name)
@@ -112,10 +112,7 @@ jobs:
             model_id=$(basename "$model_dir")
             mkdir -p "/tmp/models_txt/$model_id"
             colmap model_analyzer --path "$model_dir" | tee "/tmp/evidence/colmap-model-${model_id}-analyzer.txt"
-            colmap model_converter \
-              --input_path "$model_dir" \
-              --output_path "/tmp/models_txt/$model_id" \
-              --output_type TXT
+            colmap model_converter --input_path "$model_dir" --output_path "/tmp/models_txt/$model_id" --output_type TXT
           done
 
           python - <<'PY'
@@ -126,7 +123,9 @@ jobs:
           input_record = json.loads(Path('/tmp/evidence/colmap-input.json').read_text())
           input_names = input_record['frames']
           models = []
-          for model_dir in sorted(Path('/tmp/models_txt').iterdir(), key=lambda p: int(p.name)) if Path('/tmp/models_txt').exists() else []:
+          model_root = Path('/tmp/models_txt')
+          model_dirs = sorted(model_root.iterdir(), key=lambda p: int(p.name)) if model_root.exists() else []
+          for model_dir in model_dirs:
               images_path = model_dir / 'images.txt'
               points_path = model_dir / 'points3D.txt'
               if not images_path.exists():
@@ -139,10 +138,7 @@ jobs:
                       registered.append(metadata.split(maxsplit=9)[-1])
               points = 0
               if points_path.exists():
-                  points = sum(
-                      1 for line in points_path.read_text().splitlines()
-                      if line.strip() and not line.startswith('#')
-                  )
+                  points = sum(1 for line in points_path.read_text().splitlines() if line.strip() and not line.startswith('#'))
               analyzer_path = Path(f'/tmp/evidence/colmap-model-{model_dir.name}-analyzer.txt')
               analyzer = analyzer_path.read_text() if analyzer_path.exists() else ''
               error_match = re.search(r'Mean reprojection error:\s*([0-9.eE+-]+)px', analyzer)
@@ -167,9 +163,7 @@ jobs:
               'dominant_mean_reprojection_error_px': dominant['mean_reprojection_error_px'] if dominant else None,
               'dominant_failed_images': sorted(set(input_names) - set(dominant['registered_names'])) if dominant else input_names,
           }
-          Path('/tmp/evidence/colmap-models.json').write_text(
-              json.dumps(summary, indent=2) + '\n', encoding='utf-8'
-          )
+          Path('/tmp/evidence/colmap-models.json').write_text(json.dumps(summary, indent=2) + '\n', encoding='utf-8')
           print(json.dumps({
               'input_images': summary['input_images'],
               'submodel_count': summary['submodel_count'],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,7 @@ jobs:
               encoding='utf-8',
           )
           stats = select_video_frames(frames, '/tmp/selected')
-          Path('/tmp/evidence/frame-selection.json').write_text(
-              json.dumps(stats, indent=2) + '\n', encoding='utf-8'
-          )
+          Path('/tmp/evidence/frame-selection.json').write_text(json.dumps(stats, indent=2) + '\n', encoding='utf-8')
 
           selected = sorted(Path('/tmp/selected').glob('*.jpg'))
           stride = max(1, math.ceil(len(selected) / 80))
@@ -65,17 +63,12 @@ jobs:
               'selected_frames': len(selected),
               'temporal_stride': stride,
               'colmap_input_frames': len(colmap_input),
+              'sift_max_image_size': 1024,
+              'sift_max_num_features': 4096,
               'frames': [path.name for path in colmap_input],
           }
-          Path('/tmp/evidence/colmap-input.json').write_text(
-              json.dumps(input_record, indent=2) + '\n', encoding='utf-8'
-          )
-          print(json.dumps({
-              'extracted_frames': len(frames),
-              'selected_frames': len(selected),
-              'temporal_stride': stride,
-              'colmap_input_frames': len(colmap_input),
-          }, sort_keys=True))
+          Path('/tmp/evidence/colmap-input.json').write_text(json.dumps(input_record, indent=2) + '\n', encoding='utf-8')
+          print(json.dumps({key: value for key, value in input_record.items() if key != 'frames'}, sort_keys=True))
           PY
 
           colmap -h | head -40 | tee /tmp/evidence/colmap-version.txt
@@ -85,6 +78,8 @@ jobs:
             --image_path /tmp/colmap_images \
             --ImageReader.single_camera 1 \
             --SiftExtraction.use_gpu 0 \
+            --SiftExtraction.max_image_size 1024 \
+            --SiftExtraction.max_num_features 4096 \
             > /tmp/evidence/colmap-feature-extractor.log 2>&1
           feature_rc=$?
           colmap sequential_matcher \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
-      - name: Temporary Cabo video evidence
+      - name: Temporary Cabo reconstruction evidence
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg
-          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected
+          sudo apt-get install -y -qq ffmpeg colmap
+          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected /tmp/sparse /tmp/model_txt
           curl --fail --location --retry 3 --output /tmp/cabo.webm \
             https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
           echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
@@ -70,9 +70,76 @@ jobs:
           ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm \
             -vf "fps=1/10,scale=320:-1,tile=4x4:padding=4:margin=4" \
             -frames:v 1 /tmp/evidence/contact-sheet.jpg
+
+          colmap -h | head -40 | tee /tmp/evidence/colmap-version.txt
+          set +e
+          colmap feature_extractor \
+            --database_path /tmp/colmap.db \
+            --image_path /tmp/selected \
+            --ImageReader.single_camera 1 \
+            --SiftExtraction.use_gpu 0 \
+            > /tmp/evidence/colmap-feature-extractor.log 2>&1
+          feature_rc=$?
+          colmap sequential_matcher \
+            --database_path /tmp/colmap.db \
+            --SiftMatching.use_gpu 0 \
+            > /tmp/evidence/colmap-sequential-matcher.log 2>&1
+          matcher_rc=$?
+          colmap mapper \
+            --database_path /tmp/colmap.db \
+            --image_path /tmp/selected \
+            --output_path /tmp/sparse \
+            > /tmp/evidence/colmap-mapper.log 2>&1
+          mapper_rc=$?
+          set -e
+
+          model_count=$(find /tmp/sparse -mindepth 1 -maxdepth 1 -type d | wc -l)
+          echo "feature_extractor_return_code=$feature_rc" | tee /tmp/evidence/colmap-status.txt
+          echo "sequential_matcher_return_code=$matcher_rc" | tee -a /tmp/evidence/colmap-status.txt
+          echo "mapper_return_code=$mapper_rc" | tee -a /tmp/evidence/colmap-status.txt
+          echo "submodel_count=$model_count" | tee -a /tmp/evidence/colmap-status.txt
+
+          if [ "$model_count" -gt 0 ]; then
+            colmap model_analyzer --path /tmp/sparse/0 | tee /tmp/evidence/colmap-model-analyzer.txt
+            colmap model_converter --input_path /tmp/sparse/0 --output_path /tmp/model_txt --output_type TXT
+            python - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          selected = sorted(path.name for path in Path('/tmp/selected').glob('*.jpg'))
+          image_lines = [line.rstrip('\n') for line in Path('/tmp/model_txt/images.txt').read_text().splitlines() if not line.startswith('#')]
+          registered = []
+          for index in range(0, len(image_lines), 2):
+              line = image_lines[index].strip()
+              if line:
+                  registered.append(line.split()[-1])
+          points = sum(
+              1 for line in Path('/tmp/model_txt/points3D.txt').read_text().splitlines()
+              if line.strip() and not line.startswith('#')
+          )
+          analyzer = Path('/tmp/evidence/colmap-model-analyzer.txt').read_text()
+          error_match = re.search(r'Mean reprojection error:\s*([0-9.eE+-]+)', analyzer)
+          summary = {
+              'input_images': len(selected),
+              'registered_images': len(registered),
+              'registration_rate': len(registered) / len(selected) if selected else 0.0,
+              'sparse_points': points,
+              'failed_images': sorted(set(selected) - set(registered)),
+              'mean_reprojection_error': float(error_match.group(1)) if error_match else None,
+          }
+          Path('/tmp/evidence/colmap-summary.json').write_text(json.dumps(summary, indent=2) + '\n')
+          print(json.dumps({k: v for k, v in summary.items() if k != 'failed_images'}, sort_keys=True))
+          PY
+          fi
+
+          if [ "$feature_rc" -ne 0 ] || [ "$matcher_rc" -ne 0 ] || [ "$mapper_rc" -ne 0 ] || [ "$model_count" -eq 0 ]; then
+            echo "COLMAP reconstruction did not produce a usable sparse model" >&2
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cabo-video-evidence
+          name: cabo-reconstruction-evidence
           path: /tmp/evidence
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,141 +21,87 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
-      - name: Temporary Cabo reconstruction evidence
+      - name: Temporary Huejotzingo single-take gate
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq ffmpeg colmap
-          mkdir -p /tmp/evidence /tmp/frames2 /tmp/frames3 /tmp/selected /tmp/colmap_images /tmp/sparse /tmp/model_txt
-          curl --fail --location --retry 3 --output /tmp/cabo.webm \
-            https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
-          echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
-          ffprobe -v error -show_entries format=duration,size,format_name:stream=codec_name,width,height -of json /tmp/cabo.webm | tee /tmp/evidence/ffprobe.json
-          ffmpeg -hide_banner -i /tmp/cabo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
-          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log | tee /tmp/evidence/scene-cut-candidates.txt || true
-          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=2 -q:v 2 /tmp/frames2/frame-%06d.jpg
-          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=3 -q:v 2 /tmp/frames3/frame-%06d.jpg
-          echo "frames_2fps=$(find /tmp/frames2 -type f -name 'frame-*.jpg' | wc -l)"
-          echo "frames_3fps=$(find /tmp/frames3 -type f -name 'frame-*.jpg' | wc -l)"
+          sudo apt-get install -y -qq ffmpeg
+          mkdir -p /tmp/evidence
           python - <<'PY'
           import json
-          import shutil
           from pathlib import Path
-          from video_pipeline import (
-              VideoSource,
-              frame_timestamp_records,
-              probe_video,
-              select_video_frames,
-              write_source_manifest,
-          )
+          import requests
 
-          source = VideoSource(
-              title="Diving in Cabo San Lucas",
-              source_page="https://commons.wikimedia.org/wiki/File:Diving_in_Cabo_San_Lucas.webm",
-              media_url="https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm",
-              author="KumiM",
-              license="CC BY 3.0",
-              license_url="https://creativecommons.org/licenses/by/3.0/",
-              target="ship wreck near Land's End, Cabo San Lucas, Mexico",
+          title = "File:Vista del Ex Convento de San Miguel Arcángel, Huejotzingo, desde un dron.webm"
+          response = requests.get(
+              "https://commons.wikimedia.org/w/api.php",
+              params={
+                  "action": "query",
+                  "format": "json",
+                  "titles": title,
+                  "prop": "videoinfo",
+                  "viprop": "url|size|derivatives",
+              },
+              timeout=60,
           )
-          write_source_manifest("/tmp/cabo.webm", source, probe_video("/tmp/cabo.webm"), "/tmp/evidence/source-manifest.json")
-          frames = sorted(Path("/tmp/frames3").glob("frame-*.jpg"))
-          Path("/tmp/evidence/frame-timestamps.json").write_text(
-              json.dumps(frame_timestamp_records(frames, fps=3), indent=2) + "\n",
-              encoding="utf-8",
-          )
-          stats = select_video_frames(frames, "/tmp/selected")
-          Path("/tmp/evidence/frame-selection.json").write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
-          print(json.dumps({key: value for key, value in stats.items() if key != "selected_paths"}, sort_keys=True))
-
-          selected = sorted(Path("/tmp/selected").glob("*.jpg"))
-          colmap_input = selected[::2]
-          for path in colmap_input:
-              shutil.copy2(path, Path("/tmp/colmap_images") / path.name)
-          Path("/tmp/evidence/colmap-input.json").write_text(
-              json.dumps({
-                  "source_selected_frames": len(selected),
-                  "stride": 2,
-                  "colmap_input_frames": len(colmap_input),
-                  "frames": [path.name for path in colmap_input],
-              }, indent=2) + "\n",
-              encoding="utf-8",
-          )
-          print(f"colmap_input_frames={len(colmap_input)}")
+          response.raise_for_status()
+          data = response.json()
+          Path("/tmp/evidence/commons-videoinfo.json").write_text(json.dumps(data, indent=2) + "\n")
+          page = next(iter(data["query"]["pages"].values()))
+          info = page["videoinfo"][0]
+          candidates = [
+              item for item in info.get("derivatives", [])
+              if item.get("width") == 1280 and item.get("height") == 720 and "webm" in item.get("src", "")
+          ]
+          if not candidates:
+              raise SystemExit("No 1280x720 WebM derivative found")
+          chosen = min(candidates, key=lambda item: int(item.get("bandwidth", 10**12)))
+          Path("/tmp/evidence/media-source.json").write_text(json.dumps({
+              "source_page": "https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm",
+              "original_url": info["url"],
+              "original_size": info["size"],
+              "derivative": chosen,
+          }, indent=2) + "\n")
+          with requests.get(chosen["src"], stream=True, timeout=120) as media:
+              media.raise_for_status()
+              with open("/tmp/huejotzingo.webm", "wb") as output:
+                  for chunk in media.iter_content(1024 * 1024):
+                      if chunk:
+                          output.write(chunk)
+          print(f"derivative_url={chosen['src']}")
+          print(f"downloaded_bytes={Path('/tmp/huejotzingo.webm').stat().st_size}")
           PY
-          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm \
-            -vf "fps=1/10,scale=320:-1,tile=4x4:padding=4:margin=4" \
-            -frames:v 1 /tmp/evidence/contact-sheet.jpg
-
-          colmap -h | head -40 | tee /tmp/evidence/colmap-version.txt
-          set +e
-          colmap feature_extractor \
-            --database_path /tmp/colmap.db \
-            --image_path /tmp/colmap_images \
-            --ImageReader.single_camera 1 \
-            --SiftExtraction.use_gpu 0 \
-            > /tmp/evidence/colmap-feature-extractor.log 2>&1
-          feature_rc=$?
-          colmap sequential_matcher \
-            --database_path /tmp/colmap.db \
-            --SiftMatching.use_gpu 0 \
-            > /tmp/evidence/colmap-sequential-matcher.log 2>&1
-          matcher_rc=$?
-          colmap mapper \
-            --database_path /tmp/colmap.db \
-            --image_path /tmp/colmap_images \
-            --output_path /tmp/sparse \
-            > /tmp/evidence/colmap-mapper.log 2>&1
-          mapper_rc=$?
-          set -e
-
-          model_count=$(find /tmp/sparse -mindepth 1 -maxdepth 1 -type d | wc -l)
-          echo "feature_extractor_return_code=$feature_rc" | tee /tmp/evidence/colmap-status.txt
-          echo "sequential_matcher_return_code=$matcher_rc" | tee -a /tmp/evidence/colmap-status.txt
-          echo "mapper_return_code=$mapper_rc" | tee -a /tmp/evidence/colmap-status.txt
-          echo "submodel_count=$model_count" | tee -a /tmp/evidence/colmap-status.txt
-
-          if [ "$model_count" -gt 0 ]; then
-            colmap model_analyzer --path /tmp/sparse/0 | tee /tmp/evidence/colmap-model-analyzer.txt
-            colmap model_converter --input_path /tmp/sparse/0 --output_path /tmp/model_txt --output_type TXT
-            python - <<'PY'
+          echo "sha256=$(sha256sum /tmp/huejotzingo.webm | cut -d' ' -f1)" | tee /tmp/evidence/sha256.txt
+          ffprobe -v error -show_entries format=duration,size,format_name:stream=codec_name,width,height -of json /tmp/huejotzingo.webm | tee /tmp/evidence/ffprobe.json
+          ffmpeg -hide_banner -i /tmp/huejotzingo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
+          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log | tee /tmp/evidence/scene-cut-candidates.txt || true
+          python - <<'PY'
           import json
-          import re
-          from pathlib import Path
+          from video_pipeline import VideoSource, probe_video, write_source_manifest
 
-          selected = sorted(path.name for path in Path('/tmp/colmap_images').glob('*.jpg'))
-          image_lines = [line.rstrip('\n') for line in Path('/tmp/model_txt/images.txt').read_text().splitlines() if not line.startswith('#')]
-          registered = []
-          for index in range(0, len(image_lines), 2):
-              line = image_lines[index].strip()
-              if line:
-                  registered.append(line.split()[-1])
-          points = sum(
-              1 for line in Path('/tmp/model_txt/points3D.txt').read_text().splitlines()
-              if line.strip() and not line.startswith('#')
+          source_info = json.load(open("/tmp/evidence/media-source.json"))
+          source = VideoSource(
+              title="Vista del Ex Convento de San Miguel Arcángel, Huejotzingo, desde un dron",
+              source_page=source_info["source_page"],
+              media_url=source_info["derivative"]["src"],
+              author="Luisalvaz",
+              license="CC0 1.0",
+              license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+              target="Ex Convento de San Miguel Arcángel, Huejotzingo, Puebla, Mexico",
           )
-          analyzer = Path('/tmp/evidence/colmap-model-analyzer.txt').read_text()
-          error_match = re.search(r'Mean reprojection error:\s*([0-9.eE+-]+)', analyzer)
-          summary = {
-              'input_images': len(selected),
-              'registered_images': len(registered),
-              'registration_rate': len(registered) / len(selected) if selected else 0.0,
-              'sparse_points': points,
-              'failed_images': sorted(set(selected) - set(registered)),
-              'mean_reprojection_error': float(error_match.group(1)) if error_match else None,
-          }
-          Path('/tmp/evidence/colmap-summary.json').write_text(json.dumps(summary, indent=2) + '\n')
-          print(json.dumps({k: v for k, v in summary.items() if k != 'failed_images'}, sort_keys=True))
+          write_source_manifest(
+              "/tmp/huejotzingo.webm",
+              source,
+              probe_video("/tmp/huejotzingo.webm"),
+              "/tmp/evidence/source-manifest.json",
+          )
           PY
-          fi
-
-          if [ "$feature_rc" -ne 0 ] || [ "$matcher_rc" -ne 0 ] || [ "$mapper_rc" -ne 0 ] || [ "$model_count" -eq 0 ]; then
-            echo "COLMAP reconstruction did not produce a usable sparse model" >&2
-            exit 1
-          fi
+          ffmpeg -hide_banner -loglevel error -i /tmp/huejotzingo.webm \
+            -vf "fps=1/10,scale=320:-1,tile=6x4:padding=4:margin=4" \
+            -frames:v 1 /tmp/evidence/contact-sheet.jpg
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cabo-reconstruction-evidence
+          name: huejotzingo-single-take-gate
           path: /tmp/evidence
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,10 +53,10 @@ jobs:
           info = page["videoinfo"][0]
           candidates = [
               item for item in info.get("derivatives", [])
-              if item.get("width") == 1280 and item.get("height") == 720 and "webm" in item.get("src", "")
+              if item.get("width") == 1920 and item.get("height") == 1080 and "webm" in item.get("src", "")
           ]
           if not candidates:
-              raise SystemExit("No 1280x720 WebM derivative found")
+              raise SystemExit("No 1920x1080 WebM derivative found")
           chosen = min(candidates, key=lambda item: int(item.get("bandwidth", 10**12)))
           Path("/tmp/evidence/media-source.json").write_text(json.dumps({
               "source_page": "https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
           from pathlib import Path
           import requests
 
+          headers = {"User-Agent": "AutoPhotogrammetry/0.1 (https://github.com/KAFKA2306/AutoPhotogrammetry)"}
           title = "File:Vista del Ex Convento de San Miguel Arcángel, Huejotzingo, desde un dron.webm"
           response = requests.get(
               "https://commons.wikimedia.org/w/api.php",
@@ -42,6 +43,7 @@ jobs:
                   "prop": "videoinfo",
                   "viprop": "url|size|derivatives",
               },
+              headers=headers,
               timeout=60,
           )
           response.raise_for_status()
@@ -62,7 +64,7 @@ jobs:
               "original_size": info["size"],
               "derivative": chosen,
           }, indent=2) + "\n")
-          with requests.get(chosen["src"], stream=True, timeout=120) as media:
+          with requests.get(chosen["src"], headers=headers, stream=True, timeout=120) as media:
               media.raise_for_status()
               with open("/tmp/huejotzingo.webm", "wb") as output:
                   for chunk in media.iter_content(1024 * 1024):

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,43 @@ jobs:
       - name: Temporary Cabo single-take fixture evidence
         run: |
           set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg
+          mkdir -p /tmp/evidence /tmp/frames /tmp/selected
           curl --fail --location --retry 3 --output /tmp/cabo.webm \
             https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
           echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
-          ffprobe -v error -show_entries format=duration,size:stream=codec_name,width,height -of json /tmp/cabo.webm
+          ffprobe -v error -show_entries format=duration,size:stream=codec_name,width,height -of json /tmp/cabo.webm | tee /tmp/evidence/ffprobe.json
           ffmpeg -hide_banner -i /tmp/cabo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
-          echo "scene_cut_candidates"
-          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log || true
-          mkdir -p /tmp/frames
+          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log | tee /tmp/evidence/scene-cut-candidates.txt || true
           ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=3 -q:v 2 /tmp/frames/frame-%06d.jpg
           echo "frames_3fps=$(find /tmp/frames -type f -name 'frame-*.jpg' | wc -l)"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from video_pipeline import VideoSource, probe_video, select_video_frames, write_source_manifest
+
+          source = VideoSource(
+              title="Diving in Cabo San Lucas",
+              source_page="https://commons.wikimedia.org/wiki/File:Diving_in_Cabo_San_Lucas.webm",
+              media_url="https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm",
+              author="KumiM",
+              license="CC BY 3.0",
+              license_url="https://creativecommons.org/licenses/by/3.0/",
+              target="ship wreck near Land's End, Cabo San Lucas, Mexico",
+          )
+          write_source_manifest("/tmp/cabo.webm", source, probe_video("/tmp/cabo.webm"), "/tmp/evidence/source-manifest.json")
+          frames = sorted(Path("/tmp/frames").glob("frame-*.jpg"))
+          stats = select_video_frames(frames, "/tmp/selected")
+          Path("/tmp/evidence/frame-selection.json").write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
+          print(json.dumps({key: value for key, value in stats.items() if key != "selected_paths"}, sort_keys=True))
+          PY
+          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm \
+            -vf "fps=1/10,scale=320:-1,tile=4x4:padding=4:margin=4" \
+            -frames:v 1 /tmp/evidence/contact-sheet.jpg
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: cabo-single-take-evidence
+          path: /tmp/evidence
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,16 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
+      - name: Temporary Cabo single-take fixture evidence
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 --output /tmp/cabo.webm \
+            https://upload.wikimedia.org/wikipedia/commons/b/ba/Diving_in_Cabo_San_Lucas.webm
+          echo "sha256=$(sha256sum /tmp/cabo.webm | cut -d' ' -f1)"
+          ffprobe -v error -show_entries format=duration,size:stream=codec_name,width,height -of json /tmp/cabo.webm
+          ffmpeg -hide_banner -i /tmp/cabo.webm -filter:v "select='gt(scene,0.4)',showinfo" -an -f null - 2> /tmp/scene.log
+          echo "scene_cut_candidates"
+          grep -oE 'pts_time:[0-9.]+' /tmp/scene.log || true
+          mkdir -p /tmp/frames
+          ffmpeg -hide_banner -loglevel error -i /tmp/cabo.webm -vf fps=3 -q:v 2 /tmp/frames/frame-%06d.jpg
+          echo "frames_3fps=$(find /tmp/frames -type f -name 'frame-*.jpg' | wc -l)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements.txt
-      - run: python -m py_compile photogrammetry.py config.py tests/test_photogrammetry.py
+      - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from video_pipeline import (
     VideoSource,
     extract_frames_command,
+    frame_timestamp_records,
     gaussian_splat_export_command,
     nerfstudio_process_images_command,
     probe_video,
@@ -45,13 +46,28 @@ class VideoPipelineTests(unittest.TestCase):
             ],
         )
 
+    def test_frame_timestamps_follow_sampling_rate(self):
+        records = frame_timestamp_records(
+            ["frame-000001.jpg", "frame-000002.jpg", "frame-000003.jpg"],
+            fps=2,
+        )
+        self.assertEqual(
+            records,
+            [
+                {"frame": "frame-000001.jpg", "source_time_seconds": 0.0},
+                {"frame": "frame-000002.jpg", "source_time_seconds": 0.5},
+                {"frame": "frame-000003.jpg", "source_time_seconds": 1.0},
+            ],
+        )
+
     @patch("video_pipeline.run")
     def test_probe_video_parses_ffprobe_json(self, mocked_run):
         mocked_run.return_value.stdout = json.dumps(
-            {"format": {"duration": "123.246"}, "streams": []}
+            {"format": {"duration": "123.246", "format_name": "matroska,webm"}, "streams": []}
         )
         result = probe_video("source.webm")
         self.assertEqual(result["format"]["duration"], "123.246")
+        self.assertEqual(result["format"]["format_name"], "matroska,webm")
 
     @patch("video_pipeline.run")
     def test_scene_cut_times_parses_showinfo(self, mocked_run):
@@ -107,11 +123,13 @@ class VideoPipelineTests(unittest.TestCase):
             manifest = write_source_manifest(
                 video,
                 source,
-                {"format": {"duration": "123"}},
+                {"format": {"duration": "123", "format_name": "matroska,webm"}},
                 manifest_path,
+                downloaded_at="2026-08-17T00:00:00+00:00",
             )
             self.assertEqual(manifest["video"]["size_bytes"], 11)
             self.assertEqual(len(manifest["video"]["sha256"]), 64)
+            self.assertEqual(manifest["video"]["downloaded_at"], "2026-08-17T00:00:00+00:00")
             self.assertEqual(
                 json.loads(manifest_path.read_text())["source"]["license"],
                 "CC BY 3.0",

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -11,6 +11,7 @@ from video_pipeline import (
     nerfstudio_process_images_command,
     probe_video,
     scene_cut_times,
+    select_video_frames,
     splatfacto_train_command,
     write_source_manifest,
 )
@@ -56,6 +57,37 @@ class VideoPipelineTests(unittest.TestCase):
     def test_scene_cut_times_parses_showinfo(self, mocked_run):
         mocked_run.return_value.stderr = "x pts_time:12.5 y\nx pts_time:88.25 y\n"
         self.assertEqual(scene_cut_times("source.webm"), [12.5, 88.25])
+
+    def test_select_video_frames_is_ordered_and_linear(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            frames = []
+            for index in range(4):
+                path = root / f"frame-{index}.jpg"
+                path.write_bytes(str(index).encode())
+                frames.append(path)
+
+            sharpness = {frames[0]: 1.0, frames[1]: 0.0, frames[2]: 1.0, frames[3]: 1.0}
+            similarity_calls = []
+
+            def similarity(left, right):
+                similarity_calls.append((Path(left), Path(right)))
+                return 0.95 if Path(left) == frames[2] else 0.1
+
+            result = select_video_frames(
+                frames,
+                root / "selected",
+                sharpness_threshold=0.5,
+                similarity_threshold=0.92,
+                sharpness_fn=lambda path: sharpness[Path(path)],
+                similarity_fn=similarity,
+            )
+
+            self.assertEqual(result["input"], 4)
+            self.assertEqual(result["selected"], 2)
+            self.assertEqual(result["rejected_blur"], 1)
+            self.assertEqual(result["rejected_duplicate"], 1)
+            self.assertEqual(len(similarity_calls), 2)
 
     def test_source_manifest_hashes_exact_input(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_video_pipeline.py
+++ b/tests/test_video_pipeline.py
@@ -1,0 +1,90 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from video_pipeline import (
+    VideoSource,
+    extract_frames_command,
+    gaussian_splat_export_command,
+    nerfstudio_process_images_command,
+    probe_video,
+    scene_cut_times,
+    splatfacto_train_command,
+    write_source_manifest,
+)
+
+
+class VideoPipelineTests(unittest.TestCase):
+    def test_command_builders_preserve_spaces(self):
+        self.assertEqual(
+            extract_frames_command("source video.webm", "frames dir", fps=3),
+            [
+                "ffmpeg", "-hide_banner", "-y", "-i", "source video.webm",
+                "-vf", "fps=3", "-q:v", "2", "frames dir/frame-%06d.jpg",
+            ],
+        )
+        self.assertEqual(
+            nerfstudio_process_images_command("frames dir", "processed data"),
+            [
+                "ns-process-data", "images", "--data", "frames dir",
+                "--output-dir", "processed data",
+            ],
+        )
+        self.assertEqual(
+            splatfacto_train_command("processed data"),
+            ["ns-train", "splatfacto", "--data", "processed data"],
+        )
+        self.assertEqual(
+            gaussian_splat_export_command("outputs/config.yml", "exports/splat"),
+            [
+                "ns-export", "gaussian-splat", "--load-config", "outputs/config.yml",
+                "--output-dir", "exports/splat",
+            ],
+        )
+
+    @patch("video_pipeline.run")
+    def test_probe_video_parses_ffprobe_json(self, mocked_run):
+        mocked_run.return_value.stdout = json.dumps(
+            {"format": {"duration": "123.246"}, "streams": []}
+        )
+        result = probe_video("source.webm")
+        self.assertEqual(result["format"]["duration"], "123.246")
+
+    @patch("video_pipeline.run")
+    def test_scene_cut_times_parses_showinfo(self, mocked_run):
+        mocked_run.return_value.stderr = "x pts_time:12.5 y\nx pts_time:88.25 y\n"
+        self.assertEqual(scene_cut_times("source.webm"), [12.5, 88.25])
+
+    def test_source_manifest_hashes_exact_input(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            video = root / "source.webm"
+            video.write_bytes(b"video bytes")
+            source = VideoSource(
+                title="Example",
+                source_page="https://example.org/file",
+                media_url="https://example.org/file.webm",
+                author="Author",
+                license="CC BY 3.0",
+                license_url="https://creativecommons.org/licenses/by/3.0/",
+                target="Example target",
+            )
+            manifest_path = root / "manifest.json"
+            manifest = write_source_manifest(
+                video,
+                source,
+                {"format": {"duration": "123"}},
+                manifest_path,
+            )
+            self.assertEqual(manifest["video"]["size_bytes"], 11)
+            self.assertEqual(len(manifest["video"]["sha256"]), 64)
+            self.assertEqual(
+                json.loads(manifest_path.read_text())["source"]["license"],
+                "CC BY 3.0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/video_pipeline.py
+++ b/video_pipeline.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class VideoSource:
+    title: str
+    source_page: str
+    media_url: str
+    author: str
+    license: str
+    license_url: str
+    target: str
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(map(str, command)),
+        shell=False,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def probe_video(path: str | Path, ffprobe: str = "ffprobe") -> dict:
+    completed = run([
+        ffprobe,
+        "-v", "error",
+        "-show_entries", "format=duration,size:stream=codec_name,width,height",
+        "-of", "json",
+        str(Path(path)),
+    ])
+    return json.loads(completed.stdout)
+
+
+def scene_cut_times(
+    path: str | Path,
+    *,
+    threshold: float = 0.4,
+    ffmpeg: str = "ffmpeg",
+) -> list[float]:
+    if not 0 < threshold < 1:
+        raise ValueError("threshold must be between 0 and 1")
+    completed = run([
+        ffmpeg,
+        "-hide_banner",
+        "-i", str(Path(path)),
+        "-filter:v", f"select='gt(scene,{threshold})',showinfo",
+        "-an",
+        "-f", "null",
+        "-",
+    ])
+    return [float(value) for value in re.findall(r"pts_time:([0-9.]+)", completed.stderr)]
+
+
+def extract_frames_command(
+    video_path: str | Path,
+    output_dir: str | Path,
+    *,
+    fps: float = 3.0,
+    ffmpeg: str = "ffmpeg",
+) -> list[str]:
+    if fps <= 0:
+        raise ValueError("fps must be positive")
+    output = Path(output_dir)
+    return [
+        ffmpeg,
+        "-hide_banner",
+        "-y",
+        "-i", str(Path(video_path)),
+        "-vf", f"fps={fps:g}",
+        "-q:v", "2",
+        str(output / "frame-%06d.jpg"),
+    ]
+
+
+def nerfstudio_process_images_command(
+    image_dir: str | Path,
+    output_dir: str | Path,
+    *,
+    executable: str = "ns-process-data",
+) -> list[str]:
+    return [
+        executable,
+        "images",
+        "--data", str(Path(image_dir)),
+        "--output-dir", str(Path(output_dir)),
+    ]
+
+
+def splatfacto_train_command(
+    data_dir: str | Path,
+    *,
+    executable: str = "ns-train",
+) -> list[str]:
+    return [executable, "splatfacto", "--data", str(Path(data_dir))]
+
+
+def gaussian_splat_export_command(
+    config_path: str | Path,
+    output_dir: str | Path,
+    *,
+    executable: str = "ns-export",
+) -> list[str]:
+    return [
+        executable,
+        "gaussian-splat",
+        "--load-config", str(Path(config_path)),
+        "--output-dir", str(Path(output_dir)),
+    ]
+
+
+def write_source_manifest(
+    video_path: str | Path,
+    source: VideoSource,
+    probe: Mapping,
+    output_path: str | Path,
+) -> dict:
+    path = Path(video_path)
+    manifest = {
+        "schema_version": 1,
+        "source": asdict(source),
+        "video": {
+            "filename": path.name,
+            "size_bytes": path.stat().st_size,
+            "sha256": sha256_file(path),
+            "probe": dict(probe),
+        },
+    }
+    Path(output_path).write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest

--- a/video_pipeline.py
+++ b/video_pipeline.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence
 
 
 @dataclass(frozen=True)
@@ -88,6 +89,53 @@ def extract_frames_command(
         "-q:v", "2",
         str(output / "frame-%06d.jpg"),
     ]
+
+
+def select_video_frames(
+    frame_paths: Sequence[str | Path],
+    output_dir: str | Path,
+    *,
+    sharpness_threshold: float = 0.0001,
+    similarity_threshold: float = 0.92,
+    sharpness_fn: Callable[[str | Path], float] | None = None,
+    similarity_fn: Callable[[str | Path, str | Path], float] | None = None,
+) -> dict:
+    """Keep sharp frames and remove only near-duplicates of the last accepted frame."""
+    if sharpness_threshold < 0:
+        raise ValueError("sharpness_threshold must be non-negative")
+    if not 0 <= similarity_threshold <= 1:
+        raise ValueError("similarity_threshold must be between 0 and 1")
+
+    if sharpness_fn is None or similarity_fn is None:
+        from main import calculate_sharpness, calculate_similarity
+
+        sharpness_fn = sharpness_fn or calculate_sharpness
+        similarity_fn = similarity_fn or calculate_similarity
+
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+    selected: list[Path] = []
+    rejected_blur = 0
+    rejected_duplicate = 0
+
+    for raw_path in sorted(map(Path, frame_paths)):
+        if sharpness_fn(raw_path) < sharpness_threshold:
+            rejected_blur += 1
+            continue
+        if selected and similarity_fn(raw_path, selected[-1]) >= similarity_threshold:
+            rejected_duplicate += 1
+            continue
+        target = destination / raw_path.name
+        shutil.copy2(raw_path, target)
+        selected.append(target)
+
+    return {
+        "input": len(frame_paths),
+        "selected": len(selected),
+        "rejected_blur": rejected_blur,
+        "rejected_duplicate": rejected_duplicate,
+        "selected_paths": [str(path) for path in selected],
+    }
 
 
 def nerfstudio_process_images_command(

--- a/video_pipeline.py
+++ b/video_pipeline.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
@@ -43,7 +44,7 @@ def probe_video(path: str | Path, ffprobe: str = "ffprobe") -> dict:
     completed = run([
         ffprobe,
         "-v", "error",
-        "-show_entries", "format=duration,size:stream=codec_name,width,height",
+        "-show_entries", "format=duration,size,format_name:stream=codec_name,width,height",
         "-of", "json",
         str(Path(path)),
     ])
@@ -88,6 +89,19 @@ def extract_frames_command(
         "-vf", f"fps={fps:g}",
         "-q:v", "2",
         str(output / "frame-%06d.jpg"),
+    ]
+
+
+def frame_timestamp_records(
+    frame_paths: Sequence[str | Path],
+    *,
+    fps: float,
+) -> list[dict]:
+    if fps <= 0:
+        raise ValueError("fps must be positive")
+    return [
+        {"frame": Path(path).name, "source_time_seconds": index / fps}
+        for index, path in enumerate(sorted(map(Path, frame_paths)))
     ]
 
 
@@ -179,6 +193,8 @@ def write_source_manifest(
     source: VideoSource,
     probe: Mapping,
     output_path: str | Path,
+    *,
+    downloaded_at: str | None = None,
 ) -> dict:
     path = Path(video_path)
     manifest = {
@@ -188,6 +204,7 @@ def write_source_manifest(
             "filename": path.name,
             "size_bytes": path.stat().st_size,
             "sha256": sha256_file(path),
+            "downloaded_at": downloaded_at or datetime.now(timezone.utc).isoformat(),
             "probe": dict(probe),
         },
     }


### PR DESCRIPTION
Implements reusable video-to-Gaussian-Splat pipeline helpers without adding a custom 3D Gaussian Splatting implementation.

Changes:
- FFprobe metadata and FFmpeg scene-cut helpers
- deterministic frame-extraction and frame-selection helpers
- source provenance + SHA-256 manifest generation
- Nerfstudio `ns-process-data images`, `ns-train splatfacto`, and `ns-export gaussian-splat` command builders
- unit tests and CI compilation for the new module

Exact-head verification (`c0d84923cab8de962a5e7869e5a4e2e90d875929`):
- Test run: https://github.com/KAFKA2306/AutoPhotogrammetry/actions/runs/32042282427 — SUCCESS
- unit tests: SUCCESS
- real CC0 Wikimedia 1080p transcode downloaded and SHA-256 matched `c9723df1af171d40a5bf1f9530aa3ea881c6f95252ef3f2004f0f1013ab92e30`
- FFprobe measured duration `232.766 s`, 1920×1080 VP9
- FFmpeg sampled every 3 seconds: 78 frames
- frame selection retained 78 / 78 for this input
- COLMAP feature extraction, sequential matching, and mapping all returned 0
- one sparse model was produced; 78 / 78 images registered (100%), 32,764 sparse points, 0 failed image names
- Actions artifact: `huejotzingo-colmap-evidence`, digest `sha256:dbd2e49d9f1afe167ec64d7d0ca6e1f94fb8e3c3385d0a768c6896fcf8a60aa6`

Primary-source checks:
- Wikimedia Commons source is CC0: https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel,_Huejotzingo,_desde_un_dron.webm
- FFprobe options: https://ffmpeg.org/ffprobe.html
- Nerfstudio Splatfacto training/export: https://docs.nerf.studio/nerfology/methods/splat.html
- COLMAP CLI: https://colmap.github.io/cli.html

Still not complete:
- the uploaded COLMAP analyzer text is empty, so a final reprojection-error summary is not claimed from this run
- Nerfstudio/gsplat training and Gaussian Splat PLY export have not been executed on GPU
- #14 and #15 therefore remain open

Related: #8 #10 #11 #12 #13 #14 #15