### PR TITLE
chore: preserve LF task runner on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+task text eol=lf


### PR DESCRIPTION
## Scope\nKeep the repository-owned 	ask entry point executable from a clean Windows checkout by forcing LF line endings.\n\n## Evidence\n- Commit: 91dd672\n- git ls-files --eol task: index LF, worktree LF\n- Docker CUDA/Torch doctor was attempted locally; the Docker daemon became unresponsive during image construction before any new PLY was materialized.\n\nThis is infrastructure for #33 and does not claim 20/20 reconstruction.