### PR TITLE
Verify Puente de San Ignacio video source metadata

### DIFF
--- a/sources/videos.json
+++ b/sources/videos.json
@@ -130,9 +130,10 @@
       "title": "Puente de San Ignacio desde un dron 03",
       "provider": "Wikimedia Commons",
       "source_page": "https://commons.wikimedia.org/wiki/File:Puente_de_San_Ignacio_desde_un_dron_03.webm",
+      "media_url": "https://upload.wikimedia.org/wikipedia/commons/9/97/Puente_de_San_Ignacio_desde_un_dron_03.webm",
       "author": "Luisalvaz",
-      "license": {"name": null, "status": "needs_review", "url": null},
-      "duration_seconds": 141,
+      "license": {"name": "CC0 1.0 Universal", "status": "verified", "url": "https://creativecommons.org/publicdomain/zero/1.0/"},
+      "duration_seconds": 140.661,
       "resolution": [3840, 2160],
       "metadata_notes": ["rigid bridge structure", "vegetation may be present"],
       "measurements": {"preflight": null, "colmap": null, "splat": null}

--- a/tests/test_video_sources.py
+++ b/tests/test_video_sources.py
@@ -48,6 +48,26 @@ class VideoSourceRegistryTests(unittest.TestCase):
         )
         self.assertIsNone(source["measurements"]["splat"])
 
+    def test_puente_san_ignacio_03_keeps_verified_source_metadata(self) -> None:
+        source = get_video_source("puente-san-ignacio-03")
+        self.assertEqual(source["author"], "Luisalvaz")
+        self.assertEqual(source["license"]["name"], "CC0 1.0 Universal")
+        self.assertEqual(source["license"]["status"], "verified")
+        self.assertEqual(
+            source["license"]["url"],
+            "https://creativecommons.org/publicdomain/zero/1.0/",
+        )
+        self.assertEqual(source["duration_seconds"], 140.661)
+        self.assertEqual(source["resolution"], [3840, 2160])
+        self.assertEqual(
+            source["media_url"],
+            "https://upload.wikimedia.org/wikipedia/commons/9/97/Puente_de_San_Ignacio_desde_un_dron_03.webm",
+        )
+        self.assertEqual(source["evaluation_stage"], "metadata")
+        self.assertIsNone(source["measurements"]["preflight"])
+        self.assertIsNone(source["measurements"]["colmap"])
+        self.assertIsNone(source["measurements"]["splat"])
+
     def test_ids_and_source_pages_are_unique(self) -> None:
         videos = video_sources()
         self.assertEqual(len({video["id"] for video in videos}), len(videos))


### PR DESCRIPTION
## Related issue

- #23

## Change

- Verify `puente-san-ignacio-03` against its Wikimedia Commons file page.
- Add the original media URL.
- Replace the rounded duration with the source's structured value: 140.661 seconds.
- Record the file's CC0 1.0 Universal license as verified.
- Add a regression test without adding heuristic reconstruction scores or fake preflight/COLMAP/Splat measurements.

## Primary source

- https://commons.wikimedia.org/wiki/File:Puente_de_San_Ignacio_desde_un_dron_03.webm

The source page identifies Luisalvaz as author, CC0 1.0 Universal as the file license, 3840×2160 resolution, 140.661-second duration, and an original downloadable WebM file.

## Scope

This advances Issue #23 Stage A metadata evidence for one candidate. It does not claim Stage A completion because the selected processing input has not been fixed and SHA-256 has not been recorded. It does not advance the candidate to preflight or assign a success score.