### PR TITLE
Backend evaluation: freeze shared input and result contract (#26)

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,11 +4,17 @@ import argparse
 import json
 from pathlib import Path
 
+from processing.backend_evaluation import build_dataset_contract, write_comparison
 from processing.collection import collect_images
 from processing.batch import run_all_videos
 from processing.huejotzingo import run_huejotzingo
 from processing.image_selection import select_images
+from processing.provenance import write_json
 from processing.readiness_report import build_readiness_report
+
+
+def _read_json(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
 def main() -> None:
@@ -59,6 +65,23 @@ def main() -> None:
     batch_parser.add_argument("--train-iterations", type=int, default=2000)
     batch_parser.add_argument("--fresh", action="store_true")
 
+    dataset_parser = subparsers.add_parser(
+        "evaluation-dataset",
+        help="Freeze one source video and exact train/hold-out frame hashes for backend comparison.",
+    )
+    dataset_parser.add_argument("--source-video", required=True)
+    dataset_parser.add_argument("--frames", required=True)
+    dataset_parser.add_argument("--holdout-count", type=int, required=True)
+    dataset_parser.add_argument("--output", required=True)
+
+    compare_parser = subparsers.add_parser(
+        "evaluation-compare",
+        help="Validate backend result manifests against one dataset contract and write comparison rows.",
+    )
+    compare_parser.add_argument("--dataset", required=True)
+    compare_parser.add_argument("--result", action="append", required=True)
+    compare_parser.add_argument("--output", required=True)
+
     args = parser.parse_args()
 
     if args.command == "collect":
@@ -104,6 +127,19 @@ def main() -> None:
             input_root=args.input_root,
             output_root=args.output_root,
         )
+    elif args.command == "evaluation-dataset":
+        result = build_dataset_contract(
+            args.source_video,
+            args.frames,
+            holdout_count=args.holdout_count,
+        )
+        write_json(args.output, result)
+        result = {**result, "manifest_path": str(Path(args.output))}
+    elif args.command == "evaluation-compare":
+        dataset = _read_json(args.dataset)
+        backend_results = [_read_json(path) for path in args.result]
+        result = write_comparison(args.output, backend_results, dataset)
+        result = {**result, "comparison_path": str(Path(args.output))}
     else:
         result = run_all_videos(
             registry_path=args.registry,

--- a/processing/backend_evaluation.py
+++ b/processing/backend_evaluation.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from processing.provenance import image_records, sha256_file, write_json
+
+METRIC_FIELDS = (
+    "reconstruction_success",
+    "input_frame_count",
+    "train_frame_count",
+    "holdout_frame_count",
+    "psnr",
+    "ssim",
+    "lpips",
+    "wall_clock_seconds",
+    "peak_gpu_memory_bytes",
+    "output_size_bytes",
+    "primitive_count",
+    "camera_pose_available",
+)
+
+
+def _stable_score(source_sha256: str, frame_sha256: str) -> str:
+    return hashlib.sha256(f"{source_sha256}:{frame_sha256}".encode("ascii")).hexdigest()
+
+
+def build_dataset_contract(
+    source_video: str | Path,
+    frame_dir: str | Path,
+    *,
+    holdout_count: int,
+) -> dict:
+    """Create a content-addressed, deterministic train/hold-out split."""
+    video = Path(source_video).expanduser().resolve()
+    frames = Path(frame_dir).expanduser().resolve()
+    if not video.is_file():
+        raise ValueError(f"source video does not exist: {video}")
+    if not frames.is_dir():
+        raise ValueError(f"frame directory does not exist: {frames}")
+
+    records = image_records(frames)
+    if len(records) < 2:
+        raise ValueError("at least two frames are required")
+    if holdout_count < 1 or holdout_count >= len(records):
+        raise ValueError("holdout_count must be between 1 and frame_count - 1")
+
+    source_sha256 = sha256_file(video)
+    ranked = sorted(
+        records,
+        key=lambda record: (
+            _stable_score(source_sha256, record["sha256"]),
+            record["path"],
+        ),
+    )
+    holdout_hashes = {record["sha256"] for record in ranked[:holdout_count]}
+    annotated = [
+        {**record, "split": "holdout" if record["sha256"] in holdout_hashes else "train"}
+        for record in records
+    ]
+
+    return {
+        "schema_version": 1,
+        "source_video": {
+            "path": video.name,
+            "size_bytes": video.stat().st_size,
+            "sha256": source_sha256,
+        },
+        "frames": annotated,
+        "train_frame_sha256": [
+            record["sha256"] for record in annotated if record["split"] == "train"
+        ],
+        "holdout_frame_sha256": [
+            record["sha256"] for record in annotated if record["split"] == "holdout"
+        ],
+    }
+
+
+def dataset_identity(contract: Mapping) -> str:
+    """Return a stable identity for the source and exact train/hold-out frame sets."""
+    payload = {
+        "source_video_sha256": contract["source_video"]["sha256"],
+        "train_frame_sha256": sorted(contract["train_frame_sha256"]),
+        "holdout_frame_sha256": sorted(contract["holdout_frame_sha256"]),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def empty_metrics() -> dict:
+    """Return the common metric shape without inventing unmeasured values."""
+    return {field: None for field in METRIC_FIELDS}
+
+
+def artifact_record(path: str | Path, *, format: str) -> dict:
+    artifact = Path(path).expanduser().resolve()
+    if not artifact.is_file():
+        raise ValueError(f"output artifact does not exist: {artifact}")
+    return {
+        "path": str(artifact),
+        "format": format,
+        "size_bytes": artifact.stat().st_size,
+        "sha256": sha256_file(artifact),
+    }
+
+
+def validate_backend_result(result: Mapping, dataset: Mapping) -> None:
+    if result.get("dataset_id") != dataset_identity(dataset):
+        raise ValueError("backend result does not match the dataset contract")
+
+    backend = result.get("backend") or {}
+    if not backend.get("name"):
+        raise ValueError("backend name is required")
+    if not backend.get("upstream_revision"):
+        raise ValueError("backend upstream revision/version is required")
+    if not isinstance(result.get("command"), list) or not result["command"]:
+        raise ValueError("backend command must be a non-empty argv list")
+    if "return_code" not in result:
+        raise ValueError("backend return_code is required")
+
+    status = result.get("status")
+    if status not in {"success", "failed"}:
+        raise ValueError("backend status must be success or failed")
+    if status == "failed" and not result.get("failure_phase"):
+        raise ValueError("failed backend result requires failure_phase")
+
+    artifact = result.get("artifact")
+    if status == "success":
+        if not artifact:
+            raise ValueError("successful backend result requires an artifact")
+        if not artifact.get("format") or not artifact.get("sha256"):
+            raise ValueError("successful artifact requires format and sha256")
+        if not isinstance(artifact.get("size_bytes"), int) or artifact["size_bytes"] <= 0:
+            raise ValueError("successful artifact requires positive size_bytes")
+
+    metrics = result.get("metrics") or {}
+    unknown = set(metrics) - set(METRIC_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown metrics: {sorted(unknown)}")
+    for key, value in metrics.items():
+        if value is None:
+            continue
+        if key == "reconstruction_success" or key == "camera_pose_available":
+            if not isinstance(value, bool):
+                raise ValueError(f"{key} must be bool or null")
+        elif not isinstance(value, (int, float)):
+            raise ValueError(f"{key} must be numeric or null")
+
+
+def compare_backend_results(results: Sequence[Mapping], dataset: Mapping) -> list[dict]:
+    """Generate table rows whose values remain traceable to each result manifest."""
+    rows = []
+    for result in results:
+        validate_backend_result(result, dataset)
+        metrics = {**empty_metrics(), **(result.get("metrics") or {})}
+        rows.append(
+            {
+                "backend": result["backend"]["name"],
+                "upstream_revision": result["backend"]["upstream_revision"],
+                "status": result["status"],
+                "failure_phase": result.get("failure_phase"),
+                "artifact_format": (result.get("artifact") or {}).get("format"),
+                "artifact_sha256": (result.get("artifact") or {}).get("sha256"),
+                **metrics,
+            }
+        )
+    return rows
+
+
+def write_comparison(
+    output_path: str | Path,
+    results: Sequence[Mapping],
+    dataset: Mapping,
+) -> dict:
+    value = {
+        "schema_version": 1,
+        "dataset_id": dataset_identity(dataset),
+        "source_video_sha256": dataset["source_video"]["sha256"],
+        "train_frame_sha256": list(dataset["train_frame_sha256"]),
+        "holdout_frame_sha256": list(dataset["holdout_frame_sha256"]),
+        "results": compare_backend_results(results, dataset),
+    }
+    write_json(output_path, value)
+    return value

--- a/tests/test_backend_evaluation.py
+++ b/tests/test_backend_evaluation.py
@@ -1,0 +1,133 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from processing.backend_evaluation import (
+    artifact_record,
+    build_dataset_contract,
+    compare_backend_results,
+    dataset_identity,
+    empty_metrics,
+    validate_backend_result,
+    write_comparison,
+)
+
+
+class BackendEvaluationTests(unittest.TestCase):
+    def _dataset(self, root: Path):
+        video = root / "source.webm"
+        video.write_bytes(b"video")
+        frames = root / "frames"
+        frames.mkdir()
+        for index in range(6):
+            (frames / f"frame-{index:03d}.jpg").write_bytes(f"frame-{index}".encode())
+        return build_dataset_contract(video, frames, holdout_count=2)
+
+    def test_split_is_content_addressed_and_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            first = self._dataset(root)
+            second = build_dataset_contract(root / "source.webm", root / "frames", holdout_count=2)
+            self.assertEqual(first, second)
+            self.assertEqual(len(first["train_frame_sha256"]), 4)
+            self.assertEqual(len(first["holdout_frame_sha256"]), 2)
+            self.assertTrue(set(first["train_frame_sha256"]).isdisjoint(first["holdout_frame_sha256"]))
+            self.assertEqual(len(dataset_identity(first)), 64)
+
+    def test_success_requires_real_artifact_and_traceable_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset = self._dataset(root)
+            output = root / "model.sog"
+            output.write_bytes(b"model")
+            metrics = empty_metrics()
+            metrics.update(
+                {
+                    "reconstruction_success": True,
+                    "input_frame_count": 6,
+                    "train_frame_count": 4,
+                    "holdout_frame_count": 2,
+                    "psnr": 27.5,
+                    "wall_clock_seconds": 12.25,
+                    "output_size_bytes": 5,
+                    "camera_pose_available": True,
+                }
+            )
+            result = {
+                "schema_version": 1,
+                "dataset_id": dataset_identity(dataset),
+                "backend": {"name": "example", "upstream_revision": "abc123"},
+                "command": ["example", "--config", "config.yml"],
+                "config": {"quality": "test"},
+                "started_at": "2026-08-19T00:00:00+00:00",
+                "finished_at": "2026-08-19T00:00:12+00:00",
+                "return_code": 0,
+                "status": "success",
+                "failure_phase": None,
+                "artifact": artifact_record(output, format="sog"),
+                "metrics": metrics,
+            }
+            validate_backend_result(result, dataset)
+            rows = compare_backend_results([result], dataset)
+            self.assertEqual(rows[0]["psnr"], 27.5)
+            self.assertIsNone(rows[0]["ssim"])
+            self.assertEqual(rows[0]["artifact_format"], "sog")
+
+    def test_failed_backend_does_not_require_fake_artifact_or_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset = self._dataset(root)
+            failed = {
+                "schema_version": 1,
+                "dataset_id": dataset_identity(dataset),
+                "backend": {"name": "broken", "upstream_revision": "deadbeef"},
+                "command": ["broken"],
+                "config": {},
+                "started_at": "2026-08-19T00:00:00+00:00",
+                "finished_at": "2026-08-19T00:00:01+00:00",
+                "return_code": 2,
+                "status": "failed",
+                "failure_phase": "training",
+                "artifact": None,
+                "metrics": {},
+            }
+            validate_backend_result(failed, dataset)
+            comparison = write_comparison(root / "comparison.json", [failed], dataset)
+            self.assertEqual(comparison["results"][0]["status"], "failed")
+            self.assertIsNone(comparison["results"][0]["psnr"])
+
+    def test_dataset_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset = self._dataset(root)
+            result = {
+                "dataset_id": "0" * 64,
+                "backend": {"name": "example", "upstream_revision": "abc123"},
+                "command": ["example"],
+                "return_code": 1,
+                "status": "failed",
+                "failure_phase": "setup",
+                "metrics": {},
+            }
+            with self.assertRaisesRegex(ValueError, "dataset contract"):
+                validate_backend_result(result, dataset)
+
+    def test_unknown_metric_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset = self._dataset(root)
+            result = {
+                "dataset_id": dataset_identity(dataset),
+                "backend": {"name": "example", "upstream_revision": "abc123"},
+                "command": ["example"],
+                "return_code": 1,
+                "status": "failed",
+                "failure_phase": "setup",
+                "metrics": {"made_up_score": 1.0},
+            }
+            with self.assertRaisesRegex(ValueError, "unknown metrics"):
+                validate_backend_result(result, dataset)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the toolchain-independent part of #26 without inventing measurements.

Changes:
- adds one shared backend-evaluation contract using source-video SHA-256 plus exact train/hold-out frame SHA-256 sets
- deterministic hold-out selection is content-addressed from the source/video hashes
- records backend name/revision, argv/config, return code/failure phase, artifact format/size/SHA-256 and only measured metrics
- missing metrics remain null; failed backends require no fake artifact
- rejects dataset mismatches and unknown metrics
- adds machine-readable comparison rows that remain traceable to each backend result
- exposes `evaluation-dataset` and `evaluation-compare` through the existing CLI
- adds focused tests for split reproducibility, artifact/result semantics, failure isolation, dataset mismatch and pseudo-metric rejection

This PR does not claim #26 complete: the acceptance criterion still requires an actual Huejotzingo baseline plus at least one independent backend run under the same frozen contract. No GPU/self-hosted workflow currently exists in this repository, so no synthetic PSNR/SSIM/LPIPS values are added.