### PR TITLE
Publish Gaussian Splat runs through hf-cache-hub

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
+from processing.artifact_publish import ArtifactPublishError, publish_run_splat
 from processing.backend_evaluation import build_dataset_contract, write_comparison
 from processing.batch import run_all_videos
 from processing.collection import collect_images
@@ -64,6 +66,14 @@ def main() -> None:
     batch_parser.add_argument("--timeout", type=float, default=None)
     batch_parser.add_argument("--train-iterations", type=int, default=2000)
     batch_parser.add_argument("--fresh", action="store_true")
+
+    publish_parser = subparsers.add_parser(
+        "publish-splat",
+        help="Publish one successful run PLY through hf-cache-hub and verify remote readback.",
+    )
+    publish_parser.add_argument("--run-manifest", required=True)
+    publish_parser.add_argument("--bucket", default=os.environ.get("HF_ARTIFACT_BUCKET"))
+    publish_parser.add_argument("--hf-cache-hub-root", default=os.environ.get("HF_CACHE_HUB_ROOT"))
 
     dataset_parser = subparsers.add_parser(
         "evaluation-dataset",
@@ -127,6 +137,18 @@ def main() -> None:
             input_root=args.input_root,
             output_root=args.output_root,
         )
+    elif args.command == "publish-splat":
+        if not args.bucket:
+            raise SystemExit("--bucket or HF_ARTIFACT_BUCKET is required")
+        try:
+            result = publish_run_splat(
+                args.run_manifest,
+                bucket=args.bucket,
+                hf_cache_hub_root=args.hf_cache_hub_root,
+            )
+        except ArtifactPublishError as exc:
+            print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False, indent=2))
+            raise SystemExit(1) from exc
     elif args.command == "evaluation-dataset":
         result = build_dataset_contract(
             args.source_video,

--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Sequence
+
+import yaml
+
+from processing.provenance import sha256_file, write_json
+
+
+class ArtifactPublishError(RuntimeError):
+    pass
+
+
+def git_revision(runner: Callable[..., subprocess.CompletedProcess] = subprocess.run) -> str:
+    result = runner(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    revision = result.stdout.strip()
+    if len(revision) != 40 or any(c not in "0123456789abcdef" for c in revision):
+        raise ArtifactPublishError(f"git rev-parse did not return a full lowercase commit SHA: {revision!r}")
+    return revision
+
+
+def _hf_cache_command(hf_cache_hub_root: str | Path | None) -> list[str]:
+    root = Path(hf_cache_hub_root or os.environ.get("HF_CACHE_HUB_ROOT", "")).expanduser()
+    if not str(root):
+        raise ArtifactPublishError("HF_CACHE_HUB_ROOT or --hf-cache-hub-root is required")
+    script = root / "scripts" / "artifact_manager.py"
+    if not script.is_file():
+        raise ArtifactPublishError(f"hf-cache-hub artifact CLI not found: {script}")
+    return [sys.executable, str(script)]
+
+
+def build_artifact_manifest(
+    *,
+    dataset: str,
+    ply_path: Path,
+    bucket: str,
+    source_revision: str,
+    run_id: str,
+    source_url: str | None = None,
+    license_url: str | None = None,
+) -> tuple[dict, str]:
+    if not ply_path.is_file() or ply_path.stat().st_size == 0:
+        raise ArtifactPublishError(f"Gaussian Splat PLY is missing or empty: {ply_path}")
+    sha256 = sha256_file(ply_path)
+    artifact_id = f"autophotogrammetry/{dataset}/splat"
+    remote_path = f"autophotogrammetry/gaussian-splats/{dataset}/{sha256}.ply"
+    artifact = {
+        "id": artifact_id,
+        "kind": "gaussian-splat",
+        "format": "ply",
+        "storage": {
+            "type": "huggingface-bucket",
+            "bucket": bucket,
+            "path": remote_path,
+        },
+        "size_bytes": ply_path.stat().st_size,
+        "sha256": sha256,
+        "provenance": {
+            "repository": "KAFKA2306/AutoPhotogrammetry",
+            "revision": source_revision,
+            "source_path": str(ply_path),
+            "run_id": run_id,
+        },
+    }
+    if source_url:
+        artifact["source_url"] = source_url
+    if license_url:
+        artifact["license_url"] = license_url
+    return {"schema_version": 1, "artifacts": [artifact]}, artifact_id
+
+
+def publish_run_splat(
+    run_manifest_path: str | Path,
+    *,
+    bucket: str,
+    hf_cache_hub_root: str | Path | None = None,
+    source_revision: str | None = None,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> dict:
+    run_manifest_path = Path(run_manifest_path)
+    run_manifest = json.loads(run_manifest_path.read_text(encoding="utf-8"))
+    if run_manifest.get("status") != "success":
+        raise ArtifactPublishError("run manifest is not a successful local reconstruction")
+    try:
+        splat = run_manifest["splatfacto"]
+        ply_path = Path(splat["ply_path"])
+        expected_sha = splat["ply_sha256"]
+        expected_size = splat["ply_size_bytes"]
+    except KeyError as exc:
+        raise ArtifactPublishError(f"run manifest is missing Gaussian Splat metadata: {exc}") from exc
+
+    actual_sha = sha256_file(ply_path)
+    actual_size = ply_path.stat().st_size
+    if actual_sha != expected_sha or actual_size != expected_size:
+        raise ArtifactPublishError("local PLY no longer matches the successful run manifest")
+
+    revision = source_revision or git_revision(runner)
+    registry = run_manifest.get("registry", {})
+    license_info = registry.get("license") or {}
+    source_url = registry.get("source_page")
+    license_url = license_info.get("url") if isinstance(license_info, dict) else None
+    run_id = f"{run_manifest.get('dataset', 'unknown')}:{run_manifest.get('started_at', 'unknown')}"
+    artifact_manifest, artifact_id = build_artifact_manifest(
+        dataset=str(run_manifest["dataset"]),
+        ply_path=ply_path,
+        bucket=bucket,
+        source_revision=revision,
+        run_id=run_id,
+        source_url=source_url,
+        license_url=license_url,
+    )
+    artifact_manifest_path = run_manifest_path.parent / "artifact-manifest.yaml"
+    artifact_manifest_path.write_text(
+        yaml.safe_dump(artifact_manifest, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+    command: Sequence[str] = [
+        *_hf_cache_command(hf_cache_hub_root),
+        "--manifest",
+        str(artifact_manifest_path),
+        "publish",
+        str(ply_path),
+        "--id",
+        artifact_id,
+    ]
+    completed = runner(command, check=False, capture_output=True, text=True)
+    try:
+        publish_result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        publish_result = {"status": "FAILED", "error": "hf-cache-hub returned non-JSON output"}
+        run_manifest["artifact_publish"] = publish_result
+        write_json(run_manifest_path, run_manifest)
+        raise ArtifactPublishError(publish_result["error"]) from exc
+
+    if (
+        completed.returncode != 0
+        or publish_result.get("status") != "PUBLISHED"
+        or publish_result.get("remote_verified") is not True
+        or publish_result.get("sha256") != expected_sha
+        or publish_result.get("size_bytes") != expected_size
+    ):
+        failure = {
+            "status": "failed",
+            "artifact_id": artifact_id,
+            "local_sha256": expected_sha,
+            "local_size_bytes": expected_size,
+            "publish_result": publish_result,
+        }
+        run_manifest["artifact_publish"] = failure
+        write_json(run_manifest_path, run_manifest)
+        raise ArtifactPublishError(f"remote publish verification failed for {artifact_id}")
+
+    success = {
+        "status": "published",
+        "artifact_id": artifact_id,
+        "manifest_path": str(artifact_manifest_path),
+        "remote_uri": publish_result["remote_uri"],
+        "size_bytes": expected_size,
+        "sha256": expected_sha,
+        "source_revision": revision,
+        "run_id": run_id,
+        "remote_verified": True,
+    }
+    run_manifest["artifact_publish"] = success
+    write_json(run_manifest_path, run_manifest)
+    return success

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "beautifulsoup4>=4.12,<5",
   "numpy>=1.24,<3",
   "Pillow>=10,<12",
+  "PyYAML>=6,<7",
   "requests>=2.31,<3",
   "scikit-image>=0.22,<1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4>=4.12,<5
 numpy>=1.24,<3
 Pillow>=10,<12
+PyYAML>=6,<7
 requests>=2.31,<3
 scikit-image>=0.22,<1

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from processing.artifact_publish import ArtifactPublishError, publish_run_splat
+
+
+class ArtifactPublishTest(unittest.TestCase):
+    def _fixture(self, root: Path):
+        ply = root / "output" / "demo" / "runs" / "r1" / "export" / "splat.ply"
+        ply.parent.mkdir(parents=True)
+        payload = b"ply\nsynthetic"
+        ply.write_bytes(payload)
+        sha = hashlib.sha256(payload).hexdigest()
+        manifest = root / "output" / "demo" / "manifest.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(json.dumps({
+            "schema_version": 2,
+            "dataset": "demo",
+            "status": "success",
+            "started_at": "2026-08-20T00:00:00Z",
+            "registry": {
+                "source_page": "https://commons.wikimedia.org/wiki/File:Demo.webm",
+                "license": {"url": "https://creativecommons.org/publicdomain/zero/1.0/"},
+            },
+            "splatfacto": {
+                "ply_path": str(ply),
+                "ply_sha256": sha,
+                "ply_size_bytes": len(payload),
+            },
+        }), encoding="utf-8")
+        hf_root = root / "hf-cache-hub"
+        (hf_root / "scripts").mkdir(parents=True)
+        (hf_root / "scripts" / "artifact_manager.py").write_text("# cli", encoding="utf-8")
+        return manifest, ply, sha, hf_root
+
+    def test_publish_records_remote_verified_provenance(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, ply, sha, hf_root = self._fixture(root)
+            calls = []
+
+            def runner(command, **kwargs):
+                calls.append(command)
+                if command[:3] == ["git", "rev-parse", "HEAD"]:
+                    return subprocess.CompletedProcess(command, 0, stdout="a" * 40 + "\n", stderr="")
+                artifact_manifest = Path(command[command.index("--manifest") + 1])
+                declared = yaml.safe_load(artifact_manifest.read_text(encoding="utf-8"))["artifacts"][0]
+                result = {
+                    "status": "PUBLISHED",
+                    "remote_verified": True,
+                    "remote_uri": f"hf://buckets/{declared['storage']['bucket']}/{declared['storage']['path']}",
+                    "sha256": declared["sha256"],
+                    "size_bytes": declared["size_bytes"],
+                }
+                return subprocess.CompletedProcess(command, 0, stdout=json.dumps(result), stderr="")
+
+            result = publish_run_splat(
+                manifest,
+                bucket="k4fka/artifacts",
+                hf_cache_hub_root=hf_root,
+                runner=runner,
+            )
+            self.assertEqual("published", result["status"])
+            self.assertTrue(result["remote_verified"])
+            self.assertEqual(sha, result["sha256"])
+            self.assertEqual("a" * 40, result["source_revision"])
+            artifact_manifest = yaml.safe_load((manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8"))
+            artifact = artifact_manifest["artifacts"][0]
+            self.assertEqual("gaussian-splat", artifact["kind"])
+            self.assertEqual("ply", artifact["format"])
+            self.assertEqual(sha, artifact["sha256"])
+            self.assertEqual("a" * 40, artifact["provenance"]["revision"])
+            self.assertIn("run_id", artifact["provenance"])
+            updated = json.loads(manifest.read_text(encoding="utf-8"))
+            self.assertEqual("success", updated["status"])
+            self.assertEqual("published", updated["artifact_publish"]["status"])
+            self.assertTrue(ply.exists())
+
+    def test_publish_failure_preserves_local_run_for_retry(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, ply, _, hf_root = self._fixture(root)
+
+            def runner(command, **kwargs):
+                if command[:3] == ["git", "rev-parse", "HEAD"]:
+                    return subprocess.CompletedProcess(command, 0, stdout="b" * 40 + "\n", stderr="")
+                return subprocess.CompletedProcess(command, 1, stdout=json.dumps({"status": "FAILED"}), stderr="")
+
+            with self.assertRaises(ArtifactPublishError):
+                publish_run_splat(manifest, bucket="k4fka/artifacts", hf_cache_hub_root=hf_root, runner=runner)
+            updated = json.loads(manifest.read_text(encoding="utf-8"))
+            self.assertEqual("success", updated["status"])
+            self.assertEqual("failed", updated["artifact_publish"]["status"])
+            self.assertTrue(ply.exists())
+
+    def test_local_ply_mismatch_fails_before_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, ply, _, hf_root = self._fixture(root)
+            ply.write_bytes(b"changed")
+            with self.assertRaises(ArtifactPublishError):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    source_revision="c" * 40,
+                )
+
+    def test_generated_ply_remains_gitignored(self):
+        ignore = (Path(__file__).parents[1] / ".gitignore").read_text(encoding="utf-8")
+        self.assertIn("output/**/runs/**/export/*.ply", ignore)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the producer-side integration for KAFKA2306/hf-cache-hub#15 without duplicating Hugging Face upload logic.

- identifies the production PLY from the existing successful run manifest
- re-verifies local size and SHA-256 before any publish attempt
- writes the thin artifact manifest with exact AutoPhotogrammetry Git revision and run identifier
- calls only `hf-cache-hub/scripts/artifact_manager.py` for upload + remote readback verification
- records local reconstruction status and remote publish status separately
- preserves the PLY and successful run when publish fails, so republish is retryable
- retains the existing `.gitignore` contract for generated PLY files
- adds unit tests for success, failure preservation, local mutation rejection, and Git ignore coverage

This PR intentionally does not claim the real Storage Bucket acceptance criterion yet; that remains gated by hf-cache-hub#13's real-bucket credential/100 MiB acceptance boundary.