### PR TITLE
3DGS: reduce local quality path to one GPU container run

### DIFF
--- a/processing/quality_sweep.py
+++ b/processing/quality_sweep.py
@@ -2,12 +2,36 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 from processing.gaussian_ply import gaussian_ply_metrics
 from processing.mcmc_quality import DEFAULT_NERFSTUDIO_SOURCE, verify_research_environment
 from processing.nerfstudio import run_splatfacto_export
 from processing.provenance import write_json
+
+
+def verify_gpu_runtime() -> dict:
+    """Fail before training unless the single quality container has the expected GPU runtime."""
+    try:
+        import torch
+    except ImportError as exc:
+        raise RuntimeError("PyTorch is not installed in the GPU execution image") from exc
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available in the quality container")
+    capability = tuple(torch.cuda.get_device_capability())
+    if capability[0] != 12:
+        raise RuntimeError(
+            f"Expected compute capability 12.x for the pinned sm_120 image, got {capability}"
+        )
+    return {
+        "gpu_name": torch.cuda.get_device_name(),
+        "compute_capability": f"{capability[0]}.{capability[1]}",
+        "torch_version": torch.__version__,
+        "torch_cuda_version": torch.version.cuda,
+        "container_image_ref": os.environ.get("AUTOPHOTOGRAMMETRY_IMAGE_REF"),
+        "container_image_id": os.environ.get("AUTOPHOTOGRAMMETRY_IMAGE_ID"),
+    }
 
 
 def quality_sweep_train_args(*, iterations: int, variant: str) -> tuple[str, ...]:
@@ -48,13 +72,15 @@ def run_quality_sweep(
     data = Path(data_dir).expanduser().resolve()
     if not data.is_dir():
         raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    runtime = verify_gpu_runtime()
     environment = verify_research_environment(nerfstudio_source)
     root = Path(output_root).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
     summary_path = root / "quality-sweep.json"
     summary = {
-        "schema_version": 1,
+        "schema_version": 2,
         "data_dir": str(data),
+        "runtime": runtime,
         "environment": environment,
         "iterations": iterations,
         "variants": [],

--- a/task
+++ b/task
@@ -57,11 +57,15 @@ check_host_gpu() {
 }
 
 run_gpu() {
+  local image_id
+  image_id="$(docker image inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)"
   mkdir -p "$ROOT/input" "$ROOT/output"
   docker run --rm --gpus all --shm-size=12g \
     --user "$(id -u):$(id -g)" \
     -e HOME=/tmp \
     -e TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
+    -e AUTOPHOTOGRAMMETRY_IMAGE_REF="$IMAGE" \
+    -e AUTOPHOTOGRAMMETRY_IMAGE_ID="$image_id" \
     -v "$ROOT/input:/workspace/input" \
     -v "$ROOT/output:/workspace/output" \
     -w /opt/autophotogrammetry \
@@ -118,7 +122,9 @@ case "${1:-run}" in
       echo "Quality execution is intentionally GPU-only and will not rerun download/FFmpeg/COLMAP. Use an existing prepared dataset." >&2
       exit 1
     fi
-    doctor
+    check_docker
+    check_host_gpu
+    ensure_image
     run_gpu python -m processing.quality_sweep \
       --data "/workspace/output/$scene/nerfstudio-data" \
       --output-root "/workspace/output/$scene/quality-sweep" \

--- a/tests/test_quality_sweep.py
+++ b/tests/test_quality_sweep.py
@@ -23,7 +23,7 @@ class QualitySweepTests(unittest.TestCase):
             ("--pipeline.model.strategy", "mcmc"),
         )
 
-    def test_quality_sweep_records_three_variants_and_ply_metrics(self):
+    def test_quality_sweep_records_three_variants_ply_metrics_and_runtime(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             data = root / "data"
@@ -51,12 +51,23 @@ class QualitySweepTests(unittest.TestCase):
                 "nerfstudio_revision": "revision",
                 "gsplat_version": "1.4.0",
             }
+            runtime = {
+                "gpu_name": "test-gpu",
+                "compute_capability": "12.0",
+                "torch_version": "2.7.1",
+                "torch_cuda_version": "12.8",
+                "container_image_ref": "image",
+                "container_image_id": "sha256:image",
+            }
             metrics = {
                 "primitive_count": 100,
                 "opacity": {"below_0_1_ratio": 0.1},
                 "scale_anisotropy_ratio": {"above_10_ratio": 0.2},
             }
             with patch(
+                "processing.quality_sweep.verify_gpu_runtime",
+                return_value=runtime,
+            ), patch(
                 "processing.quality_sweep.verify_research_environment",
                 return_value=environment,
             ), patch(
@@ -80,6 +91,7 @@ class QualitySweepTests(unittest.TestCase):
             )
             self.assertTrue(Path(result["manifest_path"]).is_file())
             self.assertEqual(result["variants"][0]["ply_metrics"], metrics)
+            self.assertEqual(result["runtime"], runtime)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Finish the local boundary for #43: one command and one GPU container invocation for the quality sweep.

## Changes

- move CUDA/compute-capability validation into `processing.quality_sweep` itself;
- record GPU name, compute capability, PyTorch/CUDA runtime, container image ref and local image ID in `quality-sweep.json`;
- keep exact Nerfstudio SHA and gsplat verification in the same process;
- remove the separate `doctor` GPU container invocation from `./task quality`;
- local quality path is now host preflight/image pull plus exactly one GPU container run containing all three training variants.

The empirical work remains unchanged:

```bash
./task quality <scene-id> 30000
```

No quality winner is claimed until the real GPU runs complete.

Related: #41, #43.