### PR TITLE
3DGS: add direct floater and anisotropy metrics to backend evaluation

### DIFF
--- a/processing/backend_evaluation.py
+++ b/processing/backend_evaluation.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Mapping, Sequence
 
+from processing.gaussian_ply import gaussian_ply_metrics
 from processing.provenance import image_records, sha256_file, write_json
 
 METRIC_FIELDS = (
@@ -20,6 +21,12 @@ METRIC_FIELDS = (
     "output_size_bytes",
     "primitive_count",
     "camera_pose_available",
+    "low_opacity_primitive_count",
+    "low_opacity_primitive_ratio",
+    "scale_anisotropy_above_10_count",
+    "scale_anisotropy_above_10_ratio",
+    "cleanup_removed_primitive_count",
+    "cleanup_removed_primitive_ratio",
 )
 
 
@@ -92,6 +99,39 @@ def dataset_identity(contract: Mapping) -> str:
 def empty_metrics() -> dict:
     """Return the common metric shape without inventing unmeasured values."""
     return {field: None for field in METRIC_FIELDS}
+
+
+def gaussian_artifact_metrics(path: str | Path) -> dict:
+    """Return direct, representation-level artifact measurements for a Gaussian PLY.
+
+    These values do not classify visual quality. They expose low-opacity primitives and
+    highly anisotropic primitives so those counts can be compared alongside fixed-view
+    renders and image-space quality metrics.
+    """
+    measured = gaussian_ply_metrics(path)
+    return {
+        "primitive_count": measured["primitive_count"],
+        "output_size_bytes": measured["size_bytes"],
+        "low_opacity_primitive_count": measured["opacity"]["below_0_1_count"],
+        "low_opacity_primitive_ratio": measured["opacity"]["below_0_1_ratio"],
+        "scale_anisotropy_above_10_count": measured["scale_anisotropy_ratio"]["above_10_count"],
+        "scale_anisotropy_above_10_ratio": measured["scale_anisotropy_ratio"]["above_10_ratio"],
+    }
+
+
+def cleanup_metrics(before_path: str | Path, after_path: str | Path) -> dict:
+    """Measure primitive removal by cleanup without claiming that removed means improved."""
+    before = gaussian_ply_metrics(before_path)
+    after = gaussian_ply_metrics(after_path)
+    removed = before["primitive_count"] - after["primitive_count"]
+    if removed < 0:
+        raise ValueError(
+            "cleanup output contains more primitives than its input; use backend-specific metrics instead"
+        )
+    return {
+        "cleanup_removed_primitive_count": removed,
+        "cleanup_removed_primitive_ratio": removed / before["primitive_count"],
+    }
 
 
 def artifact_record(path: str | Path, *, format: str) -> dict:

--- a/tests/test_backend_artifact_metrics.py
+++ b/tests/test_backend_artifact_metrics.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch
+
+from processing.backend_evaluation import cleanup_metrics, empty_metrics, gaussian_artifact_metrics
+
+
+class BackendArtifactMetricTests(unittest.TestCase):
+    def test_empty_metrics_exposes_direct_artifact_fields_as_unmeasured(self):
+        metrics = empty_metrics()
+        for field in (
+            "low_opacity_primitive_count",
+            "low_opacity_primitive_ratio",
+            "scale_anisotropy_above_10_count",
+            "scale_anisotropy_above_10_ratio",
+            "cleanup_removed_primitive_count",
+            "cleanup_removed_primitive_ratio",
+        ):
+            self.assertIn(field, metrics)
+            self.assertIsNone(metrics[field])
+
+    def test_gaussian_artifact_metrics_maps_measured_ply_values(self):
+        measured = {
+            "primitive_count": 100,
+            "size_bytes": 1234,
+            "opacity": {"below_0_1_count": 20, "below_0_1_ratio": 0.2},
+            "scale_anisotropy_ratio": {"above_10_count": 5, "above_10_ratio": 0.05},
+        }
+        with patch("processing.backend_evaluation.gaussian_ply_metrics", return_value=measured):
+            metrics = gaussian_artifact_metrics("model.ply")
+        self.assertEqual(metrics["primitive_count"], 100)
+        self.assertEqual(metrics["output_size_bytes"], 1234)
+        self.assertEqual(metrics["low_opacity_primitive_count"], 20)
+        self.assertEqual(metrics["scale_anisotropy_above_10_ratio"], 0.05)
+
+    def test_cleanup_metrics_reports_removed_primitives_only(self):
+        before = {"primitive_count": 100}
+        after = {"primitive_count": 75}
+        with patch(
+            "processing.backend_evaluation.gaussian_ply_metrics",
+            side_effect=[before, after],
+        ):
+            metrics = cleanup_metrics("before.ply", "after.ply")
+        self.assertEqual(metrics["cleanup_removed_primitive_count"], 25)
+        self.assertEqual(metrics["cleanup_removed_primitive_ratio"], 0.25)
+
+    def test_cleanup_metrics_rejects_added_primitives(self):
+        with patch(
+            "processing.backend_evaluation.gaussian_ply_metrics",
+            side_effect=[{"primitive_count": 10}, {"primitive_count": 11}],
+        ):
+            with self.assertRaisesRegex(ValueError, "more primitives"):
+                cleanup_metrics("before.ply", "after.ply")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Extend #26 so the 3DGS comparison can record direct representation-level artifact measurements instead of deciding only from PSNR/SSIM/LPIPS.

## Added metrics

For Gaussian PLY outputs, the common comparison schema now accepts:

- `low_opacity_primitive_count`
- `low_opacity_primitive_ratio`
- `scale_anisotropy_above_10_count`
- `scale_anisotropy_above_10_ratio`
- `cleanup_removed_primitive_count`
- `cleanup_removed_primitive_ratio`

`gaussian_artifact_metrics()` maps these directly from the PLY parser added in PR #50. `cleanup_metrics()` measures primitive removal before/after cleanup and explicitly does **not** interpret removal as visual improvement.

The scale-anisotropy threshold 10 matches Nerfstudio Splatfacto's `max_gauss_ratio=10.0` threshold used by scale regularization. Low-opacity uses the existing 0.1 culling threshold already represented in the PLY metric path.

## Boundary

These metrics complement fixed novel-view inspection and PSNR/SSIM/LPIPS; they do not invent a single quality score or label every low-opacity/high-anisotropy Gaussian as an artifact.

Related: #26, #41, #43, #45, #46, #47, #48.