### PR TITLE
docs: expose current 9/20 Gaussian Splat completion state

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ metadata
      train / export / PSNR / SSIM / LPIPS / PLY hash
 ```
 
+### 現在の実測状態
+
+2026-08-20時点で、commit [`1fa7f35`](https://github.com/KAFKA2306/AutoPhotogrammetry/commit/1fa7f35b1fc9fce669f97d5ec7c7f46ce4601206) に **9件の実Gaussian Splat PLY** が存在します。最終展示要件は20件なので、完成状態ではありません。
+
+- 実PLY: **9 / 20**
+- Huejotzingo PLY: **38,085,465 bytes**
+- Huejotzingo SHA-256: `6dc1d2546ab848eee4587fdaaebe1b60b1f2495f8a9a9b6a58de9356222c4571`
+- 20展示の完成authority: [Issue #33](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/33)
+- 1本のsource-to-PLY lineage完成authority: [Issue #15](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/15)
+
+既存9 PLYの存在・代表PLYのsize/hashは確認済みですが、古いHuejotzingo run directoryにはtraining config/checkpoint/logが残っていないため、その過去runのexact `ns-train` / `ns-export` lineageを後から復元したとは扱いません。現在のrunnerは次回runからtool version、command、return code、config/checkpoint、PLY hash/sizeをmanifestへ保存します。
+
+今後生成する大容量PLYは通常のGit履歴へ追加せず、`output/**/runs/**/export/*.ply` を生成artifactとして扱います。
+
 現在のdefaultは `huejotzingo` です。registryの20本をすべて処理する場合は次を実行します。
 
 ```bash


### PR DESCRIPTION
## Why
The README describes the pipeline and 20-video registry but does not state the current measured output coverage. Current GitHub evidence already shows 9 real Splatfacto PLY files while the exhibition target remains 20. This makes the public entry point ambiguous about what is implemented versus still incomplete.

## Change
- add a measured-state section to README
- record real PLY coverage as 9/20
- record the verified Huejotzingo representative PLY size/SHA-256
- link the 20-item completion authority (#33) and source-to-PLY lineage authority (#15)
- state that the historical Huejotzingo run cannot be retroactively treated as having complete train/export lineage because its old run directory lacks those records
- state that future large PLYs remain generated artifacts rather than normal Git history

No runtime code, dependency, workflow, candidate selection, reconstruction result, or asset is changed.

## Primary upstream basis
- Nerfstudio Splatfacto: https://docs.nerf.studio/nerfology/methods/splat.html
- Nerfstudio documents `ns-train splatfacto --data <data>` as the training path and supports export from trained checkpoints.

## Verification boundary
This is a documentation-only current-state correction. It does not claim a new GPU run, Unity import, VRChat SDK validation, or actual-client evidence.