### PR TITLE
fix: fail closed when Docker execution is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd AutoPhotogrammetry
 
 環境確認、Docker image build、入力取得、hash検証、frame抽出、COLMAP、Splatfacto、PLY export、成功判定はtaskが行います。
 
+Docker CLIまたはDocker daemonが利用できない場合、`./task doctor` / `./task run` / `./task run-all` は `BLOCKED` と明示して停止します。このrepositoryのtaskはDocker Desktop、WSL、GPU driver、OS設定、Docker storageを修復・resetしません。host環境の修復はrepository実行とは分離してください。
+
 実行入口: [`task`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/task)  
 GPU環境: [`Dockerfile`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/Dockerfile)  
 E2E実装: [`processing/huejotzingo.py`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/processing/huejotzingo.py)

--- a/task
+++ b/task
@@ -5,6 +5,17 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${AUTOPHOTOGRAMMETRY_IMAGE:-autophotogrammetry:cuda128}"
 HOST_GPU_ARCH="${AUTOPHOTOGRAMMETRY_CUDA_ARCH:-8.6}"
 
+check_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker CLI unavailable; AutoPhotogrammetry execution is BLOCKED. Install or repair Docker outside this repository task; no host repair is attempted." >&2
+    return 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon unavailable; AutoPhotogrammetry execution is BLOCKED. Start or repair Docker outside this repository task; no host repair is attempted." >&2
+    return 1
+  fi
+}
+
 build_image() {
   docker build --pull --build-arg "CUDA_ARCH_LIST=$HOST_GPU_ARCH" -t "$IMAGE" "$ROOT"
 }
@@ -40,6 +51,7 @@ run_cpu() {
 }
 
 doctor() {
+  check_docker
   check_host_gpu
   build_image
   run_gpu python -c 'import importlib.metadata as m, shutil, torch; assert torch.cuda.is_available(), "CUDA is not available in Docker"; cap=torch.cuda.get_device_capability(); assert cap >= (8, 6), f"Expected sm_86+, got {cap}"; required=["ffmpeg","ffprobe","colmap","ns-process-data","ns-train","ns-export"]; missing=[x for x in required if shutil.which(x) is None]; assert not missing, f"Missing executables: {missing}"; import gsplat; print({"gpu": torch.cuda.get_device_name(), "capability": cap, "torch": torch.__version__, "nerfstudio": m.version("nerfstudio"), "gsplat": m.version("gsplat")})'
@@ -47,12 +59,14 @@ doctor() {
 
 case "${1:-run}" in
   image)
+    check_docker
     build_image
     ;;
   doctor)
     doctor
     ;;
   test)
+    check_docker
     build_image
     run_cpu python -m unittest discover -s tests -v
     ;;

--- a/tests/test_task_execution_boundary.py
+++ b/tests/test_task_execution_boundary.py
@@ -1,0 +1,56 @@
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TASK = ROOT / "task"
+
+
+class TaskExecutionBoundaryTests(unittest.TestCase):
+    def run_task(self, path):
+        env = os.environ.copy()
+        env["PATH"] = path
+        return subprocess.run(
+            ["/bin/bash", str(TASK), "doctor"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_missing_docker_cli_fails_closed_without_host_repair(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = self.run_task(temp_dir)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Docker CLI unavailable", result.stderr)
+        self.assertIn("execution is BLOCKED", result.stderr)
+        self.assertIn("no host repair is attempted", result.stderr)
+
+    def test_unavailable_docker_daemon_fails_closed_without_build(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            docker = Path(temp_dir) / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = info ]; then exit 1; fi\n"
+                "echo unexpected-docker-command >&2\n"
+                "exit 99\n",
+                encoding="utf-8",
+            )
+            docker.chmod(docker.stat().st_mode | stat.S_IXUSR)
+            result = self.run_task(temp_dir)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Docker daemon unavailable", result.stderr)
+        self.assertIn("execution is BLOCKED", result.stderr)
+        self.assertIn("no host repair is attempted", result.stderr)
+        self.assertNotIn("unexpected-docker-command", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #37.

## Outcome
- `./task` checks Docker CLI/daemon availability before image build or GPU work.
- Missing CLI or unavailable daemon returns a clear `execution is BLOCKED` message.
- The message explicitly states that host repair is outside the repository task; no Docker Desktop/WSL/storage repair path is introduced.
- Adds regression tests for both missing Docker CLI and unavailable daemon.
- Documents the execution boundary in README.

## Complexity
- Reuses the existing `task` entrypoint; no second runner, dependency, workflow, or host-management script.
- Production files added: 0.
- New dependency: 0.

## Evidence boundary
This change proves fail-fast repository behavior only. It does not prove Docker/WSL/GPU health or produce new Gaussian Splat artifacts.