### PR TITLE
Generate one-off Huejotzingo COLMAP dataset artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,89 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: python -m py_compile photogrammetry.py config.py video_pipeline.py tests/test_photogrammetry.py tests/test_video_pipeline.py
       - run: python -m unittest discover -s tests -v
+
+      - name: Prepare one-off Huejotzingo COLMAP dataset
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg colmap
+          mkdir -p /tmp/dataset/images /tmp/dataset/colmap/sparse /tmp/dataset/evidence
+
+          media_url='https://upload.wikimedia.org/wikipedia/commons/transcoded/3/34/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm/Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm.1080p.vp9.webm'
+          source_page='https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel%2C_Huejotzingo%2C_desde_un_dron.webm'
+          expected_sha256='c9723df1af171d40a5bf1f9530aa3ea881c6f95252ef3f2004f0f1013ab92e30'
+          curl --fail --location --retry 3 --user-agent 'AutoPhotogrammetry/0.1 (https://github.com/KAFKA2306/AutoPhotogrammetry)' --output /tmp/source.webm "$media_url"
+          actual_sha256=$(sha256sum /tmp/source.webm | cut -d' ' -f1)
+          test "$actual_sha256" = "$expected_sha256"
+
+          ffmpeg -hide_banner -loglevel error -i /tmp/source.webm \
+            -vf 'fps=1/3,scale=1024:-2' -q:v 2 /tmp/dataset/images/frame-%06d.jpg
+          frame_count=$(find /tmp/dataset/images -type f -name 'frame-*.jpg' | wc -l)
+          test "$frame_count" -eq 78
+
+          colmap feature_extractor \
+            --database_path /tmp/dataset/colmap/database.db \
+            --image_path /tmp/dataset/images \
+            --ImageReader.single_camera 1 \
+            --SiftExtraction.use_gpu 0 \
+            --SiftExtraction.max_image_size 1024 \
+            --SiftExtraction.max_num_features 4096 \
+            > /tmp/dataset/evidence/feature-extractor.log 2>&1
+          colmap sequential_matcher \
+            --database_path /tmp/dataset/colmap/database.db \
+            --SiftMatching.use_gpu 0 \
+            > /tmp/dataset/evidence/sequential-matcher.log 2>&1
+          colmap mapper \
+            --database_path /tmp/dataset/colmap/database.db \
+            --image_path /tmp/dataset/images \
+            --output_path /tmp/dataset/colmap/sparse \
+            > /tmp/dataset/evidence/mapper.log 2>&1
+
+          model_count=$(find /tmp/dataset/colmap/sparse -mindepth 1 -maxdepth 1 -type d | wc -l)
+          test "$model_count" -eq 1
+          colmap model_analyzer --path /tmp/dataset/colmap/sparse/0 2>&1 | tee /tmp/dataset/evidence/model-analyzer.txt
+          grep -q 'Registered images: 78' /tmp/dataset/evidence/model-analyzer.txt
+
+          SOURCE_PAGE="$source_page" MEDIA_URL="$media_url" SOURCE_SHA256="$actual_sha256" python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          analyzer = Path('/tmp/dataset/evidence/model-analyzer.txt').read_text()
+          def value(pattern, cast=int):
+              match = re.search(pattern, analyzer)
+              return cast(match.group(1)) if match else None
+
+          manifest = {
+              'source_page': os.environ['SOURCE_PAGE'],
+              'media_url': os.environ['MEDIA_URL'],
+              'author': 'Luisalvaz',
+              'license': 'CC0 1.0',
+              'source_sha256': os.environ['SOURCE_SHA256'],
+              'sampling_interval_seconds': 3,
+              'frame_width': 1024,
+              'image_count': 78,
+              'colmap': {
+                  'single_camera': True,
+                  'matcher': 'sequential',
+                  'sift_max_image_size': 1024,
+                  'sift_max_num_features': 4096,
+                  'registered_images': value(r'Registered images:\s*(\d+)'),
+                  'sparse_points': value(r'Points:\s*(\d+)'),
+                  'mean_reprojection_error_px': value(r'Mean reprojection error:\s*([0-9.]+)px', float),
+              },
+          }
+          Path('/tmp/dataset/dataset-manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+          PY
+
+          cd /tmp/dataset
+          find images colmap/sparse/0 evidence -type f -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS
+          rm -f colmap/database.db
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: huejotzingo-colmap-dataset
+          path: /tmp/dataset
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
Temporary evidence PR for #14 only. Rebuilds the already-validated Huejotzingo 78-frame COLMAP dataset and uploads `images/` + `colmap/sparse/0` + hashes/diagnostics as a 30-day Actions artifact. This workflow change will not be merged to main.