### PR TITLE
3DGS: verify Clean-GS checkout revision before cleanup

### DIFF
--- a/processing/clean_gs.py
+++ b/processing/clean_gs.py
@@ -58,6 +58,44 @@ def _mask_records(masks_dir: Path) -> list[dict]:
     ]
 
 
+def _git_checkout_revision(script: Path, requested_revision: str) -> dict:
+    """Resolve the script's Git checkout and require requested revision == HEAD."""
+    requested = requested_revision.strip()
+    if not requested:
+        raise ValueError("upstream_revision is required")
+
+    def git(*args: str) -> str:
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(script.parent), *args],
+                shell=False,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise ValueError(f"Clean-GS script is not in a readable Git checkout: {script}") from exc
+        return completed.stdout.strip()
+
+    checkout_root = git("rev-parse", "--show-toplevel")
+    head_revision = git("rev-parse", "HEAD")
+    try:
+        requested_commit = git("rev-parse", "--verify", f"{requested}^{{commit}}")
+    except ValueError as exc:
+        raise ValueError(f"upstream_revision cannot be resolved in Clean-GS checkout: {requested}") from exc
+    if requested_commit != head_revision:
+        raise ValueError(
+            "Clean-GS checkout HEAD does not match upstream_revision: "
+            f"requested={requested_commit}, head={head_revision}"
+        )
+    return {
+        "checkout_root": checkout_root,
+        "requested_revision": requested,
+        "resolved_revision": requested_commit,
+        "head_revision": head_revision,
+    }
+
+
 def run_clean_gs(
     *,
     script_path: str | Path,
@@ -82,8 +120,7 @@ def run_clean_gs(
     manifest_file = Path(manifest_path).expanduser().resolve()
     if not script.is_file():
         raise ValueError(f"Clean-GS script does not exist: {script}")
-    if not upstream_revision.strip():
-        raise ValueError("upstream_revision is required")
+    checkout = _git_checkout_revision(script, upstream_revision)
     if not masks.is_dir():
         raise ValueError(f"mask directory does not exist: {masks}")
     if not source.is_file():
@@ -120,7 +157,8 @@ def run_clean_gs(
         "schema_version": 1,
         "backend": "Clean-GS",
         "upstream_repository": "https://github.com/smlab-niser/clean-gs",
-        "upstream_revision": upstream_revision,
+        "upstream_revision": checkout["head_revision"],
+        "upstream_checkout": checkout,
         "scene": scene,
         "command": command,
         "started_at": started,

--- a/tests/test_clean_gs.py
+++ b/tests/test_clean_gs.py
@@ -56,7 +56,7 @@ class CleanGsTests(unittest.TestCase):
         head = "a" * 40
 
         def fake_run(command, **kwargs):
-            args = command[4:]
+            args = command[3:]
             if args == ["rev-parse", "--show-toplevel"]:
                 stdout = "/tmp/clean-gs\n"
             elif args == ["rev-parse", "HEAD"]:
@@ -80,7 +80,7 @@ class CleanGsTests(unittest.TestCase):
         head = "b" * 40
 
         def fake_run(command, **kwargs):
-            args = command[4:]
+            args = command[3:]
             if args == ["rev-parse", "--show-toplevel"]:
                 stdout = "/tmp/clean-gs\n"
             elif args == ["rev-parse", "HEAD"]:

--- a/tests/test_clean_gs.py
+++ b/tests/test_clean_gs.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 
-from processing.clean_gs import clean_gs_command, run_clean_gs
+from processing.clean_gs import _git_checkout_revision, clean_gs_command, run_clean_gs
 
 
 class CleanGsTests(unittest.TestCase):
@@ -51,6 +51,50 @@ class CleanGsTests(unittest.TestCase):
         self.assertIn("--output_ply", command)
         self.assertIn("--color_threshold", command)
 
+    def test_checkout_revision_requires_requested_commit_at_head(self):
+        script = Path("/tmp/clean-gs/clean-gs.py")
+        head = "a" * 40
+
+        def fake_run(command, **kwargs):
+            args = command[4:]
+            if args == ["rev-parse", "--show-toplevel"]:
+                stdout = "/tmp/clean-gs\n"
+            elif args == ["rev-parse", "HEAD"]:
+                stdout = f"{head}\n"
+            elif args == ["rev-parse", "--verify", "release^{commit}"]:
+                stdout = f"{head}\n"
+            else:
+                self.fail(f"unexpected git command: {command}")
+            return subprocess.CompletedProcess(command, 0, stdout, "")
+
+        with patch("processing.clean_gs.subprocess.run", side_effect=fake_run):
+            result = _git_checkout_revision(script, "release")
+
+        self.assertEqual(result["head_revision"], head)
+        self.assertEqual(result["resolved_revision"], head)
+        self.assertEqual(result["requested_revision"], "release")
+
+    def test_checkout_revision_rejects_mismatched_head(self):
+        script = Path("/tmp/clean-gs/clean-gs.py")
+        requested = "a" * 40
+        head = "b" * 40
+
+        def fake_run(command, **kwargs):
+            args = command[4:]
+            if args == ["rev-parse", "--show-toplevel"]:
+                stdout = "/tmp/clean-gs\n"
+            elif args == ["rev-parse", "HEAD"]:
+                stdout = f"{head}\n"
+            elif args == ["rev-parse", "--verify", f"{requested}^{{commit}}"]:
+                stdout = f"{requested}\n"
+            else:
+                self.fail(f"unexpected git command: {command}")
+            return subprocess.CompletedProcess(command, 0, stdout, "")
+
+        with patch("processing.clean_gs.subprocess.run", side_effect=fake_run):
+            with self.assertRaisesRegex(ValueError, "does not match"):
+                _git_checkout_revision(script, requested)
+
     def test_runner_records_masks_and_primitive_reduction(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -63,12 +107,22 @@ class CleanGsTests(unittest.TestCase):
             output = root / "output.ply"
             manifest = root / "manifest.json"
             self._write_ply(source, 3)
+            head = "d" * 40
 
             def fake_run(command, **kwargs):
                 self._write_ply(output, 2)
                 return subprocess.CompletedProcess(command, 0, "cleaned", "")
 
-            with patch("processing.clean_gs.subprocess.run", side_effect=fake_run):
+            checkout = {
+                "checkout_root": str(root),
+                "requested_revision": "deadbeef",
+                "resolved_revision": head,
+                "head_revision": head,
+            }
+            with (
+                patch("processing.clean_gs._git_checkout_revision", return_value=checkout),
+                patch("processing.clean_gs.subprocess.run", side_effect=fake_run),
+            ):
                 result = run_clean_gs(
                     script_path=script,
                     upstream_revision="deadbeef",
@@ -80,6 +134,8 @@ class CleanGsTests(unittest.TestCase):
                 )
 
             self.assertEqual(result["status"], "success")
+            self.assertEqual(result["upstream_revision"], head)
+            self.assertEqual(result["upstream_checkout"], checkout)
             self.assertEqual(result["input"]["primitive_count"], 3)
             self.assertEqual(result["output"]["primitive_count"], 2)
             self.assertEqual(result["removed_primitive_count"], 1)
@@ -95,16 +151,23 @@ class CleanGsTests(unittest.TestCase):
             masks.mkdir()
             source = root / "input.ply"
             self._write_ply(source, 1)
-            with self.assertRaisesRegex(ValueError, "semantic masks"):
-                run_clean_gs(
-                    script_path=script,
-                    upstream_revision="deadbeef",
-                    scene="temple",
-                    masks_dir=masks,
-                    input_ply=source,
-                    output_ply=root / "output.ply",
-                    manifest_path=root / "manifest.json",
-                )
+            checkout = {
+                "checkout_root": str(root),
+                "requested_revision": "deadbeef",
+                "resolved_revision": "d" * 40,
+                "head_revision": "d" * 40,
+            }
+            with patch("processing.clean_gs._git_checkout_revision", return_value=checkout):
+                with self.assertRaisesRegex(ValueError, "semantic masks"):
+                    run_clean_gs(
+                        script_path=script,
+                        upstream_revision="deadbeef",
+                        scene="temple",
+                        masks_dir=masks,
+                        input_ply=source,
+                        output_ply=root / "output.ply",
+                        manifest_path=root / "manifest.json",
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- resolve the Git repository containing the configured Clean-GS script before execution
- resolve the requested upstream revision inside that checkout and require it to equal checkout `HEAD`
- record the resolved `HEAD` and checkout metadata in the cleanup manifest instead of trusting a caller-supplied revision string
- add regression tests for matching and mismatched revisions

## Why
Issue #45 currently records `upstream_revision`, but the wrapper did not prove that the script being executed actually came from that revision. This closes that provenance gap without vendoring or reimplementing Clean-GS.

## Evidence boundary
This does not claim an actual Clean-GS run or visual-quality improvement. GPU execution, semantic masks, fixed-view comparison, and downstream validation remain unverified and stay in #45.

Refs #45