### PR TITLE
Ignore generated Gaussian Splat PLY exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 __pycache__/
 *.py[cod]
 .DS_Store
+
+# Generated Gaussian Splat exports are large run artifacts, not source files.
+output/**/runs/**/export/*.ply


### PR DESCRIPTION
Addresses the artifact-storage requirement in #14, #15, and #33.

The current repository already contains large generated `splat.ply` files as historical evidence, including the Huejotzingo export. This change does not delete or rewrite that history. It prevents future generated Gaussian Splat PLY exports under `output/**/runs/**/export/` from being added accidentally.

No runtime code, dependencies, data registry, workflow, or documentation is changed.