### PR TITLE
3DGS: pin canonical Clean-GS revision and license

### DIFF
--- a/processing/clean_gs.py
+++ b/processing/clean_gs.py
@@ -10,6 +10,13 @@ from typing import Sequence
 from processing.gaussian_ply import gaussian_ply_metrics
 from processing.provenance import sha256_file, write_json
 
+CLEAN_GS_REPOSITORY = "https://github.com/smlab-niser/clean-gs"
+CLEAN_GS_REVISION = "ba5c2fa97e9e4bec0510e25aee9f79f6bc8fa822"
+CLEAN_GS_LICENSE = "MIT"
+CLEAN_GS_LICENSE_URL = (
+    f"{CLEAN_GS_REPOSITORY}/blob/{CLEAN_GS_REVISION}/LICENSE"
+)
+
 
 def clean_gs_command(
     script_path: str | Path,
@@ -99,12 +106,12 @@ def _git_checkout_revision(script: Path, requested_revision: str) -> dict:
 def run_clean_gs(
     *,
     script_path: str | Path,
-    upstream_revision: str,
     scene: str,
     masks_dir: str | Path,
     input_ply: str | Path,
     output_ply: str | Path,
     manifest_path: str | Path,
+    upstream_revision: str = CLEAN_GS_REVISION,
     python_executable: str = "python",
     color_threshold: float | None = None,
     k_neighbors: int | None = None,
@@ -112,7 +119,7 @@ def run_clean_gs(
     timeout: float | None = None,
     extra_args: Sequence[str] = (),
 ) -> dict:
-    """Run an explicit Clean-GS checkout and record all inputs, argv and before/after artifacts."""
+    """Run the pinned Clean-GS checkout and record auditable before/after evidence."""
     script = Path(script_path).expanduser().resolve()
     masks = Path(masks_dir).expanduser().resolve()
     source = Path(input_ply).expanduser().resolve()
@@ -154,11 +161,13 @@ def run_clean_gs(
     )
     finished = _utc_now()
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "backend": "Clean-GS",
-        "upstream_repository": "https://github.com/smlab-niser/clean-gs",
+        "upstream_repository": CLEAN_GS_REPOSITORY,
         "upstream_revision": checkout["head_revision"],
         "upstream_checkout": checkout,
+        "upstream_license": CLEAN_GS_LICENSE,
+        "upstream_license_url": CLEAN_GS_LICENSE_URL,
         "scene": scene,
         "command": command,
         "started_at": started,
@@ -198,9 +207,9 @@ def run_clean_gs(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run official Clean-GS with auditable input/output lineage.")
+    parser = argparse.ArgumentParser(description="Run pinned official Clean-GS with auditable input/output lineage.")
     parser.add_argument("--script", required=True)
-    parser.add_argument("--upstream-revision", required=True)
+    parser.add_argument("--upstream-revision", default=CLEAN_GS_REVISION)
     parser.add_argument("--scene", required=True)
     parser.add_argument("--masks-dir", required=True)
     parser.add_argument("--input-ply", required=True)

--- a/tests/test_clean_gs.py
+++ b/tests/test_clean_gs.py
@@ -6,7 +6,14 @@ from unittest.mock import patch
 
 import numpy as np
 
-from processing.clean_gs import _git_checkout_revision, clean_gs_command, run_clean_gs
+from processing.clean_gs import (
+    CLEAN_GS_LICENSE,
+    CLEAN_GS_LICENSE_URL,
+    CLEAN_GS_REVISION,
+    _git_checkout_revision,
+    clean_gs_command,
+    run_clean_gs,
+)
 
 
 class CleanGsTests(unittest.TestCase):
@@ -33,6 +40,12 @@ class CleanGsTests(unittest.TestCase):
         with path.open("wb") as handle:
             handle.write(header)
             handle.write(vertices.tobytes())
+
+    def test_canonical_revision_is_exact_commit_and_license_is_pinned(self):
+        self.assertEqual(len(CLEAN_GS_REVISION), 40)
+        int(CLEAN_GS_REVISION, 16)
+        self.assertEqual(CLEAN_GS_LICENSE, "MIT")
+        self.assertIn(CLEAN_GS_REVISION, CLEAN_GS_LICENSE_URL)
 
     def test_command_uses_official_cli_flags(self):
         command = clean_gs_command(
@@ -95,7 +108,7 @@ class CleanGsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "does not match"):
                 _git_checkout_revision(script, requested)
 
-    def test_runner_records_masks_and_primitive_reduction(self):
+    def test_runner_uses_canonical_revision_by_default_and_records_license(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             script = root / "clean-gs.py"
@@ -107,7 +120,6 @@ class CleanGsTests(unittest.TestCase):
             output = root / "output.ply"
             manifest = root / "manifest.json"
             self._write_ply(source, 3)
-            head = "d" * 40
 
             def fake_run(command, **kwargs):
                 self._write_ply(output, 2)
@@ -115,17 +127,16 @@ class CleanGsTests(unittest.TestCase):
 
             checkout = {
                 "checkout_root": str(root),
-                "requested_revision": "deadbeef",
-                "resolved_revision": head,
-                "head_revision": head,
+                "requested_revision": CLEAN_GS_REVISION,
+                "resolved_revision": CLEAN_GS_REVISION,
+                "head_revision": CLEAN_GS_REVISION,
             }
             with (
-                patch("processing.clean_gs._git_checkout_revision", return_value=checkout),
+                patch("processing.clean_gs._git_checkout_revision", return_value=checkout) as revision_check,
                 patch("processing.clean_gs.subprocess.run", side_effect=fake_run),
             ):
                 result = run_clean_gs(
                     script_path=script,
-                    upstream_revision="deadbeef",
                     scene="temple",
                     masks_dir=masks,
                     input_ply=source,
@@ -133,14 +144,56 @@ class CleanGsTests(unittest.TestCase):
                     manifest_path=manifest,
                 )
 
+            revision_check.assert_called_once_with(script.resolve(), CLEAN_GS_REVISION)
             self.assertEqual(result["status"], "success")
-            self.assertEqual(result["upstream_revision"], head)
+            self.assertEqual(result["upstream_revision"], CLEAN_GS_REVISION)
+            self.assertEqual(result["upstream_license"], "MIT")
+            self.assertEqual(result["upstream_license_url"], CLEAN_GS_LICENSE_URL)
             self.assertEqual(result["upstream_checkout"], checkout)
             self.assertEqual(result["input"]["primitive_count"], 3)
             self.assertEqual(result["output"]["primitive_count"], 2)
             self.assertEqual(result["removed_primitive_count"], 1)
             self.assertEqual(len(result["masks"]), 1)
             self.assertTrue(manifest.is_file())
+
+    def test_runner_allows_explicit_revision_override_but_verifies_head(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            script = root / "clean-gs.py"
+            script.write_text("# fixture\n", encoding="utf-8")
+            masks = root / "masks"
+            masks.mkdir()
+            (masks / "000001.png").write_bytes(b"mask")
+            source = root / "input.ply"
+            output = root / "output.ply"
+            self._write_ply(source, 2)
+            explicit = "d" * 40
+            checkout = {
+                "checkout_root": str(root),
+                "requested_revision": explicit,
+                "resolved_revision": explicit,
+                "head_revision": explicit,
+            }
+
+            def fake_run(command, **kwargs):
+                self._write_ply(output, 1)
+                return subprocess.CompletedProcess(command, 0, "cleaned", "")
+
+            with (
+                patch("processing.clean_gs._git_checkout_revision", return_value=checkout) as revision_check,
+                patch("processing.clean_gs.subprocess.run", side_effect=fake_run),
+            ):
+                result = run_clean_gs(
+                    script_path=script,
+                    upstream_revision=explicit,
+                    scene="temple",
+                    masks_dir=masks,
+                    input_ply=source,
+                    output_ply=output,
+                    manifest_path=root / "manifest.json",
+                )
+            revision_check.assert_called_once_with(script.resolve(), explicit)
+            self.assertEqual(result["upstream_revision"], explicit)
 
     def test_runner_requires_masks(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -153,15 +206,14 @@ class CleanGsTests(unittest.TestCase):
             self._write_ply(source, 1)
             checkout = {
                 "checkout_root": str(root),
-                "requested_revision": "deadbeef",
-                "resolved_revision": "d" * 40,
-                "head_revision": "d" * 40,
+                "requested_revision": CLEAN_GS_REVISION,
+                "resolved_revision": CLEAN_GS_REVISION,
+                "head_revision": CLEAN_GS_REVISION,
             }
             with patch("processing.clean_gs._git_checkout_revision", return_value=checkout):
                 with self.assertRaisesRegex(ValueError, "semantic masks"):
                     run_clean_gs(
                         script_path=script,
-                        upstream_revision="deadbeef",
                         scene="temple",
                         masks_dir=masks,
                         input_ply=source,


### PR DESCRIPTION
## Goal

Remove the remaining repository-side ambiguity in #45 by defining one canonical official Clean-GS revision and license for AutoPhotogrammetry.

## Upstream authority

Official `smlab-niser/clean-gs` main HEAD verified on 2026-08-20:
- `ba5c2fa97e9e4bec0510e25aee9f79f6bc8fa822`

Pinned LICENSE at that commit:
- MIT
- https://github.com/smlab-niser/clean-gs/blob/ba5c2fa97e9e4bec0510e25aee9f79f6bc8fa822/LICENSE

## Changes

- add canonical repository/revision/license constants;
- make `run_clean_gs` default to that exact revision;
- make CLI `--upstream-revision` optional with the canonical revision as default;
- retain explicit revision override for research, while still requiring the checkout HEAD to equal the requested revision;
- record pinned license + license URL in the manifest;
- add regression tests for canonical revision/license and explicit override.

## Evidence boundary

This resolves dependency/provenance selection only. Actual semantic masks, Clean-GS runs, before/after visual evidence and downstream validation remain empirical work in #45.

Refs #45.