### PR TITLE
3DGS: add exact-commit MCMC strategy A/B runner

### DIFF
--- a/processing/mcmc_quality.py
+++ b/processing/mcmc_quality.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from importlib import metadata
+from pathlib import Path
+
+from processing.nerfstudio import run_splatfacto_export
+from processing.provenance import write_json
+
+NERFSTUDIO_MCMC_REVISION = "c7bd9539728515eded9cc4ed137ca703f900e28a"
+GSPLAT_MCMC_VERSION = "1.4.0"
+
+
+def verify_research_environment(nerfstudio_source: str | Path) -> dict:
+    """Verify the exact unreleased Nerfstudio commit that introduced the MCMC strategy."""
+    source = Path(nerfstudio_source).expanduser().resolve()
+    if not (source / ".git").exists():
+        raise ValueError(f"nerfstudio_source must be a Git checkout: {source}")
+    revision = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if revision != NERFSTUDIO_MCMC_REVISION:
+        raise ValueError(
+            "Nerfstudio research checkout revision mismatch: "
+            f"expected {NERFSTUDIO_MCMC_REVISION}, got {revision}"
+        )
+    try:
+        gsplat_version = metadata.version("gsplat")
+    except metadata.PackageNotFoundError as exc:
+        raise ValueError("gsplat is not installed in the research environment") from exc
+    if gsplat_version != GSPLAT_MCMC_VERSION:
+        raise ValueError(
+            f"gsplat version mismatch: expected {GSPLAT_MCMC_VERSION}, got {gsplat_version}"
+        )
+    return {
+        "nerfstudio_repository": "https://github.com/nerfstudio-project/nerfstudio",
+        "nerfstudio_revision": revision,
+        "gsplat_repository": "https://github.com/nerfstudio-project/gsplat",
+        "gsplat_version": gsplat_version,
+    }
+
+
+def mcmc_train_args(*, iterations: int, enabled: bool) -> tuple[str, ...]:
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    args = [
+        "--max-num-iterations",
+        str(iterations),
+        "--viewer.quit-on-train-completion",
+        "True",
+    ]
+    if enabled:
+        args.extend(("--pipeline.model.strategy", "mcmc"))
+    return tuple(args)
+
+
+def run_mcmc_comparison(
+    data_dir: str | Path,
+    output_root: str | Path,
+    *,
+    nerfstudio_source: str | Path,
+    iterations: int = 30000,
+    train_executable: str = "ns-train",
+    export_executable: str = "ns-export",
+    timeout: float | None = None,
+) -> dict:
+    """Compare DefaultStrategy vs MCMCStrategy without using the confounded splatfacto-mcmc preset."""
+    data = Path(data_dir).expanduser().resolve()
+    if not data.is_dir():
+        raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    environment = verify_research_environment(nerfstudio_source)
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    summary_path = root / "mcmc-comparison.json"
+    summary = {
+        "schema_version": 1,
+        "data_dir": str(data),
+        "research_environment": environment,
+        "iterations": iterations,
+        "experiments": [],
+    }
+
+    for enabled in (False, True):
+        variant = "mcmc" if enabled else "default"
+        result = run_splatfacto_export(
+            data,
+            root / variant,
+            train_executable=train_executable,
+            export_executable=export_executable,
+            train_extra_args=mcmc_train_args(iterations=iterations, enabled=enabled),
+            timeout=timeout,
+            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+        )
+        manifest_path = Path(result["manifest_path"])
+        summary["experiments"].append(
+            {
+                "strategy": variant,
+                "manifest_path": str(manifest_path),
+                "ply_path": str(manifest_path.parent / result["output"]["ply_path"]),
+                "ply_sha256": result["output"]["sha256"],
+                "ply_size_bytes": result["output"]["size_bytes"],
+            }
+        )
+        write_json(summary_path, summary)
+
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare Nerfstudio DefaultStrategy and MCMCStrategy at a pinned upstream commit."
+    )
+    parser.add_argument("--data", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--nerfstudio-source", required=True)
+    parser.add_argument("--iterations", type=int, default=30000)
+    parser.add_argument("--ns-train", default="ns-train")
+    parser.add_argument("--ns-export", default="ns-export")
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_mcmc_comparison(
+        args.data,
+        args.output_root,
+        nerfstudio_source=args.nerfstudio_source,
+        iterations=args.iterations,
+        train_executable=args.ns_train,
+        export_executable=args.ns_export,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcmc_quality.py
+++ b/tests/test_mcmc_quality.py
@@ -1,0 +1,86 @@
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.mcmc_quality import (
+    GSPLAT_MCMC_VERSION,
+    NERFSTUDIO_MCMC_REVISION,
+    mcmc_train_args,
+    run_mcmc_comparison,
+    verify_research_environment,
+)
+
+
+class McmcQualityTests(unittest.TestCase):
+    def test_mcmc_args_change_only_strategy(self):
+        default = mcmc_train_args(iterations=30000, enabled=False)
+        mcmc = mcmc_train_args(iterations=30000, enabled=True)
+        self.assertEqual(mcmc[: len(default)], default)
+        self.assertEqual(mcmc[len(default) :], ("--pipeline.model.strategy", "mcmc"))
+
+    def test_verify_research_environment_checks_exact_commit_and_gsplat(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "nerfstudio"
+            (source / ".git").mkdir(parents=True)
+            completed = subprocess.CompletedProcess(
+                ["git"], 0, NERFSTUDIO_MCMC_REVISION + "\n", ""
+            )
+            with patch("processing.mcmc_quality.subprocess.run", return_value=completed), patch(
+                "processing.mcmc_quality.metadata.version", return_value=GSPLAT_MCMC_VERSION
+            ):
+                result = verify_research_environment(source)
+            self.assertEqual(result["nerfstudio_revision"], NERFSTUDIO_MCMC_REVISION)
+            self.assertEqual(result["gsplat_version"], GSPLAT_MCMC_VERSION)
+
+    def test_run_comparison_records_default_and_mcmc(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = root / "data"
+            data.mkdir()
+            source = root / "nerfstudio"
+            source.mkdir()
+            calls = []
+
+            def fake_run(data_dir, output_root, **kwargs):
+                calls.append(kwargs["train_extra_args"])
+                run_dir = Path(output_root) / "splatfacto" / "run"
+                (run_dir / "export").mkdir(parents=True)
+                (run_dir / "export" / "splat.ply").write_bytes(b"ply")
+                manifest = run_dir / "manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "output": {
+                        "ply_path": "export/splat.ply",
+                        "sha256": "b" * 64,
+                        "size_bytes": 3,
+                    },
+                }
+
+            environment = {
+                "nerfstudio_repository": "https://github.com/nerfstudio-project/nerfstudio",
+                "nerfstudio_revision": NERFSTUDIO_MCMC_REVISION,
+                "gsplat_repository": "https://github.com/nerfstudio-project/gsplat",
+                "gsplat_version": GSPLAT_MCMC_VERSION,
+            }
+            with patch("processing.mcmc_quality.verify_research_environment", return_value=environment), patch(
+                "processing.mcmc_quality.run_splatfacto_export", side_effect=fake_run
+            ):
+                result = run_mcmc_comparison(
+                    data,
+                    root / "out",
+                    nerfstudio_source=source,
+                    iterations=30000,
+                )
+
+            self.assertEqual(len(calls), 2)
+            self.assertNotIn("--pipeline.model.strategy", calls[0])
+            self.assertIn("--pipeline.model.strategy", calls[1])
+            self.assertEqual([entry["strategy"] for entry in result["experiments"]], ["default", "mcmc"])
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Make #43 executable without upgrading the production Nerfstudio pin and without using the confounded `splatfacto-mcmc` preset.

## Verified upstream basis

Nerfstudio commit `c7bd9539728515eded9cc4ed137ca703f900e28a` is the commit `Finalize MCMC strategy and some tiny fix (#3548)`. It adds `MCMCStrategy`, `strategy: Literal["default", "mcmc"]`, and the `splatfacto-mcmc` preset.

At that exact commit `pyproject.toml` pins `gsplat==1.4.0`.

The preset also changes `cull_alpha_thresh`, `stop_split_at`, mixed precision and optimizer settings, so this implementation deliberately compares ordinary `splatfacto` with only:

```text
--pipeline.model.strategy mcmc
```

added to the MCMC run.

## Implementation

`python -m processing.mcmc_quality`:

- requires a real Nerfstudio Git checkout;
- verifies `git rev-parse HEAD` equals the exact MCMC-introduction commit;
- verifies the running Python environment has `gsplat==1.4.0`;
- runs default and MCMC with the same processed Nerfstudio dataset and same iteration budget;
- keeps existing Splatfacto child manifests for exact argv/config/checkpoint/PLY hashes;
- writes a comparison manifest containing the exact unreleased Nerfstudio revision and gsplat version.

Example:

```bash
python -m processing.mcmc_quality \
  --data output/<id>/nerfstudio-data \
  --output-root output/<id>/mcmc \
  --nerfstudio-source /opt/nerfstudio-c7bd953 \
  --iterations 30000
```

## Boundary

This does not modify `Dockerfile` or the production `nerfstudio==1.1.5` environment. The exact research environment still has to be built/tested on the target GPU before #43 can close. No MCMC quality claim is made by unit tests alone.

Related: #26, #41, #43.