### PR TITLE
3DGS: complete auditable quality evidence before local GPU runs

### DIFF
--- a/processing/nerfstudio.py
+++ b/processing/nerfstudio.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+import threading
 import uuid
 from datetime import datetime, timezone
 from importlib import metadata
@@ -132,6 +133,162 @@ def _run_recorded_command(
         return subprocess.CompletedProcess(list(command), 124, stdout, stderr)
 
 
+def _descendant_pids(root_pid: int) -> set[int]:
+    """Return a best-effort Linux process-tree snapshot rooted at root_pid."""
+    seen = {root_pid}
+    pending = [root_pid]
+    while pending:
+        pid = pending.pop()
+        children_path = Path(f"/proc/{pid}/task/{pid}/children")
+        try:
+            children = children_path.read_text(encoding="utf-8").split()
+        except OSError:
+            continue
+        for value in children:
+            try:
+                child = int(value)
+            except ValueError:
+                continue
+            if child not in seen:
+                seen.add(child)
+                pending.append(child)
+    return seen
+
+
+def _namespace_visible_pids(pids: set[int]) -> set[int]:
+    """Include outer namespace PIDs so nvidia-smi output can match container processes."""
+    visible = set(pids)
+    for pid in list(pids):
+        status_path = Path(f"/proc/{pid}/status")
+        try:
+            lines = status_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            if not line.startswith("NSpid:"):
+                continue
+            for value in line.split(":", 1)[1].split():
+                try:
+                    visible.add(int(value))
+                except ValueError:
+                    pass
+            break
+    return visible
+
+
+def _query_process_gpu_memory_bytes(root_pid: int, nvidia_smi: str) -> int | None:
+    """Measure framebuffer memory for the process tree when NVIDIA exposes it.
+
+    NVIDIA documents --query-compute-apps as the selective query for active compute
+    processes. Memory can be unavailable under some driver models, in which case this
+    function returns None rather than inventing a value.
+    """
+    visible_pids = _namespace_visible_pids(_descendant_pids(root_pid))
+    try:
+        result = subprocess.run(
+            [
+                nvidia_smi,
+                "--query-compute-apps=pid,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            shell=False,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+
+    total_mib = 0.0
+    found = False
+    for line in (result.stdout or "").splitlines():
+        fields = [field.strip() for field in line.split(",", 1)]
+        if len(fields) != 2:
+            continue
+        try:
+            pid = int(fields[0])
+        except ValueError:
+            continue
+        if pid not in visible_pids or fields[1].upper() in {"N/A", "[N/A]"}:
+            continue
+        try:
+            total_mib += float(fields[1])
+        except ValueError:
+            continue
+        found = True
+    if not found:
+        return None
+    return int(total_mib * 1024 * 1024)
+
+
+def _run_recorded_command_with_peak_gpu_memory(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: float | None,
+    env: Mapping[str, str] | None,
+    poll_seconds: float = 0.2,
+) -> tuple[subprocess.CompletedProcess[str], int | None]:
+    """Run a command and best-effort sample peak process-tree GPU memory.
+
+    If nvidia-smi is unavailable, preserve the normal subprocess.run path and return
+    an unmeasured peak (None). This keeps CPU-only CI deterministic.
+    """
+    nvidia_smi = shutil.which("nvidia-smi")
+    if nvidia_smi is None:
+        return (
+            _run_recorded_command(command, cwd=cwd, timeout=timeout, env=env),
+            None,
+        )
+
+    argv = list(map(str, command))
+    run_env = None if env is None else {**os.environ, **env}
+    process = subprocess.Popen(
+        argv,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        env=run_env,
+    )
+    stop = threading.Event()
+    peak_gpu_memory_bytes: int | None = None
+
+    def monitor() -> None:
+        nonlocal peak_gpu_memory_bytes
+        while not stop.is_set():
+            measured = _query_process_gpu_memory_bytes(process.pid, nvidia_smi)
+            if measured is not None:
+                peak_gpu_memory_bytes = max(peak_gpu_memory_bytes or 0, measured)
+            if stop.wait(poll_seconds):
+                break
+
+    thread = threading.Thread(target=monitor, name="gpu-memory-monitor", daemon=True)
+    thread.start()
+    timed_out = False
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        process.kill()
+        stdout, stderr = process.communicate()
+    finally:
+        stop.set()
+        thread.join(timeout=max(1.0, poll_seconds * 4))
+
+    return_code = 124 if timed_out else process.returncode
+    if timed_out:
+        stderr = (stderr or "") + f"\nTimed out after {timeout} seconds."
+    return (
+        subprocess.CompletedProcess(argv, return_code, stdout or "", stderr or ""),
+        peak_gpu_memory_bytes,
+    )
+
+
 def _nerfstudio_input_images(data: Path) -> list[dict]:
     if data.is_dir():
         return image_records(data)
@@ -197,7 +354,7 @@ def run_nerfstudio_eval(
     stdout_path.write_text(completed.stdout or "", encoding="utf-8")
     stderr_path.write_text(completed.stderr or "", encoding="utf-8")
     record = {
-        "schema_version": 1,
+        "schema_version": 2,
         "command": command,
         "started_at": started_at,
         "finished_at": finished_at,
@@ -207,6 +364,7 @@ def run_nerfstudio_eval(
         "metrics_path": metrics_path.name,
         "render_output_path": renders_path.name,
         "metrics": None,
+        "renders": None,
     }
     if completed.returncode != 0:
         record["status"] = "failed"
@@ -235,9 +393,20 @@ def run_nerfstudio_eval(
             if not isinstance(value, (int, float)):
                 raise RuntimeError(f"ns-eval result {key} is not numeric: {value!r}")
             measured[key] = float(value)
+
+    renders = image_records(renders_path) if renders_path.is_dir() else []
+    if not renders:
+        record["status"] = "failed"
+        record["metrics"] = measured
+        record["raw_results"] = results
+        write_json(manifest_path, record)
+        raise RuntimeError("ns-eval succeeded but did not create any hold-out render images")
+
     record["status"] = "success"
     record["metrics"] = measured
     record["raw_results"] = results
+    record["renders"] = renders
+    record["render_count"] = len(renders)
     write_json(manifest_path, record)
     record["manifest_path"] = str(manifest_path)
     return record
@@ -273,8 +442,7 @@ def run_splatfacto_export(
             if version is None
         ]
         raise NerfstudioConfigurationError(
-            "Installed package version could not be resolved for: "
-            + ", ".join(missing)
+            "Installed package version could not be resolved for: " + ", ".join(missing)
         )
 
     run_id = f"{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}-{uuid.uuid4().hex[:8]}"
@@ -288,7 +456,7 @@ def run_splatfacto_export(
     input_images = _nerfstudio_input_images(data)
 
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "run_id": run_id,
         "status": "running",
         "input": {
@@ -311,7 +479,7 @@ def run_splatfacto_export(
         extra_args=train_extra_args,
     )
     train_started = _utc_now()
-    train_result = _run_recorded_command(
+    train_result, peak_gpu_memory_bytes = _run_recorded_command_with_peak_gpu_memory(
         train_command,
         cwd=run_dir,
         timeout=timeout,
@@ -329,6 +497,12 @@ def run_splatfacto_export(
         "stderr_log": train_stderr.name,
         "config_path": None,
         "checkpoint_path": None,
+        "peak_gpu_memory_bytes": peak_gpu_memory_bytes,
+        "gpu_memory_measurement": (
+            "nvidia-smi --query-compute-apps process-tree sampling"
+            if peak_gpu_memory_bytes is not None
+            else None
+        ),
     }
     if train_result.returncode != 0:
         manifest["status"] = "failed"
@@ -345,13 +519,9 @@ def run_splatfacto_export(
     if len(configs) != 1:
         manifest["status"] = "failed"
         manifest["failed_phase"] = "config_discovery"
-        manifest["config_candidates"] = [
-            str(path.relative_to(run_dir)) for path in configs
-        ]
+        manifest["config_candidates"] = [str(path.relative_to(run_dir)) for path in configs]
         write_json(manifest_path, manifest)
-        raise RuntimeError(
-            f"Expected exactly one Nerfstudio config, found {len(configs)}"
-        )
+        raise RuntimeError(f"Expected exactly one Nerfstudio config, found {len(configs)}")
     config_path = configs[0]
 
     checkpoints = sorted(
@@ -362,14 +532,10 @@ def run_splatfacto_export(
         manifest["status"] = "failed"
         manifest["failed_phase"] = "checkpoint_discovery"
         write_json(manifest_path, manifest)
-        raise RuntimeError(
-            "Nerfstudio training succeeded but no checkpoint was found"
-        )
+        raise RuntimeError("Nerfstudio training succeeded but no checkpoint was found")
     checkpoint_path = checkpoints[-1]
     manifest["training"]["config_path"] = str(config_path.relative_to(run_dir))
-    manifest["training"]["checkpoint_path"] = str(
-        checkpoint_path.relative_to(run_dir)
-    )
+    manifest["training"]["checkpoint_path"] = str(checkpoint_path.relative_to(run_dir))
 
     export_dir = run_dir / "export"
     export_dir.mkdir()
@@ -412,13 +578,9 @@ def run_splatfacto_export(
     if len(ply_files) != 1:
         manifest["status"] = "failed"
         manifest["failed_phase"] = "ply_discovery"
-        manifest["ply_candidates"] = [
-            str(path.relative_to(run_dir)) for path in ply_files
-        ]
+        manifest["ply_candidates"] = [str(path.relative_to(run_dir)) for path in ply_files]
         write_json(manifest_path, manifest)
-        raise RuntimeError(
-            f"Expected exactly one exported PLY, found {len(ply_files)}"
-        )
+        raise RuntimeError(f"Expected exactly one exported PLY, found {len(ply_files)}")
 
     ply_path = ply_files[0]
     manifest["status"] = "success"

--- a/processing/quality_sweep.py
+++ b/processing/quality_sweep.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
+from typing import Mapping
 
 from processing.backend_evaluation import (
     artifact_record,
     build_nerfstudio_dataset_contract,
     dataset_identity,
+    empty_metrics,
     gaussian_artifact_metrics,
     validate_backend_result,
     write_comparison,
@@ -63,6 +66,68 @@ def quality_sweep_train_args(*, iterations: int, variant: str) -> tuple[str, ...
     return tuple(args)
 
 
+def _read_json(path: Path | None) -> dict | None:
+    if path is None or not path.is_file():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _latest_training_manifest(variant_root: Path) -> Path | None:
+    candidates = list(variant_root.rglob("manifest.json"))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: (path.stat().st_mtime_ns, path.as_posix()))
+
+
+def _base_metrics(dataset: Mapping) -> dict:
+    metrics = empty_metrics()
+    metrics.update(
+        input_frame_count=len(dataset["frames"]),
+        train_frame_count=len(dataset["train_frame_sha256"]),
+        holdout_frame_count=len(dataset["holdout_frame_sha256"]),
+        camera_pose_available=True,
+    )
+    return metrics
+
+
+def _failed_command_and_code(
+    exc: Exception,
+    manifest: Mapping | None,
+    phase: str,
+) -> tuple[list[str], int]:
+    if isinstance(exc, subprocess.CalledProcessError):
+        command = list(map(str, exc.cmd)) if isinstance(exc.cmd, (list, tuple)) else [str(exc.cmd)]
+        return command or ["quality-sweep"], int(exc.returncode)
+
+    if manifest:
+        phase_record = manifest.get("export") if phase == "export" else manifest.get("training")
+        if isinstance(phase_record, Mapping):
+            command = phase_record.get("command")
+            return_code = phase_record.get("return_code")
+            if isinstance(command, list) and command:
+                return list(map(str, command)), int(return_code) if isinstance(return_code, int) else 0
+    return ["quality-sweep", phase], 0
+
+
+def _best_effort_artifact(result: Mapping | None, manifest_path: Path | None) -> tuple[Path | None, dict | None]:
+    if not result or manifest_path is None:
+        return None, None
+    output = result.get("output")
+    if not isinstance(output, Mapping) or not output.get("ply_path"):
+        return None, None
+    ply_path = manifest_path.parent / str(output["ply_path"])
+    if not ply_path.is_file():
+        return None, None
+    try:
+        return ply_path, artifact_record(ply_path, format="ply")
+    except Exception:
+        return ply_path, None
+
+
 def run_quality_sweep(
     data_dir: str | Path,
     source_video: str | Path,
@@ -78,7 +143,9 @@ def run_quality_sweep(
     One deterministic source-hash/frame-hash contract is written before training. The
     generated transforms JSON uses Nerfstudio's explicit train/val/test filename lists,
     so all variants train and evaluate on the same exact images without modifying the
-    prepared dataset. ns-eval records PSNR/SSIM/LPIPS and saves the hold-out renders.
+    prepared dataset. Each variant is attempted independently; one failure does not
+    erase or prevent evidence from the remaining variants. The overall command still
+    fails after all attempts if any variant failed.
     """
     data = Path(data_dir).expanduser().resolve()
     if not data.is_dir():
@@ -113,7 +180,8 @@ def run_quality_sweep(
     summary_path = root / "quality-sweep.json"
     comparison_path = root / "comparison.json"
     summary = {
-        "schema_version": 3,
+        "schema_version": 4,
+        "status": "running",
         "data_dir": str(data),
         "source_video": str(source),
         "dataset_id": dataset_id,
@@ -126,85 +194,178 @@ def run_quality_sweep(
         "iterations": iterations,
         "variants": [],
     }
-    backend_results = []
+    backend_results: list[dict] = []
+    failed_variants: list[str] = []
 
     for variant in ("default", "scale-regularized", "mcmc"):
+        variant_root = root / variant
         started = time.perf_counter()
-        result = run_splatfacto_export(
-            split_transforms,
-            root / variant,
-            train_extra_args=quality_sweep_train_args(iterations=iterations, variant=variant),
-            timeout=timeout,
-            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
-        )
-        train_export_seconds = time.perf_counter() - started
-        manifest_path = Path(result["manifest_path"])
-        run_dir = manifest_path.parent
-        ply_path = run_dir / result["output"]["ply_path"]
-        config_path = run_dir / result["training"]["config_path"]
-        evaluation = run_nerfstudio_eval(
-            config_path,
-            run_dir / "evaluation",
-            timeout=timeout,
-            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
-        )
+        result: dict | None = None
+        manifest_path: Path | None = None
+        evaluation: dict | None = None
+        phase = "training"
 
-        metrics = {
-            "reconstruction_success": True,
-            "input_frame_count": len(dataset["frames"]),
-            "train_frame_count": len(dataset["train_frame_sha256"]),
-            "holdout_frame_count": len(dataset["holdout_frame_sha256"]),
-            "psnr": evaluation["metrics"].get("psnr"),
-            "ssim": evaluation["metrics"].get("ssim"),
-            "lpips": evaluation["metrics"].get("lpips"),
-            "wall_clock_seconds": train_export_seconds,
-            "peak_gpu_memory_bytes": None,
-            "camera_pose_available": True,
-            **gaussian_artifact_metrics(ply_path),
-        }
-        backend_result = {
-            "schema_version": 1,
-            "dataset_id": dataset_id,
-            "backend": {
-                "name": f"splatfacto-{variant}",
-                "upstream_revision": environment["nerfstudio_revision"],
-            },
-            "command": list(result["training"]["command"]),
-            "config": {
-                "variant": variant,
-                "iterations": iterations,
-            },
-            "return_code": 0,
-            "status": "success",
-            "failure_phase": None,
-            "artifact": artifact_record(ply_path, format="ply"),
-            "metrics": metrics,
-            "training_manifest_path": str(manifest_path),
-            "evaluation_manifest_path": evaluation["manifest_path"],
-        }
-        validate_backend_result(backend_result, dataset)
-        result_path = root / variant / "backend-result.json"
-        write_json(result_path, backend_result)
-        backend_results.append(backend_result)
-        summary["variants"].append(
-            {
-                "variant": variant,
-                "manifest_path": str(manifest_path),
-                "evaluation_manifest_path": evaluation["manifest_path"],
-                "backend_result_path": str(result_path),
-                "ply_path": str(ply_path),
-                "ply_sha256": result["output"]["sha256"],
-                "ply_size_bytes": result["output"]["size_bytes"],
+        try:
+            result = run_splatfacto_export(
+                split_transforms,
+                variant_root,
+                train_extra_args=quality_sweep_train_args(iterations=iterations, variant=variant),
+                timeout=timeout,
+                env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+            )
+            train_export_seconds = time.perf_counter() - started
+            manifest_path = Path(result["manifest_path"])
+            run_dir = manifest_path.parent
+            ply_path = run_dir / result["output"]["ply_path"]
+            config_path = run_dir / result["training"]["config_path"]
+
+            phase = "evaluation"
+            evaluation = run_nerfstudio_eval(
+                config_path,
+                run_dir / "evaluation",
+                timeout=timeout,
+                env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+            )
+
+            phase = "artifact-metrics"
+            metrics = _base_metrics(dataset)
+            metrics.update(
+                reconstruction_success=True,
+                psnr=evaluation["metrics"].get("psnr"),
+                ssim=evaluation["metrics"].get("ssim"),
+                lpips=evaluation["metrics"].get("lpips"),
+                wall_clock_seconds=train_export_seconds,
+                peak_gpu_memory_bytes=(result.get("training") or {}).get("peak_gpu_memory_bytes"),
+                **gaussian_artifact_metrics(ply_path),
+            )
+            backend_result = {
+                "schema_version": 2,
+                "dataset_id": dataset_id,
+                "backend": {
+                    "name": f"splatfacto-{variant}",
+                    "upstream_revision": environment["nerfstudio_revision"],
+                },
+                "command": list(result["training"]["command"]),
+                "config": {"variant": variant, "iterations": iterations},
+                "return_code": 0,
+                "status": "success",
+                "failure_phase": None,
+                "artifact": artifact_record(ply_path, format="ply"),
                 "metrics": metrics,
+                "training_manifest_path": str(manifest_path),
+                "evaluation_manifest_path": evaluation["manifest_path"],
             }
-        )
+            validate_backend_result(backend_result, dataset)
+            result_path = variant_root / "backend-result.json"
+            write_json(result_path, backend_result)
+            backend_results.append(backend_result)
+            summary["variants"].append(
+                {
+                    "variant": variant,
+                    "status": "success",
+                    "manifest_path": str(manifest_path),
+                    "evaluation_manifest_path": evaluation["manifest_path"],
+                    "backend_result_path": str(result_path),
+                    "ply_path": str(ply_path),
+                    "ply_sha256": result["output"]["sha256"],
+                    "ply_size_bytes": result["output"]["size_bytes"],
+                    "metrics": metrics,
+                    "render_count": evaluation.get("render_count"),
+                    "renders": evaluation.get("renders"),
+                }
+            )
+        except Exception as exc:
+            elapsed = time.perf_counter() - started
+            failed_variants.append(variant)
+            if manifest_path is None:
+                manifest_path = _latest_training_manifest(variant_root)
+            training_manifest = _read_json(manifest_path)
+            failure_phase = phase
+            if training_manifest and training_manifest.get("status") == "failed":
+                failure_phase = str(training_manifest.get("failed_phase") or failure_phase)
+
+            evaluation_manifest_path = None
+            evaluation_manifest = None
+            if manifest_path is not None:
+                candidate = manifest_path.parent / "evaluation" / "eval-manifest.json"
+                if candidate.is_file():
+                    evaluation_manifest_path = candidate
+                    evaluation_manifest = _read_json(candidate)
+            if failure_phase == "evaluation" and evaluation_manifest:
+                command_record = evaluation_manifest
+                command = list(map(str, command_record.get("command") or ["ns-eval"]))
+                return_code = int(command_record.get("return_code") or 0)
+            else:
+                command, return_code = _failed_command_and_code(exc, training_manifest, failure_phase)
+
+            metrics = _base_metrics(dataset)
+            training = (training_manifest or {}).get("training") or {}
+            metrics.update(
+                reconstruction_success=result is not None,
+                wall_clock_seconds=elapsed,
+                peak_gpu_memory_bytes=(training.get("peak_gpu_memory_bytes") if isinstance(training, Mapping) else None),
+            )
+            ply_path, artifact = _best_effort_artifact(result, manifest_path)
+            if ply_path is not None:
+                try:
+                    metrics.update(gaussian_artifact_metrics(ply_path))
+                except Exception:
+                    pass
+
+            backend_result = {
+                "schema_version": 2,
+                "dataset_id": dataset_id,
+                "backend": {
+                    "name": f"splatfacto-{variant}",
+                    "upstream_revision": environment["nerfstudio_revision"],
+                },
+                "command": command,
+                "config": {"variant": variant, "iterations": iterations},
+                "return_code": return_code,
+                "status": "failed",
+                "failure_phase": failure_phase,
+                "artifact": artifact,
+                "metrics": metrics,
+                "training_manifest_path": str(manifest_path) if manifest_path else None,
+                "evaluation_manifest_path": (
+                    str(evaluation_manifest_path) if evaluation_manifest_path else None
+                ),
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+            validate_backend_result(backend_result, dataset)
+            result_path = variant_root / "backend-result.json"
+            write_json(result_path, backend_result)
+            backend_results.append(backend_result)
+            summary["variants"].append(
+                {
+                    "variant": variant,
+                    "status": "failed",
+                    "failure_phase": failure_phase,
+                    "error": backend_result["error"],
+                    "manifest_path": str(manifest_path) if manifest_path else None,
+                    "evaluation_manifest_path": (
+                        str(evaluation_manifest_path) if evaluation_manifest_path else None
+                    ),
+                    "backend_result_path": str(result_path),
+                    "ply_path": str(ply_path) if ply_path else None,
+                    "metrics": metrics,
+                }
+            )
+
         write_json(summary_path, summary)
 
     comparison = write_comparison(comparison_path, backend_results, dataset)
     summary["comparison_path"] = str(comparison_path)
     summary["comparison"] = comparison
+    summary["failed_variants"] = failed_variants
+    summary["status"] = "failed" if failed_variants else "success"
     summary["manifest_path"] = str(summary_path)
     write_json(summary_path, summary)
+
+    if failed_variants:
+        raise RuntimeError(
+            "quality sweep attempted all variants but failed: " + ", ".join(failed_variants)
+        )
     return summary
 
 

--- a/tests/test_nerfstudio.py
+++ b/tests/test_nerfstudio.py
@@ -78,23 +78,13 @@ class NerfstudioTests(unittest.TestCase):
                     model = cwd / "outputs" / "example"
                     (model / "nerfstudio_models").mkdir(parents=True)
                     (model / "config.yml").write_text("method: splatfacto\n")
-                    (
-                        model
-                        / "nerfstudio_models"
-                        / "step-000001.ckpt"
-                    ).write_bytes(b"checkpoint")
-                    return subprocess.CompletedProcess(
-                        command, 0, "trained\n", ""
-                    )
+                    (model / "nerfstudio_models" / "step-000001.ckpt").write_bytes(b"checkpoint")
+                    return subprocess.CompletedProcess(command, 0, "trained\n", "")
                 if command[1] == "gaussian-splat":
-                    output_dir = Path(
-                        command[command.index("--output-dir") + 1]
-                    )
+                    output_dir = Path(command[command.index("--output-dir") + 1])
                     output_dir.mkdir(parents=True, exist_ok=True)
                     (output_dir / "splat.ply").write_bytes(b"ply data")
-                    return subprocess.CompletedProcess(
-                        command, 0, "exported\n", ""
-                    )
+                    return subprocess.CompletedProcess(command, 0, "exported\n", "")
                 raise AssertionError(command)
 
             with patch(
@@ -102,36 +92,26 @@ class NerfstudioTests(unittest.TestCase):
                 side_effect=lambda name: Path("/fake") / name,
             ), patch(
                 "processing.nerfstudio._package_version",
-                side_effect=lambda name: {
-                    "nerfstudio": "1.2.3",
-                    "gsplat": "1.5.0",
-                }[name],
+                side_effect=lambda name: {"nerfstudio": "1.2.3", "gsplat": "1.5.0"}[name],
             ), patch(
                 "processing.nerfstudio.subprocess.run",
                 side_effect=fake_run,
+            ), patch(
+                "processing.nerfstudio.shutil.which",
+                return_value=None,
             ):
-                result = run_splatfacto_export(
-                    data.parent,
-                    root / "runs",
-                )
+                result = run_splatfacto_export(data.parent, root / "runs")
 
             self.assertEqual(result["status"], "success")
             self.assertEqual(result["input"]["image_count"], 2)
-            self.assertEqual(
-                result["versions"],
-                {"nerfstudio": "1.2.3", "gsplat": "1.5.0"},
-            )
+            self.assertEqual(result["versions"], {"nerfstudio": "1.2.3", "gsplat": "1.5.0"})
             self.assertEqual(result["training"]["return_code"], 0)
+            self.assertIsNone(result["training"]["peak_gpu_memory_bytes"])
             self.assertEqual(result["export"]["return_code"], 0)
             self.assertEqual(result["output"]["size_bytes"], 8)
             self.assertEqual(len(result["output"]["sha256"]), 64)
-            manifest = json.loads(
-                Path(result["manifest_path"]).read_text()
-            )
-            self.assertEqual(
-                manifest["output"]["ply_path"],
-                "export/splat.ply",
-            )
+            manifest = json.loads(Path(result["manifest_path"]).read_text())
+            self.assertEqual(manifest["output"]["ply_path"], "export/splat.ply")
 
     def test_splatfacto_runner_accepts_explicit_dataset_json(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -162,6 +142,9 @@ class NerfstudioTests(unittest.TestCase):
             ), patch(
                 "processing.nerfstudio.subprocess.run",
                 return_value=subprocess.CompletedProcess(["ns-train"], 2, "", "stop"),
+            ), patch(
+                "processing.nerfstudio.shutil.which",
+                return_value=None,
             ):
                 with self.assertRaises(subprocess.CalledProcessError):
                     run_splatfacto_export(dataset, root / "runs")
@@ -169,7 +152,7 @@ class NerfstudioTests(unittest.TestCase):
             self.assertEqual(manifest["input"]["image_count"], 1)
             self.assertEqual(manifest["input"]["data_dir"], str(dataset.resolve()))
 
-    def test_eval_runner_records_image_metrics_and_render_path(self):
+    def test_eval_runner_records_image_metrics_and_render_hashes(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             config = root / "config.yml"
@@ -190,6 +173,9 @@ class NerfstudioTests(unittest.TestCase):
                     ),
                     encoding="utf-8",
                 )
+                renders = Path(command[command.index("--render-output-path") + 1])
+                renders.mkdir(parents=True, exist_ok=True)
+                (renders / "00000.png").write_bytes(b"render")
                 return subprocess.CompletedProcess(command, 0, "evaluated", "")
 
             with patch(
@@ -201,14 +187,35 @@ class NerfstudioTests(unittest.TestCase):
             ):
                 result = run_nerfstudio_eval(config, root / "evaluation")
 
-            self.assertEqual(
-                result["metrics"],
-                {"psnr": 24.5, "ssim": 0.91, "lpips": 0.12},
-            )
+            self.assertEqual(result["metrics"], {"psnr": 24.5, "ssim": 0.91, "lpips": 0.12})
             self.assertEqual(result["return_code"], 0)
             self.assertEqual(result["status"], "success")
+            self.assertEqual(result["render_count"], 1)
+            self.assertEqual(result["renders"][0]["path"], "00000.png")
+            self.assertEqual(len(result["renders"][0]["sha256"]), 64)
             self.assertTrue(Path(result["manifest_path"]).is_file())
             self.assertEqual(result["render_output_path"], "renders")
+
+    def test_eval_runner_rejects_missing_render_evidence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = root / "config.yml"
+            config.write_text("config", encoding="utf-8")
+
+            def fake_run(command, **kwargs):
+                metrics = Path(command[command.index("--output-path") + 1])
+                metrics.write_text(json.dumps({"results": {"psnr": 1.0}}), encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0, "evaluated", "")
+
+            with patch(
+                "processing.nerfstudio._resolve_cli",
+                return_value=Path("/fake/ns-eval"),
+            ), patch(
+                "processing.nerfstudio.subprocess.run",
+                side_effect=fake_run,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "hold-out render"):
+                    run_nerfstudio_eval(config, root / "evaluation")
 
     def test_splatfacto_runner_records_training_failure(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -225,18 +232,13 @@ class NerfstudioTests(unittest.TestCase):
                 side_effect=lambda name: "1.0",
             ), patch(
                 "processing.nerfstudio.subprocess.run",
-                return_value=subprocess.CompletedProcess(
-                    ["ns-train"],
-                    2,
-                    "",
-                    "training failed",
-                ),
+                return_value=subprocess.CompletedProcess(["ns-train"], 2, "", "training failed"),
+            ), patch(
+                "processing.nerfstudio.shutil.which",
+                return_value=None,
             ):
                 with self.assertRaises(subprocess.CalledProcessError):
-                    run_splatfacto_export(
-                        data,
-                        root / "runs",
-                    )
+                    run_splatfacto_export(data, root / "runs")
 
             manifests = list((root / "runs").rglob("manifest.json"))
             self.assertEqual(len(manifests), 1)
@@ -250,18 +252,9 @@ class NerfstudioTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             data = Path(tmp) / "data"
             data.mkdir()
-            with patch(
-                "processing.nerfstudio.shutil.which",
-                return_value=None,
-            ):
-                with self.assertRaisesRegex(
-                    NerfstudioConfigurationError,
-                    "ns-train",
-                ):
-                    run_splatfacto_export(
-                        data,
-                        Path(tmp) / "runs",
-                    )
+            with patch("processing.nerfstudio.shutil.which", return_value=None):
+                with self.assertRaisesRegex(NerfstudioConfigurationError, "ns-train"):
+                    run_splatfacto_export(data, Path(tmp) / "runs")
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_sweep.py
+++ b/tests/test_quality_sweep.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -8,6 +9,33 @@ from processing.quality_sweep import quality_sweep_train_args, run_quality_sweep
 
 
 class QualitySweepTests(unittest.TestCase):
+    def _dataset(self, root: Path) -> tuple[Path, Path]:
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(10):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                    ],
+                }
+            )
+        (data / "transforms.json").write_text(
+            json.dumps({"frames": frames}),
+            encoding="utf-8",
+        )
+        return data, source
+
     def test_variants_change_only_expected_training_argument(self):
         baseline = quality_sweep_train_args(iterations=30000, variant="default")
         scale = quality_sweep_train_args(iterations=30000, variant="scale-regularized")
@@ -27,25 +55,7 @@ class QualitySweepTests(unittest.TestCase):
     def test_quality_sweep_records_common_dataset_eval_and_comparison(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            source = root / "source.webm"
-            source.write_bytes(b"video")
-            data = root / "data"
-            images = data / "images"
-            images.mkdir(parents=True)
-            frames = []
-            for index in range(10):
-                image = images / f"frame-{index:03d}.jpg"
-                image.write_bytes(f"image-{index}".encode())
-                frames.append(
-                    {
-                        "file_path": f"images/{image.name}",
-                        "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
-                    }
-                )
-            (data / "transforms.json").write_text(
-                json.dumps({"frames": frames}),
-                encoding="utf-8",
-            )
+            data, source = self._dataset(root)
             calls = []
 
             def fake_run(data_path, output_root, **kwargs):
@@ -63,6 +73,7 @@ class QualitySweepTests(unittest.TestCase):
                     "training": {
                         "command": ["ns-train", "splatfacto"],
                         "config_path": "config.yml",
+                        "peak_gpu_memory_bytes": 123456,
                     },
                     "output": {
                         "ply_path": "export/splat.ply",
@@ -79,12 +90,11 @@ class QualitySweepTests(unittest.TestCase):
                 return {
                     "manifest_path": str(manifest),
                     "metrics": {"psnr": 25.0, "ssim": 0.9, "lpips": 0.1},
+                    "render_count": 2,
+                    "renders": [{"path": "0.png", "sha256": "b" * 64, "size_bytes": 1}],
                 }
 
-            environment = {
-                "nerfstudio_revision": "revision",
-                "gsplat_version": "1.4.0",
-            }
+            environment = {"nerfstudio_revision": "revision", "gsplat_version": "1.4.0"}
             runtime = {
                 "gpu_name": "test-gpu",
                 "compute_capability": "12.0",
@@ -132,16 +142,139 @@ class QualitySweepTests(unittest.TestCase):
                 [entry["variant"] for entry in result["variants"]],
                 ["default", "scale-regularized", "mcmc"],
             )
+            self.assertEqual(result["status"], "success")
             self.assertEqual(len(result["train_frame_sha256"]), 8)
             self.assertEqual(len(result["holdout_frame_sha256"]), 2)
             self.assertEqual(result["variants"][0]["metrics"]["psnr"], 25.0)
             self.assertEqual(result["variants"][0]["metrics"]["ssim"], 0.9)
             self.assertEqual(result["variants"][0]["metrics"]["lpips"], 0.1)
-            self.assertIsNone(result["variants"][0]["metrics"]["peak_gpu_memory_bytes"])
+            self.assertEqual(result["variants"][0]["metrics"]["peak_gpu_memory_bytes"], 123456)
+            self.assertEqual(result["variants"][0]["render_count"], 2)
             self.assertEqual(len(result["comparison"]["results"]), 3)
             self.assertTrue(Path(result["manifest_path"]).is_file())
             self.assertTrue(Path(result["dataset_manifest_path"]).is_file())
             self.assertTrue(Path(result["split_transforms_path"]).is_file())
+
+    def test_quality_sweep_attempts_remaining_variants_and_preserves_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data, source = self._dataset(root)
+            calls = []
+
+            def fake_run(data_path, output_root, **kwargs):
+                args = tuple(kwargs["train_extra_args"])
+                calls.append(args)
+                variant_root = Path(output_root)
+                if "--pipeline.model.use-scale-regularization" in args:
+                    run_dir = variant_root / "splatfacto" / "failed"
+                    run_dir.mkdir(parents=True)
+                    (run_dir / "manifest.json").write_text(
+                        json.dumps(
+                            {
+                                "status": "failed",
+                                "failed_phase": "training",
+                                "training": {
+                                    "command": ["ns-train", "splatfacto", "--scale"],
+                                    "return_code": 7,
+                                    "peak_gpu_memory_bytes": 987654,
+                                },
+                            }
+                        ),
+                        encoding="utf-8",
+                    )
+                    raise subprocess.CalledProcessError(7, ["ns-train", "splatfacto", "--scale"])
+
+                run_dir = variant_root / "splatfacto" / "run"
+                (run_dir / "export").mkdir(parents=True)
+                (run_dir / "export" / "splat.ply").write_bytes(b"ply")
+                (run_dir / "config.yml").write_text("config", encoding="utf-8")
+                manifest = run_dir / "manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "training": {
+                        "command": ["ns-train", "splatfacto"],
+                        "config_path": "config.yml",
+                        "peak_gpu_memory_bytes": 123,
+                    },
+                    "output": {
+                        "ply_path": "export/splat.ply",
+                        "sha256": "a" * 64,
+                        "size_bytes": 3,
+                    },
+                }
+
+            def fake_eval(config_path, output_root, **kwargs):
+                eval_root = Path(output_root)
+                eval_root.mkdir(parents=True)
+                manifest = eval_root / "eval-manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "metrics": {"psnr": 25.0, "ssim": 0.9, "lpips": 0.1},
+                    "render_count": 1,
+                    "renders": [{"path": "0.png", "sha256": "b" * 64, "size_bytes": 1}],
+                }
+
+            environment = {"nerfstudio_revision": "revision", "gsplat_version": "1.4.0"}
+            runtime = {
+                "gpu_name": "test-gpu",
+                "compute_capability": "12.0",
+                "torch_version": "2.7.1",
+                "torch_cuda_version": "12.8",
+                "container_image_ref": "image",
+                "container_image_id": "sha256:image",
+            }
+            ply_metrics = {
+                "primitive_count": 100,
+                "output_size_bytes": 3,
+                "low_opacity_primitive_count": 10,
+                "low_opacity_primitive_ratio": 0.1,
+                "scale_anisotropy_above_10_count": 20,
+                "scale_anisotropy_above_10_ratio": 0.2,
+            }
+            output_root = root / "out"
+            with patch(
+                "processing.quality_sweep.verify_gpu_runtime",
+                return_value=runtime,
+            ), patch(
+                "processing.quality_sweep.verify_research_environment",
+                return_value=environment,
+            ), patch(
+                "processing.quality_sweep.run_splatfacto_export",
+                side_effect=fake_run,
+            ), patch(
+                "processing.quality_sweep.run_nerfstudio_eval",
+                side_effect=fake_eval,
+            ), patch(
+                "processing.quality_sweep.gaussian_artifact_metrics",
+                return_value=ply_metrics,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "scale-regularized"):
+                    run_quality_sweep(
+                        data,
+                        source,
+                        output_root,
+                        nerfstudio_source=root / "nerfstudio",
+                        iterations=30000,
+                        holdout_count=2,
+                    )
+
+            self.assertEqual(len(calls), 3)
+            summary = json.loads((output_root / "quality-sweep.json").read_text())
+            comparison = json.loads((output_root / "comparison.json").read_text())
+            self.assertEqual(summary["status"], "failed")
+            self.assertEqual(summary["failed_variants"], ["scale-regularized"])
+            self.assertEqual(
+                [entry["status"] for entry in summary["variants"]],
+                ["success", "failed", "success"],
+            )
+            self.assertEqual(summary["variants"][1]["metrics"]["peak_gpu_memory_bytes"], 987654)
+            self.assertEqual(len(comparison["results"]), 3)
+            self.assertEqual(
+                [row["status"] for row in comparison["results"]],
+                ["success", "failed", "success"],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Finish the remaining repository-side evidence work for #26/#39/#41/#43 while keeping local execution to the existing `./task quality <scene> <iterations>` command.

## Changes

- preserve the deterministic train/hold-out + `ns-eval` path merged in #56;
- require `ns-eval --render-output-path` to actually emit hold-out render files and record each render path/size/SHA-256;
- best-effort measure training-process peak GPU framebuffer memory via NVIDIA `nvidia-smi --query-compute-apps=pid,used_gpu_memory`; retain `null` when the driver/runtime cannot expose it;
- resolve container/host PID namespace differences through `/proc/*/status` `NSpid` aliases before matching `nvidia-smi` process rows;
- attempt default / Scale Regularization / MCMC independently even when one variant fails;
- preserve a failed `backend-result.json`, partial `comparison.json`, artifact metrics when available, and failure phase/error;
- after all three attempts, return non-zero if any variant failed instead of silently declaring the sweep successful;
- add regression coverage for render evidence and failure isolation.

## Evidence boundary

This does not claim a quality winner and does not claim the RTX 5070 Ti experiments have run. It removes repository-side setup gaps so the remaining empirical action is the canonical local GPU command on prepared bad-scene + good-control datasets.

NVIDIA reference for selective compute-process query and per-process framebuffer memory:
- https://docs.nvidia.com/deploy/nvidia-smi/index.html
- https://docs.nvidia.com/deploy/nvml-api/structnvmlProcessInfo__v1__t.html

Related: #26, #39, #41, #43.