### PR TITLE
3DGS: add measurable Splatfacto cleanup experiments

### DIFF
--- a/processing/clean_gs.py
+++ b/processing/clean_gs.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+from processing.gaussian_ply import gaussian_ply_metrics
+from processing.provenance import sha256_file, write_json
+
+
+def clean_gs_command(
+    script_path: str | Path,
+    *,
+    scene: str,
+    masks_dir: str | Path,
+    input_ply: str | Path,
+    output_ply: str | Path,
+    python_executable: str = "python",
+    color_threshold: float | None = None,
+    k_neighbors: int | None = None,
+    neighbor_threshold: float | None = None,
+) -> list[str]:
+    command = [
+        python_executable,
+        str(Path(script_path)),
+        "--scene",
+        scene,
+        "--masks_dir",
+        str(Path(masks_dir)),
+        "--input_ply",
+        str(Path(input_ply)),
+        "--output_ply",
+        str(Path(output_ply)),
+    ]
+    if color_threshold is not None:
+        command.extend(("--color_threshold", str(color_threshold)))
+    if k_neighbors is not None:
+        command.extend(("--k_neighbors", str(k_neighbors)))
+    if neighbor_threshold is not None:
+        command.extend(("--neighbor_threshold", str(neighbor_threshold)))
+    return command
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _mask_records(masks_dir: Path) -> list[dict]:
+    masks = sorted(path for path in masks_dir.iterdir() if path.is_file() and path.suffix.lower() == ".png")
+    if not masks:
+        raise ValueError(f"no PNG semantic masks found: {masks_dir}")
+    return [
+        {"path": path.name, "size_bytes": path.stat().st_size, "sha256": sha256_file(path)}
+        for path in masks
+    ]
+
+
+def run_clean_gs(
+    *,
+    script_path: str | Path,
+    upstream_revision: str,
+    scene: str,
+    masks_dir: str | Path,
+    input_ply: str | Path,
+    output_ply: str | Path,
+    manifest_path: str | Path,
+    python_executable: str = "python",
+    color_threshold: float | None = None,
+    k_neighbors: int | None = None,
+    neighbor_threshold: float | None = None,
+    timeout: float | None = None,
+    extra_args: Sequence[str] = (),
+) -> dict:
+    """Run an explicit Clean-GS checkout and record all inputs, argv and before/after artifacts."""
+    script = Path(script_path).expanduser().resolve()
+    masks = Path(masks_dir).expanduser().resolve()
+    source = Path(input_ply).expanduser().resolve()
+    output = Path(output_ply).expanduser().resolve()
+    manifest_file = Path(manifest_path).expanduser().resolve()
+    if not script.is_file():
+        raise ValueError(f"Clean-GS script does not exist: {script}")
+    if not upstream_revision.strip():
+        raise ValueError("upstream_revision is required")
+    if not masks.is_dir():
+        raise ValueError(f"mask directory does not exist: {masks}")
+    if not source.is_file():
+        raise ValueError(f"input PLY does not exist: {source}")
+
+    mask_records = _mask_records(masks)
+    before = gaussian_ply_metrics(source)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    manifest_file.parent.mkdir(parents=True, exist_ok=True)
+    output.unlink(missing_ok=True)
+    command = clean_gs_command(
+        script,
+        scene=scene,
+        masks_dir=masks,
+        input_ply=source,
+        output_ply=output,
+        python_executable=python_executable,
+        color_threshold=color_threshold,
+        k_neighbors=k_neighbors,
+        neighbor_threshold=neighbor_threshold,
+    ) + list(map(str, extra_args))
+    started = _utc_now()
+    result = subprocess.run(
+        command,
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=script.parent,
+        timeout=timeout,
+    )
+    finished = _utc_now()
+    manifest = {
+        "schema_version": 1,
+        "backend": "Clean-GS",
+        "upstream_repository": "https://github.com/smlab-niser/clean-gs",
+        "upstream_revision": upstream_revision,
+        "scene": scene,
+        "command": command,
+        "started_at": started,
+        "finished_at": finished,
+        "return_code": result.returncode,
+        "masks": mask_records,
+        "input": before,
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+        "status": "running",
+    }
+    if result.returncode != 0:
+        manifest.update(status="failed", failure_phase="clean-gs")
+        write_json(manifest_file, manifest)
+        raise subprocess.CalledProcessError(
+            result.returncode,
+            command,
+            output=result.stdout,
+            stderr=result.stderr,
+        )
+    if not output.is_file() or output.stat().st_size <= 0:
+        manifest.update(status="failed", failure_phase="output-validation")
+        write_json(manifest_file, manifest)
+        raise RuntimeError("Clean-GS returned success but did not create a non-empty output PLY")
+
+    after = gaussian_ply_metrics(output)
+    removed = before["primitive_count"] - after["primitive_count"]
+    manifest.update(
+        status="success",
+        output=after,
+        removed_primitive_count=removed,
+        removed_primitive_ratio=removed / before["primitive_count"],
+    )
+    write_json(manifest_file, manifest)
+    manifest["manifest_path"] = str(manifest_file)
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run official Clean-GS with auditable input/output lineage.")
+    parser.add_argument("--script", required=True)
+    parser.add_argument("--upstream-revision", required=True)
+    parser.add_argument("--scene", required=True)
+    parser.add_argument("--masks-dir", required=True)
+    parser.add_argument("--input-ply", required=True)
+    parser.add_argument("--output-ply", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--python", default="python")
+    parser.add_argument("--color-threshold", type=float)
+    parser.add_argument("--k-neighbors", type=int)
+    parser.add_argument("--neighbor-threshold", type=float)
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_clean_gs(
+        script_path=args.script,
+        upstream_revision=args.upstream_revision,
+        scene=args.scene,
+        masks_dir=args.masks_dir,
+        input_ply=args.input_ply,
+        output_ply=args.output_ply,
+        manifest_path=args.manifest,
+        python_executable=args.python,
+        color_threshold=args.color_threshold,
+        k_neighbors=args.k_neighbors,
+        neighbor_threshold=args.neighbor_threshold,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/gaussian_ply.py
+++ b/processing/gaussian_ply.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+
+from processing.provenance import sha256_file, write_json
+
+_PLY_TYPES = {
+    "char": "i1",
+    "uchar": "u1",
+    "int8": "i1",
+    "uint8": "u1",
+    "short": "<i2",
+    "ushort": "<u2",
+    "int16": "<i2",
+    "uint16": "<u2",
+    "int": "<i4",
+    "uint": "<u4",
+    "int32": "<i4",
+    "uint32": "<u4",
+    "float": "<f4",
+    "float32": "<f4",
+    "double": "<f8",
+    "float64": "<f8",
+}
+
+
+def _read_vertex_layout(handle) -> tuple[int, np.dtype]:
+    first = handle.readline().decode("ascii", errors="strict").strip()
+    if first != "ply":
+        raise ValueError("not a PLY file")
+
+    format_name = None
+    vertex_count = None
+    properties: list[tuple[str, str]] = []
+    current_element = None
+    while True:
+        raw = handle.readline()
+        if not raw:
+            raise ValueError("PLY header ended before end_header")
+        line = raw.decode("ascii", errors="strict").strip()
+        if line == "end_header":
+            break
+        if not line or line.startswith("comment ") or line.startswith("obj_info "):
+            continue
+        parts = line.split()
+        if parts[0] == "format":
+            format_name = parts[1]
+        elif parts[0] == "element":
+            current_element = parts[1]
+            if current_element == "vertex":
+                vertex_count = int(parts[2])
+        elif parts[0] == "property" and current_element == "vertex":
+            if parts[1] == "list":
+                raise ValueError("list properties are not supported in the vertex element")
+            ply_type, name = parts[1], parts[2]
+            if ply_type not in _PLY_TYPES:
+                raise ValueError(f"unsupported PLY property type: {ply_type}")
+            properties.append((name, _PLY_TYPES[ply_type]))
+
+    if format_name != "binary_little_endian":
+        raise ValueError(f"expected binary_little_endian PLY, got {format_name!r}")
+    if vertex_count is None or vertex_count < 0:
+        raise ValueError("PLY vertex count is missing or invalid")
+    if not properties:
+        raise ValueError("PLY vertex properties are missing")
+    return vertex_count, np.dtype(properties)
+
+
+def gaussian_ply_metrics(path: str | Path) -> dict:
+    """Measure primitive, opacity and scale-anisotropy statistics from a standard 3DGS PLY.
+
+    The exporter representation stores opacity as logits and scale components as log-scales.
+    Unsupported PLY layouts fail closed instead of producing guessed metrics.
+    """
+    ply = Path(path).expanduser().resolve()
+    if not ply.is_file():
+        raise ValueError(f"PLY does not exist: {ply}")
+
+    with ply.open("rb") as handle:
+        vertex_count, dtype = _read_vertex_layout(handle)
+        required = {"opacity", "scale_0", "scale_1", "scale_2"}
+        missing = required - set(dtype.names or ())
+        if missing:
+            raise ValueError(f"PLY is missing Gaussian properties: {sorted(missing)}")
+        vertices = np.fromfile(handle, dtype=dtype, count=vertex_count)
+
+    if len(vertices) != vertex_count:
+        raise ValueError(f"PLY vertex payload is truncated: expected {vertex_count}, got {len(vertices)}")
+    if vertex_count == 0:
+        raise ValueError("PLY has zero Gaussian primitives")
+
+    opacity_logits = np.asarray(vertices["opacity"], dtype=np.float64)
+    opacity = np.empty_like(opacity_logits)
+    positive = opacity_logits >= 0
+    opacity[positive] = 1.0 / (1.0 + np.exp(-opacity_logits[positive]))
+    exp_logits = np.exp(opacity_logits[~positive])
+    opacity[~positive] = exp_logits / (1.0 + exp_logits)
+
+    log_scales = np.column_stack(
+        [
+            np.asarray(vertices["scale_0"], dtype=np.float64),
+            np.asarray(vertices["scale_1"], dtype=np.float64),
+            np.asarray(vertices["scale_2"], dtype=np.float64),
+        ]
+    )
+    log_ratio = np.max(log_scales, axis=1) - np.min(log_scales, axis=1)
+    ratio = np.exp(np.minimum(log_ratio, math.log(np.finfo(np.float64).max)))
+
+    def quantiles(values: np.ndarray) -> dict:
+        p50, p95, p99 = np.quantile(values, [0.50, 0.95, 0.99])
+        return {
+            "p50": float(p50),
+            "p95": float(p95),
+            "p99": float(p99),
+            "max": float(np.max(values)),
+        }
+
+    low_opacity = opacity < 0.1
+    spiky = ratio > 10.0
+    return {
+        "schema_version": 1,
+        "path": str(ply),
+        "size_bytes": ply.stat().st_size,
+        "sha256": sha256_file(ply),
+        "primitive_count": int(vertex_count),
+        "opacity": {
+            "quantiles": quantiles(opacity),
+            "below_0_1_count": int(np.count_nonzero(low_opacity)),
+            "below_0_1_ratio": float(np.mean(low_opacity)),
+        },
+        "scale_anisotropy_ratio": {
+            "quantiles": quantiles(ratio),
+            "above_10_count": int(np.count_nonzero(spiky)),
+            "above_10_ratio": float(np.mean(spiky)),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Measure Gaussian PLY primitive/opacity/scale statistics.")
+    parser.add_argument("ply")
+    parser.add_argument("--output")
+    args = parser.parse_args()
+    result = gaussian_ply_metrics(args.ply)
+    if args.output:
+        write_json(args.output, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/splatfacto_quality.py
+++ b/processing/splatfacto_quality.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from processing.nerfstudio import run_splatfacto_export
+from processing.provenance import write_json
+
+
+def quality_train_args(*, iterations: int, scale_regularization: bool) -> tuple[str, ...]:
+    """Build the one-variable Splatfacto training arguments used for quality A/B runs."""
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    args = [
+        "--max-num-iterations",
+        str(iterations),
+        "--viewer.quit-on-train-completion",
+        "True",
+    ]
+    if scale_regularization:
+        args.extend(("--pipeline.model.use-scale-regularization", "True"))
+    return tuple(args)
+
+
+def run_quality_comparison(
+    data_dir: str | Path,
+    output_root: str | Path,
+    *,
+    iterations: Sequence[int] = (2000,),
+    timeout: float | None = None,
+) -> dict:
+    """Run baseline and scale-regularized Splatfacto with the same processed dataset.
+
+    Each child run keeps the exact Nerfstudio/gsplat versions, argv, checkpoint and PLY hash
+    in the existing Splatfacto manifest. This function only coordinates the controlled A/B
+    matrix and never changes culling thresholds or silently substitutes another backend.
+    """
+    data = Path(data_dir).expanduser().resolve()
+    if not data.is_dir():
+        raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    budgets = tuple(dict.fromkeys(int(value) for value in iterations))
+    if not budgets or any(value <= 0 for value in budgets):
+        raise ValueError("iterations must contain one or more positive values")
+
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    summary_path = root / "quality-comparison.json"
+    summary = {
+        "schema_version": 1,
+        "data_dir": str(data),
+        "experiments": [],
+    }
+
+    for budget in budgets:
+        for scale_regularization in (False, True):
+            variant = "scale-regularized" if scale_regularization else "baseline"
+            result = run_splatfacto_export(
+                data,
+                root / f"iterations-{budget}" / variant,
+                train_extra_args=quality_train_args(
+                    iterations=budget,
+                    scale_regularization=scale_regularization,
+                ),
+                timeout=timeout,
+                env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+            )
+            manifest_path = Path(result["manifest_path"])
+            summary["experiments"].append(
+                {
+                    "iterations": budget,
+                    "scale_regularization": scale_regularization,
+                    "manifest_path": str(manifest_path),
+                    "ply_path": str(manifest_path.parent / result["output"]["ply_path"]),
+                    "ply_sha256": result["output"]["sha256"],
+                    "ply_size_bytes": result["output"]["size_bytes"],
+                }
+            )
+            write_json(summary_path, summary)
+
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run controlled Splatfacto baseline/scale-regularization quality comparisons."
+    )
+    parser.add_argument("--data", required=True, help="Existing Nerfstudio processed dataset.")
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--iterations", action="append", type=int, required=True)
+    parser.add_argument("--timeout", type=float, default=None)
+    args = parser.parse_args()
+    result = run_quality_comparison(
+        args.data,
+        args.output_root,
+        iterations=args.iterations,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_clean_gs.py
+++ b/tests/test_clean_gs.py
@@ -1,0 +1,111 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from processing.clean_gs import clean_gs_command, run_clean_gs
+
+
+class CleanGsTests(unittest.TestCase):
+    def _write_ply(self, path: Path, count: int) -> None:
+        dtype = np.dtype(
+            [
+                ("opacity", "<f4"),
+                ("scale_0", "<f4"),
+                ("scale_1", "<f4"),
+                ("scale_2", "<f4"),
+            ]
+        )
+        vertices = np.zeros(count, dtype=dtype)
+        header = (
+            "ply\n"
+            "format binary_little_endian 1.0\n"
+            f"element vertex {count}\n"
+            "property float opacity\n"
+            "property float scale_0\n"
+            "property float scale_1\n"
+            "property float scale_2\n"
+            "end_header\n"
+        ).encode("ascii")
+        with path.open("wb") as handle:
+            handle.write(header)
+            handle.write(vertices.tobytes())
+
+    def test_command_uses_official_cli_flags(self):
+        command = clean_gs_command(
+            "clean-gs.py",
+            scene="temple",
+            masks_dir="masks",
+            input_ply="input.ply",
+            output_ply="output.ply",
+            color_threshold=0.3,
+            k_neighbors=5,
+            neighbor_threshold=0.7,
+        )
+        self.assertEqual(command[:2], ["python", "clean-gs.py"])
+        self.assertIn("--masks_dir", command)
+        self.assertIn("--input_ply", command)
+        self.assertIn("--output_ply", command)
+        self.assertIn("--color_threshold", command)
+
+    def test_runner_records_masks_and_primitive_reduction(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "clean-gs.py"
+            script.write_text("# fixture\n", encoding="utf-8")
+            masks = root / "masks"
+            masks.mkdir()
+            (masks / "000001.png").write_bytes(b"mask")
+            source = root / "input.ply"
+            output = root / "output.ply"
+            manifest = root / "manifest.json"
+            self._write_ply(source, 3)
+
+            def fake_run(command, **kwargs):
+                self._write_ply(output, 2)
+                return subprocess.CompletedProcess(command, 0, "cleaned", "")
+
+            with patch("processing.clean_gs.subprocess.run", side_effect=fake_run):
+                result = run_clean_gs(
+                    script_path=script,
+                    upstream_revision="deadbeef",
+                    scene="temple",
+                    masks_dir=masks,
+                    input_ply=source,
+                    output_ply=output,
+                    manifest_path=manifest,
+                )
+
+            self.assertEqual(result["status"], "success")
+            self.assertEqual(result["input"]["primitive_count"], 3)
+            self.assertEqual(result["output"]["primitive_count"], 2)
+            self.assertEqual(result["removed_primitive_count"], 1)
+            self.assertEqual(len(result["masks"]), 1)
+            self.assertTrue(manifest.is_file())
+
+    def test_runner_requires_masks(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "clean-gs.py"
+            script.write_text("# fixture\n", encoding="utf-8")
+            masks = root / "masks"
+            masks.mkdir()
+            source = root / "input.ply"
+            self._write_ply(source, 1)
+            with self.assertRaisesRegex(ValueError, "semantic masks"):
+                run_clean_gs(
+                    script_path=script,
+                    upstream_revision="deadbeef",
+                    scene="temple",
+                    masks_dir=masks,
+                    input_ply=source,
+                    output_ply=root / "output.ply",
+                    manifest_path=root / "manifest.json",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gaussian_ply.py
+++ b/tests/test_gaussian_ply.py
@@ -1,0 +1,73 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from processing.gaussian_ply import gaussian_ply_metrics
+
+
+class GaussianPlyMetricsTests(unittest.TestCase):
+    def _write_ply(self, path: Path) -> None:
+        dtype = np.dtype(
+            [
+                ("x", "<f4"),
+                ("y", "<f4"),
+                ("z", "<f4"),
+                ("opacity", "<f4"),
+                ("scale_0", "<f4"),
+                ("scale_1", "<f4"),
+                ("scale_2", "<f4"),
+            ]
+        )
+        vertices = np.zeros(2, dtype=dtype)
+        vertices[0]["opacity"] = np.float32(-3.0)
+        vertices[1]["opacity"] = np.float32(3.0)
+        vertices[0]["scale_0"] = np.float32(0.0)
+        vertices[0]["scale_1"] = np.float32(0.0)
+        vertices[0]["scale_2"] = np.float32(0.0)
+        vertices[1]["scale_0"] = np.float32(0.0)
+        vertices[1]["scale_1"] = np.float32(0.0)
+        vertices[1]["scale_2"] = np.float32(3.0)
+        header = (
+            "ply\n"
+            "format binary_little_endian 1.0\n"
+            "element vertex 2\n"
+            "property float x\n"
+            "property float y\n"
+            "property float z\n"
+            "property float opacity\n"
+            "property float scale_0\n"
+            "property float scale_1\n"
+            "property float scale_2\n"
+            "end_header\n"
+        ).encode("ascii")
+        with path.open("wb") as handle:
+            handle.write(header)
+            handle.write(vertices.tobytes())
+
+    def test_metrics_measure_low_opacity_and_spiky_gaussians(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "splat.ply"
+            self._write_ply(path)
+            result = gaussian_ply_metrics(path)
+            self.assertEqual(result["primitive_count"], 2)
+            self.assertEqual(result["opacity"]["below_0_1_count"], 1)
+            self.assertAlmostEqual(result["opacity"]["below_0_1_ratio"], 0.5)
+            self.assertEqual(result["scale_anisotropy_ratio"]["above_10_count"], 1)
+            self.assertAlmostEqual(result["scale_anisotropy_ratio"]["above_10_ratio"], 0.5)
+            self.assertEqual(len(result["sha256"]), 64)
+
+    def test_metrics_fail_closed_for_ascii_ply(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ascii.ply"
+            path.write_text(
+                "ply\nformat ascii 1.0\nelement vertex 0\nproperty float opacity\nend_header\n",
+                encoding="ascii",
+            )
+            with self.assertRaisesRegex(ValueError, "binary_little_endian"):
+                gaussian_ply_metrics(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_splatfacto_quality.py
+++ b/tests/test_splatfacto_quality.py
@@ -1,0 +1,81 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.splatfacto_quality import quality_train_args, run_quality_comparison
+
+
+class SplatfactoQualityTests(unittest.TestCase):
+    def test_quality_train_args_change_only_scale_regularization(self):
+        baseline = quality_train_args(iterations=2000, scale_regularization=False)
+        regularized = quality_train_args(iterations=2000, scale_regularization=True)
+        self.assertEqual(
+            baseline,
+            (
+                "--max-num-iterations",
+                "2000",
+                "--viewer.quit-on-train-completion",
+                "True",
+            ),
+        )
+        self.assertEqual(regularized[: len(baseline)], baseline)
+        self.assertEqual(
+            regularized[len(baseline) :],
+            ("--pipeline.model.use-scale-regularization", "True"),
+        )
+
+    def test_quality_comparison_runs_same_budget_with_and_without_regularization(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = root / "data"
+            data.mkdir()
+            calls = []
+
+            def fake_run(data_dir, output_root, **kwargs):
+                calls.append((Path(data_dir), Path(output_root), kwargs))
+                run_dir = Path(output_root) / "splatfacto" / "run"
+                export_dir = run_dir / "export"
+                export_dir.mkdir(parents=True)
+                (export_dir / "splat.ply").write_bytes(b"ply")
+                manifest = run_dir / "manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "output": {
+                        "ply_path": "export/splat.ply",
+                        "sha256": "a" * 64,
+                        "size_bytes": 3,
+                    },
+                }
+
+            with patch(
+                "processing.splatfacto_quality.run_splatfacto_export",
+                side_effect=fake_run,
+            ):
+                result = run_quality_comparison(
+                    data,
+                    root / "comparison",
+                    iterations=(2000,),
+                )
+
+            self.assertEqual(len(calls), 2)
+            baseline_args = calls[0][2]["train_extra_args"]
+            regularized_args = calls[1][2]["train_extra_args"]
+            self.assertNotIn("--pipeline.model.use-scale-regularization", baseline_args)
+            self.assertIn("--pipeline.model.use-scale-regularization", regularized_args)
+            self.assertEqual(len(result["experiments"]), 2)
+            self.assertFalse(result["experiments"][0]["scale_regularization"])
+            self.assertTrue(result["experiments"][1]["scale_regularization"])
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+
+    def test_quality_comparison_rejects_invalid_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            data = Path(tmp) / "data"
+            data.mkdir()
+            with self.assertRaisesRegex(ValueError, "positive"):
+                run_quality_comparison(data, Path(tmp) / "out", iterations=(0,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Turn #41, #45 and #48 from manual ideas into reproducible execution paths without changing the existing production default.

Related: #26, #33, #41, #43, #45, #46, #47, #48.

## What changes

- add `processing.splatfacto_quality` to run the same processed Nerfstudio dataset as baseline vs `--pipeline.model.use-scale-regularization True`, optionally across multiple iteration budgets;
- keep culling thresholds and the existing Splatfacto backend unchanged so the first A/B isolates scale regularization;
- add `processing.gaussian_ply` to measure exported PLY primitive count, opacity distribution, and scale anisotropy (`max(scale)/min(scale)`) from the standard binary 3DGS PLY representation;
- add an auditable `processing.clean_gs` wrapper around the official Clean-GS CLI. It requires an explicit upstream revision and semantic-mask hashes, records exact argv and before/after PLY hashes, and fails if no cleaned PLY is produced;
- add unit tests for all three paths.

## Important upstream boundary

The repository currently pins `nerfstudio==1.1.5`. That exact upstream version has `use_scale_regularization` but does **not** implement the newer `strategy=mcmc` configuration. Therefore this PR deliberately does not pretend that #43 is runnable on the production pin. MCMC needs a separately verified Nerfstudio/gsplat environment or an explicitly reviewed dependency upgrade.

Likewise, this PR does not vendor EFA-GS or Signal Structure-Aware Gaussian. Their official implementations remain research backends and need their own environment/data adaptation and GPU execution evidence.

## Commands after merge

Controlled scale-regularization + training-budget comparison on an existing processed dataset:

```bash
python -m processing.splatfacto_quality \
  --data output/<id>/nerfstudio-data \
  --output-root output/<id>/quality \
  --iterations 2000 \
  --iterations 30000
```

Measure one exported PLY:

```bash
python -m processing.gaussian_ply output/<id>/runs/.../export/splat.ply --output metrics.json
```

Run a fixed Clean-GS checkout after semantic masks exist:

```bash
python -m processing.clean_gs \
  --script /path/to/clean-gs/clean-gs.py \
  --upstream-revision <exact-commit> \
  --scene <scene> \
  --masks-dir <masks> \
  --input-ply <input.ply> \
  --output-ply <clean.ply> \
  --manifest <clean.manifest.json>
```

## Evidence boundary

This PR can be proven by repository unit tests only. It does not claim GPU quality improvement. #41/#45/#48 require the bad-scene + good-control GPU runs and fixed-view comparison before their empirical acceptance criteria can close.

Closes no empirical issue by code alone.