### PR TITLE
Generate JSON and HTML input audit reports

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from processing.collection import collect_images
 from processing.huejotzingo import run_huejotzingo
 from processing.image_selection import select_images
+from processing.readiness_report import build_readiness_report
 
 
 def main() -> None:
@@ -27,6 +28,16 @@ def main() -> None:
     select_parser.add_argument("--output-root", default="output")
     select_parser.add_argument("--sharpness-threshold", type=float, default=0.0001)
     select_parser.add_argument("--similarity-threshold", type=float, default=0.92)
+
+    audit_parser = subparsers.add_parser(
+        "audit",
+        help="Select a collected image set and generate JSON/HTML input audit reports.",
+    )
+    audit_parser.add_argument("--dataset", required=True)
+    audit_parser.add_argument("--input-root", default="input")
+    audit_parser.add_argument("--output-root", default="output")
+    audit_parser.add_argument("--sharpness-threshold", type=float, default=0.0001)
+    audit_parser.add_argument("--similarity-threshold", type=float, default=0.92)
 
     huejotzingo_parser = subparsers.add_parser(
         "huejotzingo",
@@ -67,6 +78,14 @@ def main() -> None:
             "selected": len(selected),
             "output_dir": str(output_dir),
         }
+    elif args.command == "audit":
+        result = build_readiness_report(
+            args.dataset,
+            input_root=args.input_root,
+            output_root=args.output_root,
+            sharpness_threshold=args.sharpness_threshold,
+            similarity_threshold=args.similarity_threshold,
+        )
     else:
         result = run_huejotzingo(
             input_root=args.input_root,

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import html
+import json
+from collections import Counter
+from pathlib import Path
+
+from processing.image_selection import calculate_sharpness, select_images
+from processing.provenance import IMAGE_SUFFIXES, sha256_file, write_json
+
+REQUIRED_PROVENANCE_FIELDS = (
+    "source_page",
+    "image_url",
+    "sha256",
+    "width",
+    "height",
+    "content_type",
+)
+
+
+def _read_manifest(path: Path) -> list[dict]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Collection manifest does not exist: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+        raise ValueError(f"Collection manifest must be a JSON array of objects: {path}")
+    return payload
+
+
+def _render_html(report: dict) -> str:
+    reason_counts = report["selection"]["reason_counts"]
+    dimensions = report["dimensions"]
+    rows = [
+        ("Input images", report["input"]["count"]),
+        ("Selected images", report["selection"]["selected_count"]),
+        ("Low sharpness", reason_counts["LOW_SHARPNESS"]),
+        ("Near duplicate", reason_counts["NEAR_DUPLICATE"]),
+        ("Exact duplicate manifest rows", reason_counts["EXACT_DUPLICATE"]),
+        ("Missing provenance", reason_counts["PROVENANCE_MISSING"]),
+        (
+            "Provenance coverage",
+            f'{report["provenance"]["covered_count"]}/{report["input"]["count"]}',
+        ),
+        ("Distinct image sizes", dimensions["distinct_size_count"]),
+        ("Backend execution", report["backend"]["status"]),
+    ]
+    table = "\n".join(
+        f"<tr><th>{html.escape(str(label))}</th><td>{html.escape(str(value))}</td></tr>"
+        for label, value in rows
+    )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Photogrammetry input audit — {html.escape(report['asset_id'])}</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 880px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th, td {{ border-bottom: 1px solid #ddd; padding: .6rem; text-align: left; }}
+    .notice {{ background: #f6f6f6; padding: 1rem; border-radius: .5rem; }}
+  </style>
+</head>
+<body>
+  <h1>Photogrammetry input audit</h1>
+  <p><strong>Asset:</strong> {html.escape(report['asset_id'])}</p>
+  <table><tbody>{table}</tbody></table>
+  <div class="notice">
+    <p>This report describes input selection and provenance only.</p>
+    <p>Registration rate, reprojection error, geometry completeness, and texture quality are not measured here, so this report does not guarantee 3D reconstruction quality.</p>
+  </div>
+</body>
+</html>
+"""
+
+
+def build_readiness_report(
+    dataset: str,
+    *,
+    input_root: str | Path = "input",
+    output_root: str | Path = "output",
+    sharpness_threshold: float = 0.0001,
+    similarity_threshold: float = 0.92,
+) -> dict:
+    image_dir = Path(input_root) / dataset / "images"
+    if not image_dir.is_dir():
+        raise FileNotFoundError(f"Input image directory does not exist: {image_dir}")
+
+    image_paths = sorted(
+        path for path in image_dir.iterdir() if path.suffix.lower() in IMAGE_SUFFIXES
+    )
+    if not image_paths:
+        raise ValueError(f"No supported images found in: {image_dir}")
+
+    source_manifest_path = image_dir / "manifest.json"
+    source_records = _read_manifest(source_manifest_path)
+    output_dir = Path(output_root) / dataset
+    selected_dir = output_dir / "selected"
+    selected_paths = select_images(
+        image_paths,
+        sharpness_threshold=sharpness_threshold,
+        similarity_threshold=similarity_threshold,
+        output_dir=selected_dir,
+    )
+    selected_names = {path.name for path in selected_paths}
+
+    low_sharpness = 0
+    near_duplicate = 0
+    for image_path in image_paths:
+        if image_path.name in selected_names:
+            continue
+        if calculate_sharpness(image_path) < sharpness_threshold:
+            low_sharpness += 1
+        else:
+            near_duplicate += 1
+
+    hashes = [
+        str(record.get("sha256", ""))
+        for record in source_records
+        if record.get("sha256")
+    ]
+    exact_duplicates = len(hashes) - len(set(hashes))
+    records_by_name = {
+        Path(str(record.get("local_path", ""))).name: record for record in source_records
+    }
+    covered = 0
+    dimensions: list[tuple[int, int]] = []
+    content_types: Counter[str] = Counter()
+    for image_path in image_paths:
+        record = records_by_name.get(image_path.name)
+        if record and all(
+            record.get(field) not in (None, "") for field in REQUIRED_PROVENANCE_FIELDS
+        ):
+            covered += 1
+        if record:
+            width = record.get("width")
+            height = record.get("height")
+            if (
+                isinstance(width, int)
+                and width > 0
+                and isinstance(height, int)
+                and height > 0
+            ):
+                dimensions.append((width, height))
+            content_type = record.get("content_type")
+            if isinstance(content_type, str) and content_type:
+                content_types[content_type] += 1
+
+    missing_provenance = len(image_paths) - covered
+    distinct_sizes = sorted(set(dimensions))
+    report = {
+        "schema_version": 1,
+        "asset_id": dataset,
+        "generated_views_used": False,
+        "input": {
+            "count": len(image_paths),
+            "source_manifest": str(source_manifest_path),
+        },
+        "selection": {
+            "selected_count": len(selected_paths),
+            "selected_dir": str(selected_dir),
+            "sharpness_threshold": sharpness_threshold,
+            "similarity_threshold": similarity_threshold,
+            "reason_counts": {
+                "LOW_SHARPNESS": low_sharpness,
+                "NEAR_DUPLICATE": near_duplicate,
+                "EXACT_DUPLICATE": exact_duplicates,
+                "PROVENANCE_MISSING": missing_provenance,
+            },
+        },
+        "provenance": {
+            "covered_count": covered,
+            "coverage_ratio": covered / len(image_paths),
+        },
+        "dimensions": {
+            "distinct_size_count": len(distinct_sizes),
+            "sizes": [[width, height] for width, height in distinct_sizes],
+            "content_types": dict(sorted(content_types.items())),
+        },
+        "backend": {
+            "status": "not_run",
+            "run_manifest_path": None,
+        },
+        "quality_measurements": {
+            "registration_rate": None,
+            "reprojection_error": None,
+            "mesh_completeness": None,
+            "quality_guarantee": False,
+        },
+    }
+
+    selected_manifest = {
+        "schema_version": 1,
+        "asset_id": dataset,
+        "generated_views_used": False,
+        "source_manifest": str(source_manifest_path),
+        "images": [
+            {
+                "filename": path.name,
+                "sha256": sha256_file(path),
+            }
+            for path in selected_paths
+        ],
+    }
+    selected_manifest_path = output_dir / "selected-manifest.json"
+    report_json_path = output_dir / "readiness-report.json"
+    report_html_path = output_dir / "readiness-report.html"
+    write_json(selected_manifest_path, selected_manifest)
+    write_json(report_json_path, report)
+    report_html_path.write_text(_render_html(report), encoding="utf-8")
+
+    return {
+        "asset_id": dataset,
+        "report_json": str(report_json_path),
+        "report_html": str(report_html_path),
+        "selected_manifest": str(selected_manifest_path),
+        "input": len(image_paths),
+        "selected": len(selected_paths),
+    }

--- a/tests/test_readiness_report.py
+++ b/tests/test_readiness_report.py
@@ -1,0 +1,84 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from processing.provenance import sha256_file, write_json
+from processing.readiness_report import build_readiness_report
+
+
+class ReadinessReportTests(unittest.TestCase):
+    def _write_checkerboard(self, path: Path) -> None:
+        pattern = np.indices((128, 128)).sum(axis=0) % 2
+        array = np.repeat((pattern * 255).astype(np.uint8)[..., None], 3, axis=2)
+        Image.fromarray(array, mode="RGB").save(path)
+
+    def _write_flat(self, path: Path) -> None:
+        array = np.full((128, 128, 3), 127, dtype=np.uint8)
+        Image.fromarray(array, mode="RGB").save(path)
+
+    def test_report_uses_existing_selection_and_preserves_quality_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            image_dir = root / "input" / "artifact" / "images"
+            image_dir.mkdir(parents=True)
+            first = image_dir / "first.jpg"
+            duplicate = image_dir / "duplicate.jpg"
+            blurry = image_dir / "blurry.jpg"
+            self._write_checkerboard(first)
+            duplicate.write_bytes(first.read_bytes())
+            self._write_flat(blurry)
+
+            records = []
+            for path in (first, duplicate, blurry):
+                records.append(
+                    {
+                        "source_page": "https://example.test/object",
+                        "image_url": f"https://example.test/{path.name}",
+                        "local_path": str(path),
+                        "sha256": sha256_file(path),
+                        "width": 128,
+                        "height": 128,
+                        "content_type": "image/jpeg",
+                    }
+                )
+            write_json(image_dir / "manifest.json", records)
+
+            result = build_readiness_report(
+                "artifact",
+                input_root=root / "input",
+                output_root=root / "output",
+                sharpness_threshold=0.0001,
+                similarity_threshold=0.92,
+            )
+
+            report = json.loads(Path(result["report_json"]).read_text(encoding="utf-8"))
+            selected_manifest = json.loads(
+                Path(result["selected_manifest"]).read_text(encoding="utf-8")
+            )
+            report_html = Path(result["report_html"]).read_text(encoding="utf-8")
+
+            self.assertEqual(report["asset_id"], "artifact")
+            self.assertEqual(report["input"]["count"], 3)
+            self.assertEqual(report["selection"]["selected_count"], 1)
+            self.assertEqual(report["selection"]["reason_counts"]["LOW_SHARPNESS"], 1)
+            self.assertEqual(report["selection"]["reason_counts"]["NEAR_DUPLICATE"], 1)
+            self.assertEqual(report["selection"]["reason_counts"]["EXACT_DUPLICATE"], 1)
+            self.assertEqual(report["selection"]["reason_counts"]["PROVENANCE_MISSING"], 0)
+            self.assertEqual(report["provenance"]["covered_count"], 3)
+            self.assertEqual(report["provenance"]["coverage_ratio"], 1.0)
+            self.assertFalse(report["generated_views_used"])
+            self.assertFalse(report["quality_measurements"]["quality_guarantee"])
+            self.assertIsNone(report["quality_measurements"]["registration_rate"])
+            self.assertIsNone(report["quality_measurements"]["reprojection_error"])
+            self.assertIsNone(report["quality_measurements"]["mesh_completeness"])
+            self.assertEqual(selected_manifest["asset_id"], "artifact")
+            self.assertEqual(len(selected_manifest["images"]), 1)
+            self.assertIn("does not guarantee 3D reconstruction quality", report_html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Progresses #3.

Adds one `audit` command that reuses the existing collected-image manifest and existing non-destructive image selection path to produce:

- `readiness-report.json`
- `readiness-report.html`
- `selected-manifest.json`
- the existing `selected/` image set

The report records input/selected counts, low-sharpness and near-duplicate rejections, duplicate manifest hashes, provenance coverage, dimensions/content types, and `generated_views_used=false`.

It deliberately leaves registration rate, reprojection error, and mesh completeness unmeasured and sets `quality_guarantee=false`; selection metrics are not presented as 3D reconstruction quality.

No new dependencies, workflows, backend implementations, database, or README changes. Existing source images remain untouched.