### PR TITLE
3DGS: evaluate quality sweep on one deterministic holdout

### DIFF
--- a/processing/backend_evaluation.py
+++ b/processing/backend_evaluation.py
@@ -34,6 +34,55 @@ def _stable_score(source_sha256: str, frame_sha256: str) -> str:
     return hashlib.sha256(f"{source_sha256}:{frame_sha256}".encode("ascii")).hexdigest()
 
 
+def _build_dataset_contract_from_records(
+    source_video: Path,
+    records: Sequence[Mapping],
+    *,
+    holdout_count: int,
+) -> dict:
+    if len(records) < 2:
+        raise ValueError("at least two frames are required")
+    if holdout_count < 1 or holdout_count >= len(records):
+        raise ValueError("holdout_count must be between 1 and frame_count - 1")
+
+    hashes = [str(record["sha256"]) for record in records]
+    if len(set(hashes)) != len(hashes):
+        raise ValueError("dataset contract requires unique frame SHA-256 values")
+
+    source_sha256 = sha256_file(source_video)
+    ranked = sorted(
+        records,
+        key=lambda record: (
+            _stable_score(source_sha256, str(record["sha256"])),
+            str(record["path"]),
+        ),
+    )
+    holdout_hashes = {str(record["sha256"]) for record in ranked[:holdout_count]}
+    annotated = [
+        {
+            **dict(record),
+            "split": "holdout" if str(record["sha256"]) in holdout_hashes else "train",
+        }
+        for record in records
+    ]
+
+    return {
+        "schema_version": 1,
+        "source_video": {
+            "path": source_video.name,
+            "size_bytes": source_video.stat().st_size,
+            "sha256": source_sha256,
+        },
+        "frames": annotated,
+        "train_frame_sha256": [
+            str(record["sha256"]) for record in annotated if record["split"] == "train"
+        ],
+        "holdout_frame_sha256": [
+            str(record["sha256"]) for record in annotated if record["split"] == "holdout"
+        ],
+    }
+
+
 def build_dataset_contract(
     source_video: str | Path,
     frame_dir: str | Path,
@@ -47,41 +96,138 @@ def build_dataset_contract(
         raise ValueError(f"source video does not exist: {video}")
     if not frames.is_dir():
         raise ValueError(f"frame directory does not exist: {frames}")
-
-    records = image_records(frames)
-    if len(records) < 2:
-        raise ValueError("at least two frames are required")
-    if holdout_count < 1 or holdout_count >= len(records):
-        raise ValueError("holdout_count must be between 1 and frame_count - 1")
-
-    source_sha256 = sha256_file(video)
-    ranked = sorted(
-        records,
-        key=lambda record: (
-            _stable_score(source_sha256, record["sha256"]),
-            record["path"],
-        ),
+    return _build_dataset_contract_from_records(
+        video,
+        image_records(frames),
+        holdout_count=holdout_count,
     )
-    holdout_hashes = {record["sha256"] for record in ranked[:holdout_count]}
-    annotated = [
-        {**record, "split": "holdout" if record["sha256"] in holdout_hashes else "train"}
-        for record in records
-    ]
 
+
+def build_nerfstudio_dataset_contract(
+    source_video: str | Path,
+    transforms_json: str | Path,
+    *,
+    holdout_count: int | None = None,
+) -> dict:
+    """Freeze the exact image files referenced by a Nerfstudio transforms.json.
+
+    When holdout_count is omitted, use a deterministic 90/10-style split while
+    preserving at least one train and one hold-out image.
+    """
+    video = Path(source_video).expanduser().resolve()
+    transforms = Path(transforms_json).expanduser().resolve()
+    if not video.is_file():
+        raise ValueError(f"source video does not exist: {video}")
+    if not transforms.is_file():
+        raise ValueError(f"Nerfstudio transforms.json does not exist: {transforms}")
+
+    meta = json.loads(transforms.read_text(encoding="utf-8"))
+    frames = meta.get("frames")
+    if not isinstance(frames, list) or len(frames) < 2:
+        raise ValueError("Nerfstudio transforms.json requires at least two frames")
+
+    records = []
+    for frame in frames:
+        declared = frame.get("file_path")
+        if not declared:
+            raise ValueError("Nerfstudio frame is missing file_path")
+        declared_path = Path(str(declared))
+        resolved = declared_path if declared_path.is_absolute() else transforms.parent / declared_path
+        resolved = resolved.resolve()
+        if not resolved.is_file():
+            raise ValueError(f"Nerfstudio frame does not exist: {resolved}")
+        records.append(
+            {
+                "path": declared_path.as_posix(),
+                "size_bytes": resolved.stat().st_size,
+                "sha256": sha256_file(resolved),
+            }
+        )
+
+    count = holdout_count
+    if count is None:
+        count = max(1, int(round(len(records) * 0.1)))
+        count = min(count, len(records) - 1)
+    return _build_dataset_contract_from_records(video, records, holdout_count=count)
+
+
+def write_nerfstudio_split_transforms(
+    transforms_json: str | Path,
+    dataset: Mapping,
+    output_path: str | Path,
+) -> dict:
+    """Write a generated Nerfstudio JSON with explicit train/val/test filenames.
+
+    The pinned Nerfstudio dataparser accepts explicit split filename lists. Resource
+    paths are made absolute because this generated JSON lives outside the original
+    processed-data directory; the original dataset is never modified.
+    """
+    source = Path(transforms_json).expanduser().resolve()
+    if not source.is_file():
+        raise ValueError(f"Nerfstudio transforms.json does not exist: {source}")
+    meta = json.loads(source.read_text(encoding="utf-8"))
+    frames = meta.get("frames")
+    if not isinstance(frames, list) or not frames:
+        raise ValueError("Nerfstudio transforms.json has no frames")
+
+    train_hashes = set(dataset.get("train_frame_sha256") or [])
+    holdout_hashes = set(dataset.get("holdout_frame_sha256") or [])
+    if not train_hashes or not holdout_hashes or train_hashes & holdout_hashes:
+        raise ValueError("dataset contract must contain disjoint train and hold-out hashes")
+
+    def absolute_path(value: str) -> Path:
+        candidate = Path(value)
+        return (candidate if candidate.is_absolute() else source.parent / candidate).resolve()
+
+    rewritten_frames = []
+    train_filenames: list[str] = []
+    holdout_filenames: list[str] = []
+    seen_hashes: set[str] = set()
+
+    for frame in frames:
+        rewritten = dict(frame)
+        file_path = absolute_path(str(frame["file_path"]))
+        if not file_path.is_file():
+            raise ValueError(f"Nerfstudio frame does not exist: {file_path}")
+        frame_hash = sha256_file(file_path)
+        seen_hashes.add(frame_hash)
+        rewritten["file_path"] = file_path.as_posix()
+        if frame_hash in train_hashes:
+            train_filenames.append(file_path.as_posix())
+        elif frame_hash in holdout_hashes:
+            holdout_filenames.append(file_path.as_posix())
+        else:
+            raise ValueError(
+                f"Nerfstudio frame hash is absent from dataset contract: {file_path} ({frame_hash})"
+            )
+
+        for key in ("mask_path", "depth_file_path"):
+            if frame.get(key):
+                rewritten[key] = absolute_path(str(frame[key])).as_posix()
+        rewritten_frames.append(rewritten)
+
+    expected_hashes = train_hashes | holdout_hashes
+    if seen_hashes != expected_hashes:
+        missing = sorted(expected_hashes - seen_hashes)
+        extra = sorted(seen_hashes - expected_hashes)
+        raise ValueError(f"dataset/transforms hash mismatch; missing={missing}, extra={extra}")
+
+    rewritten_meta = dict(meta)
+    rewritten_meta["frames"] = rewritten_frames
+    if meta.get("ply_file_path"):
+        rewritten_meta["ply_file_path"] = absolute_path(str(meta["ply_file_path"])).as_posix()
+    rewritten_meta["train_filenames"] = train_filenames
+    rewritten_meta["val_filenames"] = holdout_filenames
+    rewritten_meta["test_filenames"] = holdout_filenames
+
+    destination = Path(output_path).expanduser().resolve()
+    write_json(destination, rewritten_meta)
     return {
         "schema_version": 1,
-        "source_video": {
-            "path": video.name,
-            "size_bytes": video.stat().st_size,
-            "sha256": source_sha256,
-        },
-        "frames": annotated,
-        "train_frame_sha256": [
-            record["sha256"] for record in annotated if record["split"] == "train"
-        ],
-        "holdout_frame_sha256": [
-            record["sha256"] for record in annotated if record["split"] == "holdout"
-        ],
+        "dataset_id": dataset_identity(dataset),
+        "transforms_path": str(destination),
+        "train_frame_count": len(train_filenames),
+        "holdout_frame_count": len(holdout_filenames),
     }
 
 

--- a/processing/nerfstudio.py
+++ b/processing/nerfstudio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -62,6 +63,23 @@ def gaussian_splat_export_command(
     ]
 
 
+def nerfstudio_eval_command(
+    config_path: str | Path,
+    output_path: str | Path,
+    *,
+    render_output_path: str | Path | None = None,
+    executable: str = "ns-eval",
+) -> list[str]:
+    command = [
+        executable,
+        "--load-config", str(Path(config_path)),
+        "--output-path", str(Path(output_path)),
+    ]
+    if render_output_path is not None:
+        command.extend(("--render-output-path", str(Path(render_output_path))))
+    return command
+
+
 def _resolve_cli(executable: str) -> Path:
     candidate = Path(executable).expanduser()
     if candidate.is_absolute() or candidate.parent != Path("."):
@@ -114,6 +132,117 @@ def _run_recorded_command(
         return subprocess.CompletedProcess(list(command), 124, stdout, stderr)
 
 
+def _nerfstudio_input_images(data: Path) -> list[dict]:
+    if data.is_dir():
+        return image_records(data)
+    if not data.is_file() or data.suffix.lower() != ".json":
+        raise ValueError(f"Nerfstudio data must be a directory or JSON file: {data}")
+    meta = json.loads(data.read_text(encoding="utf-8"))
+    records = []
+    for frame in meta.get("frames") or []:
+        declared = frame.get("file_path")
+        if not declared:
+            raise ValueError("Nerfstudio frame is missing file_path")
+        candidate = Path(str(declared))
+        resolved = candidate if candidate.is_absolute() else data.parent / candidate
+        resolved = resolved.resolve()
+        if not resolved.is_file():
+            raise ValueError(f"Nerfstudio frame does not exist: {resolved}")
+        records.append(
+            {
+                "path": str(declared),
+                "size_bytes": resolved.stat().st_size,
+                "sha256": sha256_file(resolved),
+            }
+        )
+    if not records:
+        raise ValueError(f"Nerfstudio JSON contains no image frames: {data}")
+    return records
+
+
+def run_nerfstudio_eval(
+    config_path: str | Path,
+    output_root: str | Path,
+    *,
+    executable: str = "ns-eval",
+    timeout: float | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict:
+    """Run ns-eval, save per-holdout renders, and return auditable image metrics."""
+    config = Path(config_path).expanduser().resolve()
+    if not config.is_file():
+        raise ValueError(f"Nerfstudio config does not exist: {config}")
+    eval_cli = _resolve_cli(executable)
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    metrics_path = root / "metrics.json"
+    renders_path = root / "renders"
+    stdout_path = root / "eval.stdout.log"
+    stderr_path = root / "eval.stderr.log"
+    manifest_path = root / "eval-manifest.json"
+    command = nerfstudio_eval_command(
+        config,
+        metrics_path,
+        render_output_path=renders_path,
+        executable=str(eval_cli),
+    )
+    started_at = _utc_now()
+    completed = _run_recorded_command(
+        command,
+        cwd=root,
+        timeout=timeout,
+        env=env,
+    )
+    finished_at = _utc_now()
+    stdout_path.write_text(completed.stdout or "", encoding="utf-8")
+    stderr_path.write_text(completed.stderr or "", encoding="utf-8")
+    record = {
+        "schema_version": 1,
+        "command": command,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "return_code": completed.returncode,
+        "stdout_log": stdout_path.name,
+        "stderr_log": stderr_path.name,
+        "metrics_path": metrics_path.name,
+        "render_output_path": renders_path.name,
+        "metrics": None,
+    }
+    if completed.returncode != 0:
+        record["status"] = "failed"
+        write_json(manifest_path, record)
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            command,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    if not metrics_path.is_file():
+        record["status"] = "failed"
+        write_json(manifest_path, record)
+        raise RuntimeError("ns-eval succeeded but did not write metrics.json")
+
+    payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    results = payload.get("results")
+    if not isinstance(results, dict):
+        record["status"] = "failed"
+        write_json(manifest_path, record)
+        raise RuntimeError("ns-eval metrics.json does not contain a results object")
+    measured = {}
+    for key in ("psnr", "ssim", "lpips"):
+        value = results.get(key)
+        if value is not None:
+            if not isinstance(value, (int, float)):
+                raise RuntimeError(f"ns-eval result {key} is not numeric: {value!r}")
+            measured[key] = float(value)
+    record["status"] = "success"
+    record["metrics"] = measured
+    record["raw_results"] = results
+    write_json(manifest_path, record)
+    record["manifest_path"] = str(manifest_path)
+    return record
+
+
 def run_splatfacto_export(
     data_dir: str | Path,
     output_root: str | Path,
@@ -127,8 +256,8 @@ def run_splatfacto_export(
 ) -> dict:
     """Run external Nerfstudio Splatfacto training and export one auditable PLY."""
     data = Path(data_dir).expanduser().resolve()
-    if not data.is_dir():
-        raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    if not data.is_dir() and not (data.is_file() and data.suffix.lower() == ".json"):
+        raise ValueError(f"Nerfstudio data directory/JSON does not exist: {data}")
 
     train_cli = _resolve_cli(train_executable)
     export_cli = _resolve_cli(export_executable)
@@ -156,7 +285,7 @@ def run_splatfacto_export(
     train_stderr = run_dir / "train.stderr.log"
     export_stdout = run_dir / "export.stdout.log"
     export_stderr = run_dir / "export.stderr.log"
-    input_images = image_records(data)
+    input_images = _nerfstudio_input_images(data)
 
     manifest = {
         "schema_version": 1,

--- a/processing/quality_sweep.py
+++ b/processing/quality_sweep.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 from pathlib import Path
 
-from processing.gaussian_ply import gaussian_ply_metrics
+from processing.backend_evaluation import (
+    artifact_record,
+    build_nerfstudio_dataset_contract,
+    dataset_identity,
+    gaussian_artifact_metrics,
+    validate_backend_result,
+    write_comparison,
+    write_nerfstudio_split_transforms,
+)
 from processing.mcmc_quality import DEFAULT_NERFSTUDIO_SOURCE, verify_research_environment
-from processing.nerfstudio import run_splatfacto_export
+from processing.nerfstudio import run_nerfstudio_eval, run_splatfacto_export
 from processing.provenance import write_json
 
 
@@ -56,59 +65,144 @@ def quality_sweep_train_args(*, iterations: int, variant: str) -> tuple[str, ...
 
 def run_quality_sweep(
     data_dir: str | Path,
+    source_video: str | Path,
     output_root: str | Path,
     *,
     nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
     iterations: int = 30000,
+    holdout_count: int | None = None,
     timeout: float | None = None,
 ) -> dict:
-    """Run the three first-line Splatfacto candidates and measure their exported PLYs.
+    """Run and evaluate default, scale-regularized and MCMC Splatfacto variants.
 
-    The sweep changes one refinement choice at a time on one exact Nerfstudio/gsplat
-    environment: upstream default, PhysGaussian-derived scale regularization, and MCMC.
-    Clean-GS is intentionally excluded because it requires semantic masks and is a
-    post-processing experiment rather than a training-strategy variable.
+    One deterministic source-hash/frame-hash contract is written before training. The
+    generated transforms JSON uses Nerfstudio's explicit train/val/test filename lists,
+    so all variants train and evaluate on the same exact images without modifying the
+    prepared dataset. ns-eval records PSNR/SSIM/LPIPS and saves the hold-out renders.
     """
     data = Path(data_dir).expanduser().resolve()
     if not data.is_dir():
         raise ValueError(f"Nerfstudio data directory does not exist: {data}")
+    transforms = data / "transforms.json"
+    if not transforms.is_file():
+        raise ValueError(f"Nerfstudio transforms.json does not exist: {transforms}")
+    source = Path(source_video).expanduser().resolve()
+    if not source.is_file():
+        raise ValueError(f"source video does not exist: {source}")
+
     runtime = verify_gpu_runtime()
     environment = verify_research_environment(nerfstudio_source)
     root = Path(output_root).expanduser().resolve()
     root.mkdir(parents=True, exist_ok=True)
+
+    dataset = build_nerfstudio_dataset_contract(
+        source,
+        transforms,
+        holdout_count=holdout_count,
+    )
+    dataset_path = root / "evaluation-dataset.json"
+    write_json(dataset_path, dataset)
+    split = write_nerfstudio_split_transforms(
+        transforms,
+        dataset,
+        root / "evaluation-transforms.json",
+    )
+    split_transforms = Path(split["transforms_path"])
+    dataset_id = dataset_identity(dataset)
+
     summary_path = root / "quality-sweep.json"
+    comparison_path = root / "comparison.json"
     summary = {
-        "schema_version": 2,
+        "schema_version": 3,
         "data_dir": str(data),
+        "source_video": str(source),
+        "dataset_id": dataset_id,
+        "dataset_manifest_path": str(dataset_path),
+        "split_transforms_path": str(split_transforms),
+        "train_frame_sha256": list(dataset["train_frame_sha256"]),
+        "holdout_frame_sha256": list(dataset["holdout_frame_sha256"]),
         "runtime": runtime,
         "environment": environment,
         "iterations": iterations,
         "variants": [],
     }
+    backend_results = []
 
     for variant in ("default", "scale-regularized", "mcmc"):
+        started = time.perf_counter()
         result = run_splatfacto_export(
-            data,
+            split_transforms,
             root / variant,
             train_extra_args=quality_sweep_train_args(iterations=iterations, variant=variant),
             timeout=timeout,
             env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
         )
+        train_export_seconds = time.perf_counter() - started
         manifest_path = Path(result["manifest_path"])
-        ply_path = manifest_path.parent / result["output"]["ply_path"]
-        ply_metrics = gaussian_ply_metrics(ply_path)
+        run_dir = manifest_path.parent
+        ply_path = run_dir / result["output"]["ply_path"]
+        config_path = run_dir / result["training"]["config_path"]
+        evaluation = run_nerfstudio_eval(
+            config_path,
+            run_dir / "evaluation",
+            timeout=timeout,
+            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+        )
+
+        metrics = {
+            "reconstruction_success": True,
+            "input_frame_count": len(dataset["frames"]),
+            "train_frame_count": len(dataset["train_frame_sha256"]),
+            "holdout_frame_count": len(dataset["holdout_frame_sha256"]),
+            "psnr": evaluation["metrics"].get("psnr"),
+            "ssim": evaluation["metrics"].get("ssim"),
+            "lpips": evaluation["metrics"].get("lpips"),
+            "wall_clock_seconds": train_export_seconds,
+            "peak_gpu_memory_bytes": None,
+            "camera_pose_available": True,
+            **gaussian_artifact_metrics(ply_path),
+        }
+        backend_result = {
+            "schema_version": 1,
+            "dataset_id": dataset_id,
+            "backend": {
+                "name": f"splatfacto-{variant}",
+                "upstream_revision": environment["nerfstudio_revision"],
+            },
+            "command": list(result["training"]["command"]),
+            "config": {
+                "variant": variant,
+                "iterations": iterations,
+            },
+            "return_code": 0,
+            "status": "success",
+            "failure_phase": None,
+            "artifact": artifact_record(ply_path, format="ply"),
+            "metrics": metrics,
+            "training_manifest_path": str(manifest_path),
+            "evaluation_manifest_path": evaluation["manifest_path"],
+        }
+        validate_backend_result(backend_result, dataset)
+        result_path = root / variant / "backend-result.json"
+        write_json(result_path, backend_result)
+        backend_results.append(backend_result)
         summary["variants"].append(
             {
                 "variant": variant,
                 "manifest_path": str(manifest_path),
+                "evaluation_manifest_path": evaluation["manifest_path"],
+                "backend_result_path": str(result_path),
                 "ply_path": str(ply_path),
                 "ply_sha256": result["output"]["sha256"],
                 "ply_size_bytes": result["output"]["size_bytes"],
-                "ply_metrics": ply_metrics,
+                "metrics": metrics,
             }
         )
         write_json(summary_path, summary)
 
+    comparison = write_comparison(comparison_path, backend_results, dataset)
+    summary["comparison_path"] = str(comparison_path)
+    summary["comparison"] = comparison
     summary["manifest_path"] = str(summary_path)
     write_json(summary_path, summary)
     return summary
@@ -116,19 +210,26 @@ def run_quality_sweep(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Run default, scale-regularized and MCMC Splatfacto on one pinned GPU environment."
+        description=(
+            "Run default, scale-regularized and MCMC Splatfacto on one deterministic "
+            "train/hold-out split in the pinned GPU environment."
+        )
     )
     parser.add_argument("--data", required=True)
+    parser.add_argument("--source-video", required=True)
     parser.add_argument("--output-root", required=True)
     parser.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
     parser.add_argument("--iterations", type=int, default=30000)
+    parser.add_argument("--holdout-count", type=int)
     parser.add_argument("--timeout", type=float)
     args = parser.parse_args()
     result = run_quality_sweep(
         args.data,
+        args.source_video,
         args.output_root,
         nerfstudio_source=args.nerfstudio_source,
         iterations=args.iterations,
+        holdout_count=args.holdout_count,
         timeout=args.timeout,
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/task
+++ b/task
@@ -117,9 +117,15 @@ case "${1:-run}" in
     scene="${2:-huejotzingo}"
     iterations="${3:-30000}"
     data="$ROOT/output/$scene/nerfstudio-data"
+    source="$ROOT/input/$scene/source.webm"
     if [[ ! -f "$data/transforms.json" ]]; then
       echo "Prepared Nerfstudio dataset is missing: $data/transforms.json" >&2
       echo "Quality execution is intentionally GPU-only and will not rerun download/FFmpeg/COLMAP. Use an existing prepared dataset." >&2
+      exit 1
+    fi
+    if [[ ! -f "$source" ]]; then
+      echo "Source video required for deterministic evaluation identity is missing: $source" >&2
+      echo "Quality execution does not redownload source media; run the canonical production path that prepared this dataset." >&2
       exit 1
     fi
     check_docker
@@ -127,6 +133,7 @@ case "${1:-run}" in
     ensure_image
     run_gpu python -m processing.quality_sweep \
       --data "/workspace/output/$scene/nerfstudio-data" \
+      --source-video "/workspace/input/$scene/source.webm" \
       --output-root "/workspace/output/$scene/quality-sweep" \
       --iterations "$iterations"
     ;;

--- a/tests/test_backend_evaluation.py
+++ b/tests/test_backend_evaluation.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -5,11 +6,13 @@ from pathlib import Path
 from processing.backend_evaluation import (
     artifact_record,
     build_dataset_contract,
+    build_nerfstudio_dataset_contract,
     compare_backend_results,
     dataset_identity,
     empty_metrics,
     validate_backend_result,
     write_comparison,
+    write_nerfstudio_split_transforms,
 )
 
 
@@ -33,6 +36,45 @@ class BackendEvaluationTests(unittest.TestCase):
             self.assertEqual(len(first["holdout_frame_sha256"]), 2)
             self.assertTrue(set(first["train_frame_sha256"]).isdisjoint(first["holdout_frame_sha256"]))
             self.assertEqual(len(dataset_identity(first)), 64)
+
+    def test_nerfstudio_contract_writes_explicit_split_without_mutating_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            video = root / "source.webm"
+            video.write_bytes(b"video")
+            data = root / "nerfstudio-data"
+            images = data / "images"
+            images.mkdir(parents=True)
+            frames = []
+            for index in range(10):
+                image = images / f"frame-{index:03d}.jpg"
+                image.write_bytes(f"processed-{index}".encode())
+                frames.append(
+                    {
+                        "file_path": f"images/{image.name}",
+                        "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                    }
+                )
+            transforms = data / "transforms.json"
+            transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+
+            dataset = build_nerfstudio_dataset_contract(video, transforms, holdout_count=2)
+            result = write_nerfstudio_split_transforms(
+                transforms,
+                dataset,
+                root / "quality" / "evaluation-transforms.json",
+            )
+            split = json.loads(Path(result["transforms_path"]).read_text(encoding="utf-8"))
+            original = json.loads(transforms.read_text(encoding="utf-8"))
+
+            self.assertEqual(result["train_frame_count"], 8)
+            self.assertEqual(result["holdout_frame_count"], 2)
+            self.assertEqual(len(split["train_filenames"]), 8)
+            self.assertEqual(split["val_filenames"], split["test_filenames"])
+            self.assertEqual(len(split["val_filenames"]), 2)
+            self.assertTrue(all(Path(path).is_absolute() for path in split["train_filenames"]))
+            self.assertNotIn("train_filenames", original)
+            self.assertEqual(result["dataset_id"], dataset_identity(dataset))
 
     def test_success_requires_real_artifact_and_traceable_metrics(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_nerfstudio.py
+++ b/tests/test_nerfstudio.py
@@ -8,7 +8,9 @@ from unittest.mock import patch
 from processing.nerfstudio import (
     NerfstudioConfigurationError,
     gaussian_splat_export_command,
+    nerfstudio_eval_command,
     nerfstudio_process_images_command,
+    run_nerfstudio_eval,
     run_splatfacto_export,
     splatfacto_train_command,
 )
@@ -43,6 +45,22 @@ class NerfstudioTests(unittest.TestCase):
                 "outputs/config.yml",
                 "--output-dir",
                 "exports/splat",
+            ],
+        )
+        self.assertEqual(
+            nerfstudio_eval_command(
+                "outputs/config.yml",
+                "evaluation/metrics.json",
+                render_output_path="evaluation/renders",
+            ),
+            [
+                "ns-eval",
+                "--load-config",
+                "outputs/config.yml",
+                "--output-path",
+                "evaluation/metrics.json",
+                "--render-output-path",
+                "evaluation/renders",
             ],
         )
 
@@ -114,6 +132,83 @@ class NerfstudioTests(unittest.TestCase):
                 manifest["output"]["ply_path"],
                 "export/splat.ply",
             )
+
+    def test_splatfacto_runner_accepts_explicit_dataset_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            image = root / "image.jpg"
+            image.write_bytes(b"image")
+            dataset = root / "evaluation-transforms.json"
+            dataset.write_text(
+                json.dumps(
+                    {
+                        "frames": [
+                            {
+                                "file_path": image.as_posix(),
+                                "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch(
+                "processing.nerfstudio._resolve_cli",
+                side_effect=lambda name: Path("/fake") / name,
+            ), patch(
+                "processing.nerfstudio._package_version",
+                return_value="1.0",
+            ), patch(
+                "processing.nerfstudio.subprocess.run",
+                return_value=subprocess.CompletedProcess(["ns-train"], 2, "", "stop"),
+            ):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    run_splatfacto_export(dataset, root / "runs")
+            manifest = json.loads(next((root / "runs").rglob("manifest.json")).read_text())
+            self.assertEqual(manifest["input"]["image_count"], 1)
+            self.assertEqual(manifest["input"]["data_dir"], str(dataset.resolve()))
+
+    def test_eval_runner_records_image_metrics_and_render_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "config.yml"
+            config.write_text("config", encoding="utf-8")
+
+            def fake_run(command, **kwargs):
+                metrics = Path(command[command.index("--output-path") + 1])
+                metrics.write_text(
+                    json.dumps(
+                        {
+                            "results": {
+                                "psnr": 24.5,
+                                "ssim": 0.91,
+                                "lpips": 0.12,
+                                "psnr_std": 1.0,
+                            }
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                return subprocess.CompletedProcess(command, 0, "evaluated", "")
+
+            with patch(
+                "processing.nerfstudio._resolve_cli",
+                return_value=Path("/fake/ns-eval"),
+            ), patch(
+                "processing.nerfstudio.subprocess.run",
+                side_effect=fake_run,
+            ):
+                result = run_nerfstudio_eval(config, root / "evaluation")
+
+            self.assertEqual(
+                result["metrics"],
+                {"psnr": 24.5, "ssim": 0.91, "lpips": 0.12},
+            )
+            self.assertEqual(result["return_code"], 0)
+            self.assertEqual(result["status"], "success")
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+            self.assertEqual(result["render_output_path"], "renders")
 
     def test_splatfacto_runner_records_training_failure(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_quality_sweep.py
+++ b/tests/test_quality_sweep.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -23,28 +24,61 @@ class QualitySweepTests(unittest.TestCase):
             ("--pipeline.model.strategy", "mcmc"),
         )
 
-    def test_quality_sweep_records_three_variants_ply_metrics_and_runtime(self):
+    def test_quality_sweep_records_common_dataset_eval_and_comparison(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
+            source = root / "source.webm"
+            source.write_bytes(b"video")
             data = root / "data"
-            data.mkdir()
+            images = data / "images"
+            images.mkdir(parents=True)
+            frames = []
+            for index in range(10):
+                image = images / f"frame-{index:03d}.jpg"
+                image.write_bytes(f"image-{index}".encode())
+                frames.append(
+                    {
+                        "file_path": f"images/{image.name}",
+                        "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                    }
+                )
+            (data / "transforms.json").write_text(
+                json.dumps({"frames": frames}),
+                encoding="utf-8",
+            )
             calls = []
 
-            def fake_run(data_dir, output_root, **kwargs):
-                calls.append(kwargs["train_extra_args"])
+            def fake_run(data_path, output_root, **kwargs):
+                calls.append((Path(data_path), kwargs["train_extra_args"]))
                 run_dir = Path(output_root) / "splatfacto" / "run"
                 (run_dir / "export").mkdir(parents=True)
                 ply = run_dir / "export" / "splat.ply"
                 ply.write_bytes(b"ply")
+                config = run_dir / "config.yml"
+                config.write_text("config", encoding="utf-8")
                 manifest = run_dir / "manifest.json"
                 manifest.write_text("{}", encoding="utf-8")
                 return {
                     "manifest_path": str(manifest),
+                    "training": {
+                        "command": ["ns-train", "splatfacto"],
+                        "config_path": "config.yml",
+                    },
                     "output": {
                         "ply_path": "export/splat.ply",
                         "sha256": "a" * 64,
                         "size_bytes": 3,
                     },
+                }
+
+            def fake_eval(config_path, output_root, **kwargs):
+                eval_root = Path(output_root)
+                eval_root.mkdir(parents=True)
+                manifest = eval_root / "eval-manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "metrics": {"psnr": 25.0, "ssim": 0.9, "lpips": 0.1},
                 }
 
             environment = {
@@ -61,8 +95,11 @@ class QualitySweepTests(unittest.TestCase):
             }
             metrics = {
                 "primitive_count": 100,
-                "opacity": {"below_0_1_ratio": 0.1},
-                "scale_anisotropy_ratio": {"above_10_ratio": 0.2},
+                "output_size_bytes": 3,
+                "low_opacity_primitive_count": 10,
+                "low_opacity_primitive_ratio": 0.1,
+                "scale_anisotropy_above_10_count": 20,
+                "scale_anisotropy_above_10_ratio": 0.2,
             }
             with patch(
                 "processing.quality_sweep.verify_gpu_runtime",
@@ -74,24 +111,37 @@ class QualitySweepTests(unittest.TestCase):
                 "processing.quality_sweep.run_splatfacto_export",
                 side_effect=fake_run,
             ), patch(
-                "processing.quality_sweep.gaussian_ply_metrics",
+                "processing.quality_sweep.run_nerfstudio_eval",
+                side_effect=fake_eval,
+            ), patch(
+                "processing.quality_sweep.gaussian_artifact_metrics",
                 return_value=metrics,
             ):
                 result = run_quality_sweep(
                     data,
+                    source,
                     root / "out",
                     nerfstudio_source=root / "nerfstudio",
                     iterations=30000,
+                    holdout_count=2,
                 )
 
             self.assertEqual(len(calls), 3)
+            self.assertTrue(all(path.name == "evaluation-transforms.json" for path, _ in calls))
             self.assertEqual(
                 [entry["variant"] for entry in result["variants"]],
                 ["default", "scale-regularized", "mcmc"],
             )
+            self.assertEqual(len(result["train_frame_sha256"]), 8)
+            self.assertEqual(len(result["holdout_frame_sha256"]), 2)
+            self.assertEqual(result["variants"][0]["metrics"]["psnr"], 25.0)
+            self.assertEqual(result["variants"][0]["metrics"]["ssim"], 0.9)
+            self.assertEqual(result["variants"][0]["metrics"]["lpips"], 0.1)
+            self.assertIsNone(result["variants"][0]["metrics"]["peak_gpu_memory_bytes"])
+            self.assertEqual(len(result["comparison"]["results"]), 3)
             self.assertTrue(Path(result["manifest_path"]).is_file())
-            self.assertEqual(result["variants"][0]["ply_metrics"], metrics)
-            self.assertEqual(result["runtime"], runtime)
+            self.assertTrue(Path(result["dataset_manifest_path"]).is_file())
+            self.assertTrue(Path(result["split_transforms_path"]).is_file())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Remove the remaining repository-side comparison gap in #39/#41/#43 while keeping the local responsibility to one canonical GPU command.

`./task quality <scene-id> <iterations>` now carries the prepared scene's source identity into the existing one-container quality sweep. The sweep itself freezes one deterministic train/hold-out contract, runs all three variants on that exact split, evaluates each checkpoint with upstream `ns-eval`, saves hold-out renders, and writes the existing common comparison rows.

## Upstream basis

Pinned Nerfstudio revision remains `50e0e3c70c775e89333256213363badbf074f29d`.

At that exact revision, `NerfstudioDataParser` supports explicit `train_filenames`, `val_filenames`, and `test_filenames` in the dataset JSON. This PR uses those fields rather than inventing a separate split parser or renaming source data.

Official sources:
- https://github.com/nerfstudio-project/nerfstudio/blob/50e0e3c70c775e89333256213363badbf074f29d/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
- https://docs.nerf.studio/reference/cli/ns_eval.html
- https://github.com/nerfstudio-project/nerfstudio/blob/50e0e3c70c775e89333256213363badbf074f29d/nerfstudio/scripts/eval.py
- https://github.com/nerfstudio-project/nerfstudio/blob/50e0e3c70c775e89333256213363badbf074f29d/nerfstudio/models/splatfacto.py

## Changes

- build the #26 content-addressed dataset contract directly from the exact images referenced by `nerfstudio-data/transforms.json`;
- default to a deterministic approximately 90/10 split when an explicit holdout count is not supplied;
- write a generated transforms JSON with explicit train/val/test filename lists without modifying the prepared dataset;
- allow the existing Splatfacto runner to consume an explicit Nerfstudio JSON file;
- add an auditable `ns-eval` runner that records command/return code/logs, PSNR/SSIM/LPIPS, and `--render-output-path` output;
- make default / Scale Regularization / MCMC use the same dataset identity and hold-out hashes;
- write one validated backend result per variant and one `comparison.json` through the existing #26 comparison contract;
- record comparable train+export wall-clock seconds;
- keep `peak_gpu_memory_bytes = null` rather than fabricate a measurement not currently observed from the child training process;
- keep the local quality path at one GPU container invocation and do not re-run download/FFmpeg/COLMAP.

## Evidence boundary

This PR is repository/test evidence only. It does not claim the bad-scene or good-control GPU experiments have run. After merge, the remaining empirical action is still the canonical local command for each prepared scene.

No production strategy is promoted by this PR.

Related: #26, #39, #40, #41, #43, #48.