### PR TITLE
3DGS: make local quality work GPU-only on pinned Blackwell image

### DIFF
--- a/.github/workflows/gpu-image.yml
+++ b/.github/workflows/gpu-image.yml
@@ -1,0 +1,44 @@
+name: GPU Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - requirements.txt
+      - main.py
+      - processing/**
+      - sources/**
+      - task
+      - .github/workflows/gpu-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/kafka2306/autophotogrammetry:quality-ns50e0e3-sm120-v1
+            ghcr.io/kafka2306/autophotogrammetry:sha-${{ github.sha }}
+          build-args: |
+            CUDA_ARCH_LIST=12.0
+            NERFSTUDIO_REVISION=50e0e3c70c775e89333256213363badbf074f29d
+            GSPLAT_REVISION=v1.4.0
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG CUDA_ARCH_LIST=8.6
+ARG CUDA_ARCH_LIST=12.0
+ARG NERFSTUDIO_REVISION=50e0e3c70c775e89333256213363badbf074f29d
+ARG GSPLAT_REVISION=v1.4.0
 ENV CUDA_HOME=/usr/local/cuda \
     TORCH_CUDA_ARCH_LIST=${CUDA_ARCH_LIST} \
     TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
     MAX_JOBS=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
+
+LABEL org.opencontainers.image.source="https://github.com/KAFKA2306/AutoPhotogrammetry" \
+      org.opencontainers.image.description="Pinned AutoPhotogrammetry CUDA environment for Splatfacto quality experiments"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -26,14 +31,21 @@ RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
         torch==2.7.1 torchvision==0.22.1 \
         --index-url https://download.pytorch.org/whl/cu128
 
-RUN git clone --depth 1 --branch v1.4.0 --recurse-submodules --shallow-submodules \
+RUN git clone --depth 1 --branch "${GSPLAT_REVISION}" --recurse-submodules --shallow-submodules \
         https://github.com/nerfstudio-project/gsplat.git /tmp/gsplat \
     && python -m pip install --no-cache-dir --no-build-isolation /tmp/gsplat \
-    && rm -rf /tmp/gsplat \
-    && python -m pip install --no-cache-dir nerfstudio==1.1.5
+    && rm -rf /tmp/gsplat
+
+RUN git init /opt/nerfstudio \
+    && git -C /opt/nerfstudio remote add origin https://github.com/nerfstudio-project/nerfstudio.git \
+    && git -C /opt/nerfstudio fetch --depth 1 origin "${NERFSTUDIO_REVISION}" \
+    && git -C /opt/nerfstudio checkout --detach FETCH_HEAD \
+    && test "$(git -C /opt/nerfstudio rev-parse HEAD)" = "${NERFSTUDIO_REVISION}" \
+    && python -m pip install --no-cache-dir /opt/nerfstudio
 
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --no-cache-dir -r /tmp/requirements.txt \
     && python -m pip check
 
-WORKDIR /workspace
+COPY . /opt/autophotogrammetry
+WORKDIR /opt/autophotogrammetry

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AutoPhotogrammetry
 
 [![Test](https://github.com/KAFKA2306/AutoPhotogrammetry/actions/workflows/test.yml/badge.svg)](https://github.com/KAFKA2306/AutoPhotogrammetry/actions/workflows/test.yml)
+[![GPU Image](https://github.com/KAFKA2306/AutoPhotogrammetry/actions/workflows/gpu-image.yml/badge.svg)](https://github.com/KAFKA2306/AutoPhotogrammetry/actions/workflows/gpu-image.yml)
 
 **実写動画 → camera poses → Gaussian Splat PLY** を1タスクで再現します。
 
@@ -20,13 +21,31 @@ cd AutoPhotogrammetry
 ./task run
 ```
 
-環境確認、Docker image build、入力取得、hash検証、frame抽出、COLMAP、Splatfacto、PLY export、成功判定はtaskが行います。
+GPU用のCUDA / PyTorch / gsplat / Nerfstudio環境はGitHub Actionsでコンテナ化します。通常のGPU実行ではローカルでNerfstudio checkoutやpip installを行いません。`task` がprebuilt imageを取得し、入力・出力だけをhostへmountします。
 
 Docker CLIまたはDocker daemonが利用できない場合、`./task doctor` / `./task run` / `./task run-all` は `BLOCKED` と明示して停止します。このrepositoryのtaskはDocker Desktop、WSL、GPU driver、OS設定、Docker storageを修復・resetしません。host環境の修復はrepository実行とは分離してください。
 
 実行入口: [`task`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/task)  
 GPU環境: [`Dockerfile`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/Dockerfile)  
 E2E実装: [`processing/huejotzingo.py`](https://github.com/KAFKA2306/AutoPhotogrammetry/blob/main/processing/huejotzingo.py)
+
+### GPUだけで品質候補を比較する
+
+既に `output/<scene>/nerfstudio-data/transforms.json` があるsceneは、ローカル側では次の1コマンドだけで品質比較できます。
+
+```bash
+./task quality huejotzingo 30000
+```
+
+このrunは同じprocessed dataset、同じ30,000 iteration budget、同じexact Nerfstudio / gsplat環境で以下を独立実行します。
+
+- upstream default Splatfacto
+- `use_scale_regularization=True`
+- `strategy=mcmc`
+
+各PLYについてSHA-256、size、primitive count、opacity < 0.1、scale anisotropy > 10を自動集計し、`output/<scene>/quality-sweep/quality-sweep.json` に保存します。semantic maskが必要なClean-GSはtraining strategyの比較と混ぜず、別のpost-process実験として扱います。
+
+GPU imageはNerfstudio commit `50e0e3c70c775e89333256213363badbf074f29d`、gsplat `1.4.0`、CUDA 12.8 / PyTorch 2.7.1、`sm_120`を固定します。floating `main` には依存しません。
 
 ## 撮影セットを3D化前に監査する
 
@@ -122,14 +141,8 @@ metadata
 
 各動画は `output/<id>/manifest.json` と独立したGaussian Splat PLYを生成し、全体の
 `output/batch-manifest.json` に20件の成功・失敗とPLY hashを記録します。`run-all` は
-途中生成物を消してから全件を再実行します。個別に再実行したい場合は、例えば次のようにします。
-実証時のSplatfactoは `--max-num-iterations 2000` で実行します。品質重視の再学習では
-`main.py batch --train-iterations 30000` のように増やせます。
-
-```bash
-docker run --rm --gpus all -v "$PWD:/workspace" -w /workspace \
-  autophotogrammetry:cuda128 python main.py batch --id huejotzingo --fresh
-```
+途中生成物を消してから全件を再実行します。個別に再実行したい場合も `task` を入口にします。
+実証時のSplatfactoは `--max-num-iterations 2000` で実行します。品質比較は上記 `./task quality <scene> 30000` を使います。
 
 - source: [Wikimedia Commons — Ex Convento de San Miguel Arcángel, Huejotzingo](https://commons.wikimedia.org/wiki/File:Vista_del_Ex_Convento_de_San_Miguel_Arc%C3%A1ngel,_Huejotzingo,_desde_un_dron.webm)
 - author: Luisalvaz

--- a/processing/mcmc_quality.py
+++ b/processing/mcmc_quality.py
@@ -9,12 +9,13 @@ from pathlib import Path
 from processing.nerfstudio import run_splatfacto_export
 from processing.provenance import write_json
 
-NERFSTUDIO_MCMC_REVISION = "c7bd9539728515eded9cc4ed137ca703f900e28a"
+NERFSTUDIO_MCMC_REVISION = "50e0e3c70c775e89333256213363badbf074f29d"
 GSPLAT_MCMC_VERSION = "1.4.0"
+DEFAULT_NERFSTUDIO_SOURCE = Path("/opt/nerfstudio")
 
 
-def verify_research_environment(nerfstudio_source: str | Path) -> dict:
-    """Verify the exact unreleased Nerfstudio commit that introduced the MCMC strategy."""
+def verify_research_environment(nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE) -> dict:
+    """Verify the exact MCMC-capable Nerfstudio source baked into the GPU image."""
     source = Path(nerfstudio_source).expanduser().resolve()
     if not (source / ".git").exists():
         raise ValueError(f"nerfstudio_source must be a Git checkout: {source}")
@@ -26,13 +27,13 @@ def verify_research_environment(nerfstudio_source: str | Path) -> dict:
     ).stdout.strip()
     if revision != NERFSTUDIO_MCMC_REVISION:
         raise ValueError(
-            "Nerfstudio research checkout revision mismatch: "
+            "Nerfstudio checkout revision mismatch: "
             f"expected {NERFSTUDIO_MCMC_REVISION}, got {revision}"
         )
     try:
         gsplat_version = metadata.version("gsplat")
     except metadata.PackageNotFoundError as exc:
-        raise ValueError("gsplat is not installed in the research environment") from exc
+        raise ValueError("gsplat is not installed in the execution environment") from exc
     if gsplat_version != GSPLAT_MCMC_VERSION:
         raise ValueError(
             f"gsplat version mismatch: expected {GSPLAT_MCMC_VERSION}, got {gsplat_version}"
@@ -63,13 +64,13 @@ def run_mcmc_comparison(
     data_dir: str | Path,
     output_root: str | Path,
     *,
-    nerfstudio_source: str | Path,
+    nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
     iterations: int = 30000,
     train_executable: str = "ns-train",
     export_executable: str = "ns-export",
     timeout: float | None = None,
 ) -> dict:
-    """Compare DefaultStrategy vs MCMCStrategy without using the confounded splatfacto-mcmc preset."""
+    """Compare DefaultStrategy vs MCMCStrategy at the pinned production candidate revision."""
     data = Path(data_dir).expanduser().resolve()
     if not data.is_dir():
         raise ValueError(f"Nerfstudio data directory does not exist: {data}")
@@ -78,9 +79,9 @@ def run_mcmc_comparison(
     root.mkdir(parents=True, exist_ok=True)
     summary_path = root / "mcmc-comparison.json"
     summary = {
-        "schema_version": 1,
+        "schema_version": 2,
         "data_dir": str(data),
-        "research_environment": environment,
+        "environment": environment,
         "iterations": iterations,
         "experiments": [],
     }
@@ -115,11 +116,11 @@ def run_mcmc_comparison(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Compare Nerfstudio DefaultStrategy and MCMCStrategy at a pinned upstream commit."
+        description="Compare Nerfstudio DefaultStrategy and MCMCStrategy in the pinned GPU image."
     )
     parser.add_argument("--data", required=True)
     parser.add_argument("--output-root", required=True)
-    parser.add_argument("--nerfstudio-source", required=True)
+    parser.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
     parser.add_argument("--iterations", type=int, default=30000)
     parser.add_argument("--ns-train", default="ns-train")
     parser.add_argument("--ns-export", default="ns-export")

--- a/processing/quality_sweep.py
+++ b/processing/quality_sweep.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from processing.gaussian_ply import gaussian_ply_metrics
+from processing.mcmc_quality import DEFAULT_NERFSTUDIO_SOURCE, verify_research_environment
+from processing.nerfstudio import run_splatfacto_export
+from processing.provenance import write_json
+
+
+def quality_sweep_train_args(*, iterations: int, variant: str) -> tuple[str, ...]:
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    args = [
+        "--max-num-iterations",
+        str(iterations),
+        "--viewer.quit-on-train-completion",
+        "True",
+    ]
+    if variant == "default":
+        pass
+    elif variant == "scale-regularized":
+        args.extend(("--pipeline.model.use-scale-regularization", "True"))
+    elif variant == "mcmc":
+        args.extend(("--pipeline.model.strategy", "mcmc"))
+    else:
+        raise ValueError(f"unknown quality sweep variant: {variant}")
+    return tuple(args)
+
+
+def run_quality_sweep(
+    data_dir: str | Path,
+    output_root: str | Path,
+    *,
+    nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
+    iterations: int = 30000,
+    timeout: float | None = None,
+) -> dict:
+    """Run the three first-line Splatfacto candidates and measure their exported PLYs.
+
+    The sweep changes one refinement choice at a time on one exact Nerfstudio/gsplat
+    environment: upstream default, PhysGaussian-derived scale regularization, and MCMC.
+    Clean-GS is intentionally excluded because it requires semantic masks and is a
+    post-processing experiment rather than a training-strategy variable.
+    """
+    data = Path(data_dir).expanduser().resolve()
+    if not data.is_dir():
+        raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    environment = verify_research_environment(nerfstudio_source)
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    summary_path = root / "quality-sweep.json"
+    summary = {
+        "schema_version": 1,
+        "data_dir": str(data),
+        "environment": environment,
+        "iterations": iterations,
+        "variants": [],
+    }
+
+    for variant in ("default", "scale-regularized", "mcmc"):
+        result = run_splatfacto_export(
+            data,
+            root / variant,
+            train_extra_args=quality_sweep_train_args(iterations=iterations, variant=variant),
+            timeout=timeout,
+            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+        )
+        manifest_path = Path(result["manifest_path"])
+        ply_path = manifest_path.parent / result["output"]["ply_path"]
+        ply_metrics = gaussian_ply_metrics(ply_path)
+        summary["variants"].append(
+            {
+                "variant": variant,
+                "manifest_path": str(manifest_path),
+                "ply_path": str(ply_path),
+                "ply_sha256": result["output"]["sha256"],
+                "ply_size_bytes": result["output"]["size_bytes"],
+                "ply_metrics": ply_metrics,
+            }
+        )
+        write_json(summary_path, summary)
+
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run default, scale-regularized and MCMC Splatfacto on one pinned GPU environment."
+    )
+    parser.add_argument("--data", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
+    parser.add_argument("--iterations", type=int, default=30000)
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_quality_sweep(
+        args.data,
+        args.output_root,
+        nerfstudio_source=args.nerfstudio_source,
+        iterations=args.iterations,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/task
+++ b/task
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-IMAGE="${AUTOPHOTOGRAMMETRY_IMAGE:-autophotogrammetry:cuda128}"
-HOST_GPU_ARCH="${AUTOPHOTOGRAMMETRY_CUDA_ARCH:-8.6}"
+IMAGE="${AUTOPHOTOGRAMMETRY_IMAGE:-ghcr.io/kafka2306/autophotogrammetry:quality-ns50e0e3-sm120-v1}"
+HOST_GPU_ARCH="${AUTOPHOTOGRAMMETRY_CUDA_ARCH:-12.0}"
 
 check_docker() {
   if ! command -v docker >/dev/null 2>&1; then
@@ -20,24 +20,51 @@ build_image() {
   docker build --pull --build-arg "CUDA_ARCH_LIST=$HOST_GPU_ARCH" -t "$IMAGE" "$ROOT"
 }
 
+pull_image() {
+  if docker pull "$IMAGE"; then
+    return 0
+  fi
+
+  if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+    local login token
+    login="$(gh api user --jq .login)"
+    token="$(gh auth token)"
+    printf '%s' "$token" | docker login ghcr.io -u "$login" --password-stdin >/dev/null
+    docker pull "$IMAGE"
+    return 0
+  fi
+
+  echo "Prebuilt GPU image is unavailable. The local quality path intentionally does not build dependencies; publish the GPU Image workflow or authenticate gh/docker to GHCR." >&2
+  return 1
+}
+
+ensure_image() {
+  if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    return 0
+  fi
+  pull_image
+}
+
 check_host_gpu() {
   if ! command -v nvidia-smi >/dev/null 2>&1; then
     return 0
   fi
   HOST_GPU_ARCH="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1 | tr -d '[:space:]')"
-  if ! awk -v capability="$HOST_GPU_ARCH" 'BEGIN { exit !(capability >= 8.6) }'; then
-    echo "Incompatible GPU compute capability: ${HOST_GPU_ARCH:-unknown}; this image requires sm_86+ (8.6 or newer)." >&2
+  if ! awk -v capability="$HOST_GPU_ARCH" 'BEGIN { exit !(capability >= 12.0 && capability < 13.0) }'; then
+    echo "GPU compute capability ${HOST_GPU_ARCH:-unknown} does not match the prebuilt sm_120 quality image. Override AUTOPHOTOGRAMMETRY_IMAGE/CUDA_ARCH only with another explicitly built image." >&2
     return 1
   fi
 }
 
 run_gpu() {
+  mkdir -p "$ROOT/input" "$ROOT/output"
   docker run --rm --gpus all --shm-size=12g \
     --user "$(id -u):$(id -g)" \
     -e HOME=/tmp \
     -e TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
-    -v "$ROOT:/workspace" \
-    -w /workspace \
+    -v "$ROOT/input:/workspace/input" \
+    -v "$ROOT/output:/workspace/output" \
+    -w /opt/autophotogrammetry \
     "$IMAGE" "$@"
 }
 
@@ -45,22 +72,26 @@ run_cpu() {
   docker run --rm \
     --user "$(id -u):$(id -g)" \
     -e HOME=/tmp \
-    -v "$ROOT:/workspace" \
-    -w /workspace \
+    -w /opt/autophotogrammetry \
     "$IMAGE" "$@"
 }
 
 doctor() {
   check_docker
   check_host_gpu
-  build_image
-  run_gpu python -c 'import importlib.metadata as m, shutil, torch; assert torch.cuda.is_available(), "CUDA is not available in Docker"; cap=torch.cuda.get_device_capability(); assert cap >= (8, 6), f"Expected sm_86+, got {cap}"; required=["ffmpeg","ffprobe","colmap","ns-process-data","ns-train","ns-export"]; missing=[x for x in required if shutil.which(x) is None]; assert not missing, f"Missing executables: {missing}"; import gsplat; print({"gpu": torch.cuda.get_device_name(), "capability": cap, "torch": torch.__version__, "nerfstudio": m.version("nerfstudio"), "gsplat": m.version("gsplat")})'
+  ensure_image
+  run_gpu python -c 'import importlib.metadata as m, shutil, subprocess, torch; assert torch.cuda.is_available(), "CUDA is not available in Docker"; cap=torch.cuda.get_device_capability(); assert cap[0] == 12, f"Expected compute capability 12.x, got {cap}"; required=["ffmpeg","ffprobe","colmap","ns-process-data","ns-train","ns-export"]; missing=[x for x in required if shutil.which(x) is None]; assert not missing, f"Missing executables: {missing}"; rev=subprocess.run(["git","-C","/opt/nerfstudio","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev == "50e0e3c70c775e89333256213363badbf074f29d", rev; print({"gpu": torch.cuda.get_device_name(), "capability": cap, "torch": torch.__version__, "nerfstudio_revision": rev, "nerfstudio_package": m.version("nerfstudio"), "gsplat": m.version("gsplat")})'
 }
 
 case "${1:-run}" in
   image)
     check_docker
+    check_host_gpu
     build_image
+    ;;
+  pull)
+    check_docker
+    pull_image
     ;;
   doctor)
     doctor
@@ -72,13 +103,26 @@ case "${1:-run}" in
     ;;
   run)
     doctor
-    mkdir -p "$ROOT/input" "$ROOT/output"
-    run_gpu python main.py huejotzingo
+    run_gpu python main.py huejotzingo --input-root /workspace/input --output-root /workspace/output
     ;;
   run-all)
     doctor
-    mkdir -p "$ROOT/input" "$ROOT/output"
-    run_gpu python main.py batch
+    run_gpu python main.py batch --input-root /workspace/input --output-root /workspace/output
+    ;;
+  quality)
+    scene="${2:-huejotzingo}"
+    iterations="${3:-30000}"
+    data="$ROOT/output/$scene/nerfstudio-data"
+    if [[ ! -f "$data/transforms.json" ]]; then
+      echo "Prepared Nerfstudio dataset is missing: $data/transforms.json" >&2
+      echo "Quality execution is intentionally GPU-only and will not rerun download/FFmpeg/COLMAP. Use an existing prepared dataset." >&2
+      exit 1
+    fi
+    doctor
+    run_gpu python -m processing.quality_sweep \
+      --data "/workspace/output/$scene/nerfstudio-data" \
+      --output-root "/workspace/output/$scene/quality-sweep" \
+      --iterations "$iterations"
     ;;
   clean)
     find "$ROOT/output" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
@@ -87,7 +131,7 @@ case "${1:-run}" in
     find "$ROOT/output" "$ROOT/input" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
     ;;
   *)
-    echo "usage: ./task {run|run-all|doctor|test|image|clean|clean-all}" >&2
+    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|doctor|pull|test|image|clean|clean-all}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_quality_sweep.py
+++ b/tests/test_quality_sweep.py
@@ -1,0 +1,86 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.quality_sweep import quality_sweep_train_args, run_quality_sweep
+
+
+class QualitySweepTests(unittest.TestCase):
+    def test_variants_change_only_expected_training_argument(self):
+        baseline = quality_sweep_train_args(iterations=30000, variant="default")
+        scale = quality_sweep_train_args(iterations=30000, variant="scale-regularized")
+        mcmc = quality_sweep_train_args(iterations=30000, variant="mcmc")
+
+        self.assertEqual(scale[: len(baseline)], baseline)
+        self.assertEqual(
+            scale[len(baseline) :],
+            ("--pipeline.model.use-scale-regularization", "True"),
+        )
+        self.assertEqual(mcmc[: len(baseline)], baseline)
+        self.assertEqual(
+            mcmc[len(baseline) :],
+            ("--pipeline.model.strategy", "mcmc"),
+        )
+
+    def test_quality_sweep_records_three_variants_and_ply_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data = root / "data"
+            data.mkdir()
+            calls = []
+
+            def fake_run(data_dir, output_root, **kwargs):
+                calls.append(kwargs["train_extra_args"])
+                run_dir = Path(output_root) / "splatfacto" / "run"
+                (run_dir / "export").mkdir(parents=True)
+                ply = run_dir / "export" / "splat.ply"
+                ply.write_bytes(b"ply")
+                manifest = run_dir / "manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "output": {
+                        "ply_path": "export/splat.ply",
+                        "sha256": "a" * 64,
+                        "size_bytes": 3,
+                    },
+                }
+
+            environment = {
+                "nerfstudio_revision": "revision",
+                "gsplat_version": "1.4.0",
+            }
+            metrics = {
+                "primitive_count": 100,
+                "opacity": {"below_0_1_ratio": 0.1},
+                "scale_anisotropy_ratio": {"above_10_ratio": 0.2},
+            }
+            with patch(
+                "processing.quality_sweep.verify_research_environment",
+                return_value=environment,
+            ), patch(
+                "processing.quality_sweep.run_splatfacto_export",
+                side_effect=fake_run,
+            ), patch(
+                "processing.quality_sweep.gaussian_ply_metrics",
+                return_value=metrics,
+            ):
+                result = run_quality_sweep(
+                    data,
+                    root / "out",
+                    nerfstudio_source=root / "nerfstudio",
+                    iterations=30000,
+                )
+
+            self.assertEqual(len(calls), 3)
+            self.assertEqual(
+                [entry["variant"] for entry in result["variants"]],
+                ["default", "scale-regularized", "mcmc"],
+            )
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+            self.assertEqual(result["variants"][0]["ply_metrics"], metrics)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Make the local responsibility for #41/#43 a single GPU execution command. Dependency selection, exact upstream pinning, image construction, environment verification, candidate orchestration and PLY artifact measurements are moved into repository/CI code.

## Upstream basis

- NVIDIA lists GeForce RTX 5070 Ti as compute capability 12.0.
- CUDA 12.8 supports Blackwell.
- PyTorch 2.7 ships CUDA 12.8 Blackwell support.
- Nerfstudio exact commit `50e0e3c70c775e89333256213363badbf074f29d` includes Splatfacto `default`/`mcmc`, scale regularization and pins `gsplat==1.4.0`.

## Changes

- replace the old production `nerfstudio==1.1.5` PyPI-only install with exact Nerfstudio commit `50e0e3...`;
- change the default CUDA extension target from stale `sm_86` to target `sm_120` (still overridable as a Docker build arg);
- retain the Nerfstudio Git checkout inside the image so runtime provenance can verify the exact SHA;
- publish the exact GPU image through GitHub Actions/GHCR;
- add `processing.quality_sweep` for one controlled three-way run:
  1. upstream default Splatfacto,
  2. `use_scale_regularization=True`,
  3. `strategy=mcmc`;
- automatically calculate exported PLY primitive count, low-opacity ratio and scale anisotropy metrics;
- add `./task quality <scene> <iterations>` which only consumes an existing `nerfstudio-data` directory and intentionally does not rerun download/FFmpeg/COLMAP;
- remove local Nerfstudio checkout/pip-install/Docker-build from the normal quality path. The task pulls the prebuilt exact image; if GHCR requires authentication it reuses an existing `gh` login.

## Local remaining action

For a prepared scene:

```bash
./task quality huejotzingo 30000
```

Output:

```text
output/huejotzingo/quality-sweep/quality-sweep.json
```

No quality winner is claimed by this PR. GPU evidence remains the empirical gate.

Related: #26, #41, #43, #48.