### PR TITLE
3DGS: add winner-fixed culling and budget quality followups

### DIFF
--- a/processing/quality_followup.py
+++ b/processing/quality_followup.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from processing.backend_evaluation import (
+    artifact_record,
+    build_nerfstudio_dataset_contract,
+    dataset_identity,
+    empty_metrics,
+    gaussian_artifact_metrics,
+    validate_backend_result,
+    write_comparison,
+    write_nerfstudio_split_transforms,
+)
+from processing.mcmc_quality import DEFAULT_NERFSTUDIO_SOURCE, verify_research_environment
+from processing.nerfstudio import run_nerfstudio_eval, run_splatfacto_export
+from processing.provenance import write_json
+from processing.quality_sweep import quality_sweep_train_args, verify_gpu_runtime
+
+WINNERS = ("default", "scale-regularized", "mcmc")
+CULLING_FLAGS = {
+    "cull_alpha_thresh": "--pipeline.model.cull-alpha-thresh",
+    "cull_scale_thresh": "--pipeline.model.cull-scale-thresh",
+    "cull_screen_size": "--pipeline.model.cull-screen-size",
+    "stop_screen_size_at": "--pipeline.model.stop-screen-size-at",
+}
+MCMC_EFFECTIVE_CULLING_PARAMETERS = {"cull_alpha_thresh"}
+
+
+def winner_train_args(*, winner: str, iterations: int) -> tuple[str, ...]:
+    if winner not in WINNERS:
+        raise ValueError(f"winner must be one of {WINNERS}, got {winner!r}")
+    return quality_sweep_train_args(iterations=iterations, variant=winner)
+
+
+def _validate_culling_parameter(winner: str, parameter: str) -> None:
+    if parameter not in CULLING_FLAGS:
+        raise ValueError(f"unknown culling parameter: {parameter}")
+    if winner == "mcmc" and parameter not in MCMC_EFFECTIVE_CULLING_PARAMETERS:
+        raise ValueError(
+            f"{parameter} is not consumed by the pinned Splatfacto MCMCStrategy; "
+            "refusing a no-op culling experiment"
+        )
+
+
+def _format_culling_value(parameter: str, value: float | int) -> str:
+    if parameter == "stop_screen_size_at":
+        numeric = float(value)
+        if not numeric.is_integer():
+            raise ValueError("stop_screen_size_at must be an integer")
+        return str(int(numeric))
+    return str(float(value))
+
+
+def culling_train_args(
+    *,
+    winner: str,
+    iterations: int,
+    parameter: str | None = None,
+    value: float | int | None = None,
+) -> tuple[str, ...]:
+    """Freeze the #43 winner and optionally change exactly one effective culling field."""
+    args = list(winner_train_args(winner=winner, iterations=iterations))
+    if parameter is None:
+        if value is not None:
+            raise ValueError("culling value requires a parameter")
+        return tuple(args)
+    _validate_culling_parameter(winner, parameter)
+    if value is None:
+        raise ValueError("culling parameter requires a value")
+    args.extend((CULLING_FLAGS[parameter], _format_culling_value(parameter, value)))
+    return tuple(args)
+
+
+def _prepare_dataset(
+    data_dir: str | Path,
+    source_video: str | Path,
+    output_root: str | Path,
+    *,
+    holdout_count: int | None,
+) -> tuple[Path, Path, dict]:
+    data = Path(data_dir).expanduser().resolve()
+    transforms = data / "transforms.json"
+    if not transforms.is_file():
+        raise ValueError(f"Nerfstudio transforms.json does not exist: {transforms}")
+    source = Path(source_video).expanduser().resolve()
+    if not source.is_file():
+        raise ValueError(f"source video does not exist: {source}")
+
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    dataset = build_nerfstudio_dataset_contract(
+        source,
+        transforms,
+        holdout_count=holdout_count,
+    )
+    dataset_path = root / "evaluation-dataset.json"
+    write_json(dataset_path, dataset)
+    split = write_nerfstudio_split_transforms(
+        transforms,
+        dataset,
+        root / "evaluation-transforms.json",
+    )
+    return root, Path(split["transforms_path"]), dataset
+
+
+def _base_metrics(dataset: Mapping) -> dict:
+    metrics = empty_metrics()
+    metrics.update(
+        input_frame_count=len(dataset["frames"]),
+        train_frame_count=len(dataset["train_frame_sha256"]),
+        holdout_frame_count=len(dataset["holdout_frame_sha256"]),
+        camera_pose_available=True,
+    )
+    return metrics
+
+
+def _run_experiment(
+    *,
+    name: str,
+    dataset: Mapping,
+    split_transforms: Path,
+    output_root: Path,
+    environment: Mapping,
+    train_args: Sequence[str],
+    config: Mapping,
+    timeout: float | None,
+) -> tuple[dict, dict]:
+    """Run one follow-up and preserve an explicit success/failure backend result."""
+    output_root.mkdir(parents=True, exist_ok=True)
+    started = time.perf_counter()
+    result: dict | None = None
+    evaluation: dict | None = None
+    manifest_path: Path | None = None
+    ply_path: Path | None = None
+    phase = "training-export"
+    fallback_command = [
+        "ns-train",
+        "splatfacto",
+        "--data",
+        str(split_transforms),
+        *map(str, train_args),
+    ]
+
+    try:
+        result = run_splatfacto_export(
+            split_transforms,
+            output_root,
+            train_extra_args=train_args,
+            timeout=timeout,
+            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+        )
+        train_export_seconds = time.perf_counter() - started
+        manifest_path = Path(result["manifest_path"])
+        run_dir = manifest_path.parent
+        ply_path = run_dir / result["output"]["ply_path"]
+        config_path = run_dir / result["training"]["config_path"]
+
+        phase = "evaluation"
+        evaluation = run_nerfstudio_eval(
+            config_path,
+            run_dir / "evaluation",
+            timeout=timeout,
+            env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+        )
+
+        phase = "artifact-metrics"
+        metrics = _base_metrics(dataset)
+        metrics.update(
+            reconstruction_success=True,
+            psnr=evaluation["metrics"].get("psnr"),
+            ssim=evaluation["metrics"].get("ssim"),
+            lpips=evaluation["metrics"].get("lpips"),
+            wall_clock_seconds=train_export_seconds,
+            peak_gpu_memory_bytes=(result.get("training") or {}).get("peak_gpu_memory_bytes"),
+            **gaussian_artifact_metrics(ply_path),
+        )
+        backend_result = {
+            "schema_version": 2,
+            "dataset_id": dataset_identity(dataset),
+            "backend": {
+                "name": name,
+                "upstream_revision": environment["nerfstudio_revision"],
+            },
+            "command": list(result["training"]["command"]),
+            "config": dict(config),
+            "return_code": 0,
+            "status": "success",
+            "failure_phase": None,
+            "artifact": artifact_record(ply_path, format="ply"),
+            "metrics": metrics,
+            "training_manifest_path": str(manifest_path),
+            "evaluation_manifest_path": evaluation["manifest_path"],
+        }
+        validate_backend_result(backend_result, dataset)
+        result_path = output_root / "backend-result.json"
+        write_json(result_path, backend_result)
+        return (
+            {
+                "name": name,
+                "status": "success",
+                "backend_result_path": str(result_path),
+                "training_manifest_path": str(manifest_path),
+                "evaluation_manifest_path": evaluation["manifest_path"],
+                "render_count": evaluation.get("render_count"),
+                "renders": evaluation.get("renders"),
+                "ply_path": str(ply_path),
+                "metrics": metrics,
+            },
+            backend_result,
+        )
+    except Exception as exc:
+        elapsed = time.perf_counter() - started
+        metrics = _base_metrics(dataset)
+        training = (result or {}).get("training") or {}
+        metrics.update(
+            reconstruction_success=result is not None,
+            wall_clock_seconds=elapsed,
+            peak_gpu_memory_bytes=(
+                training.get("peak_gpu_memory_bytes") if isinstance(training, Mapping) else None
+            ),
+        )
+
+        artifact = None
+        if result is not None and manifest_path is not None:
+            try:
+                ply_path = manifest_path.parent / result["output"]["ply_path"]
+                if ply_path.is_file():
+                    artifact = artifact_record(ply_path, format="ply")
+                    metrics.update(gaussian_artifact_metrics(ply_path))
+            except Exception:
+                artifact = None
+
+        if isinstance(exc, subprocess.CalledProcessError):
+            command = (
+                list(map(str, exc.cmd))
+                if isinstance(exc.cmd, (list, tuple))
+                else [str(exc.cmd)]
+            )
+            return_code = int(exc.returncode)
+        else:
+            command = list(map(str, training.get("command") or fallback_command))
+            return_code = 1
+
+        backend_result = {
+            "schema_version": 2,
+            "dataset_id": dataset_identity(dataset),
+            "backend": {
+                "name": name,
+                "upstream_revision": environment["nerfstudio_revision"],
+            },
+            "command": command,
+            "config": dict(config),
+            "return_code": return_code,
+            "status": "failed",
+            "failure_phase": phase,
+            "artifact": artifact,
+            "metrics": metrics,
+            "training_manifest_path": str(manifest_path) if manifest_path else None,
+            "evaluation_manifest_path": (
+                evaluation.get("manifest_path") if evaluation is not None else None
+            ),
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+        validate_backend_result(backend_result, dataset)
+        result_path = output_root / "backend-result.json"
+        write_json(result_path, backend_result)
+        return (
+            {
+                "name": name,
+                "status": "failed",
+                "failure_phase": phase,
+                "backend_result_path": str(result_path),
+                "error": backend_result["error"],
+                "metrics": metrics,
+            },
+            backend_result,
+        )
+
+
+def run_culling_sweep(
+    data_dir: str | Path,
+    source_video: str | Path,
+    output_root: str | Path,
+    *,
+    winner: str,
+    parameter: str,
+    values: Sequence[float],
+    iterations: int = 30000,
+    holdout_count: int | None = None,
+    nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
+    timeout: float | None = None,
+) -> dict:
+    """Run baseline + one culling parameter family after #43 fixes the winner."""
+    if winner not in WINNERS:
+        raise ValueError(f"winner must be one of {WINNERS}, got {winner!r}")
+    _validate_culling_parameter(winner, parameter)
+    unique_values = tuple(dict.fromkeys(float(value) for value in values))
+    if not unique_values:
+        raise ValueError("at least one culling value is required")
+
+    runtime = verify_gpu_runtime()
+    environment = verify_research_environment(nerfstudio_source)
+    root, split, dataset = _prepare_dataset(
+        data_dir,
+        source_video,
+        output_root,
+        holdout_count=holdout_count,
+    )
+    summary = {
+        "schema_version": 1,
+        "experiment_type": "culling-only",
+        "dataset_id": dataset_identity(dataset),
+        "winner": winner,
+        "iterations": iterations,
+        "culling_parameter": parameter,
+        "runtime": runtime,
+        "environment": environment,
+        "experiments": [],
+    }
+    results = []
+
+    experiments: list[tuple[str, float | None, tuple[str, ...]]] = [
+        ("baseline", None, culling_train_args(winner=winner, iterations=iterations))
+    ]
+    for value in unique_values:
+        experiments.append(
+            (
+                f"{parameter}-{str(value).replace('-', 'm').replace('.', 'p')}",
+                value,
+                culling_train_args(
+                    winner=winner,
+                    iterations=iterations,
+                    parameter=parameter,
+                    value=value,
+                ),
+            )
+        )
+
+    for label, value, args in experiments:
+        entry, backend_result = _run_experiment(
+            name=f"splatfacto-{winner}-culling-{label}",
+            dataset=dataset,
+            split_transforms=split,
+            output_root=root / label,
+            environment=environment,
+            train_args=args,
+            config={
+                "experiment_type": "culling-only",
+                "winner": winner,
+                "iterations": iterations,
+                "changed_parameter": None if value is None else parameter,
+                "value": value,
+            },
+            timeout=timeout,
+        )
+        summary["experiments"].append(
+            {
+                "changed_parameter": None if value is None else parameter,
+                "value": value,
+                **entry,
+            }
+        )
+        results.append(backend_result)
+
+    comparison_path = root / "comparison.json"
+    summary["comparison"] = write_comparison(comparison_path, results, dataset)
+    summary["comparison_path"] = str(comparison_path)
+    summary["status"] = (
+        "success"
+        if all(entry["status"] == "success" for entry in summary["experiments"])
+        else "failed"
+    )
+    summary_path = root / "culling-sweep.json"
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def run_budget_sweep(
+    data_dir: str | Path,
+    source_video: str | Path,
+    output_root: str | Path,
+    *,
+    winner: str,
+    budgets: Sequence[int],
+    holdout_count: int | None = None,
+    nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
+    timeout: float | None = None,
+) -> dict:
+    """Change only training iteration budget after #43 fixes the winner."""
+    if winner not in WINNERS:
+        raise ValueError(f"winner must be one of {WINNERS}, got {winner!r}")
+    unique_budgets = tuple(dict.fromkeys(int(value) for value in budgets))
+    if len(unique_budgets) < 2 or any(value <= 0 for value in unique_budgets):
+        raise ValueError("budget sweep requires at least two distinct positive iteration values")
+
+    runtime = verify_gpu_runtime()
+    environment = verify_research_environment(nerfstudio_source)
+    root, split, dataset = _prepare_dataset(
+        data_dir,
+        source_video,
+        output_root,
+        holdout_count=holdout_count,
+    )
+    summary = {
+        "schema_version": 1,
+        "experiment_type": "budget-only",
+        "dataset_id": dataset_identity(dataset),
+        "winner": winner,
+        "budgets": list(unique_budgets),
+        "runtime": runtime,
+        "environment": environment,
+        "experiments": [],
+    }
+    results = []
+
+    for budget in unique_budgets:
+        entry, backend_result = _run_experiment(
+            name=f"splatfacto-{winner}-iterations-{budget}",
+            dataset=dataset,
+            split_transforms=split,
+            output_root=root / f"iterations-{budget}",
+            environment=environment,
+            train_args=winner_train_args(winner=winner, iterations=budget),
+            config={
+                "experiment_type": "budget-only",
+                "winner": winner,
+                "iterations": budget,
+            },
+            timeout=timeout,
+        )
+        summary["experiments"].append({"iterations": budget, **entry})
+        results.append(backend_result)
+
+    comparison_path = root / "comparison.json"
+    summary["comparison"] = write_comparison(comparison_path, results, dataset)
+    summary["comparison_path"] = str(comparison_path)
+    summary["status"] = (
+        "success"
+        if all(entry["status"] == "success" for entry in summary["experiments"])
+        else "failed"
+    )
+    summary_path = root / "budget-sweep.json"
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run #43-winner-fixed culling-only or budget-only Splatfacto follow-ups."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    culling = subparsers.add_parser("culling")
+    culling.add_argument("--data", required=True)
+    culling.add_argument("--source-video", required=True)
+    culling.add_argument("--output-root", required=True)
+    culling.add_argument("--winner", choices=WINNERS, required=True)
+    culling.add_argument("--parameter", choices=tuple(CULLING_FLAGS), required=True)
+    culling.add_argument("--value", action="append", type=float, required=True)
+    culling.add_argument("--iterations", type=int, default=30000)
+    culling.add_argument("--holdout-count", type=int)
+    culling.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
+    culling.add_argument("--timeout", type=float)
+
+    budget = subparsers.add_parser("budget")
+    budget.add_argument("--data", required=True)
+    budget.add_argument("--source-video", required=True)
+    budget.add_argument("--output-root", required=True)
+    budget.add_argument("--winner", choices=WINNERS, required=True)
+    budget.add_argument("--iterations", action="append", type=int, required=True)
+    budget.add_argument("--holdout-count", type=int)
+    budget.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
+    budget.add_argument("--timeout", type=float)
+
+    args = parser.parse_args()
+    if args.command == "culling":
+        result = run_culling_sweep(
+            args.data,
+            args.source_video,
+            args.output_root,
+            winner=args.winner,
+            parameter=args.parameter,
+            values=args.value,
+            iterations=args.iterations,
+            holdout_count=args.holdout_count,
+            nerfstudio_source=args.nerfstudio_source,
+            timeout=args.timeout,
+        )
+    else:
+        result = run_budget_sweep(
+            args.data,
+            args.source_video,
+            args.output_root,
+            winner=args.winner,
+            budgets=args.iterations,
+            holdout_count=args.holdout_count,
+            nerfstudio_source=args.nerfstudio_source,
+            timeout=args.timeout,
+        )
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if result["status"] != "success":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/task
+++ b/task
@@ -84,7 +84,39 @@ doctor() {
   check_docker
   check_host_gpu
   ensure_image
-  run_gpu python -c 'import importlib.metadata as m, shutil, subprocess, torch; assert torch.cuda.is_available(), "CUDA is not available in Docker"; cap=torch.cuda.get_device_capability(); assert cap[0] == 12, f"Expected compute capability 12.x, got {cap}"; required=["ffmpeg","ffprobe","colmap","ns-process-data","ns-train","ns-export"]; missing=[x for x in required if shutil.which(x) is None]; assert not missing, f"Missing executables: {missing}"; rev=subprocess.run(["git","-C","/opt/nerfstudio","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev == "50e0e3c70c775e89333256213363badbf074f29d", rev; print({"gpu": torch.cuda.get_device_name(), "capability": cap, "torch": torch.__version__, "nerfstudio_revision": rev, "nerfstudio_package": m.version("nerfstudio"), "gsplat": m.version("gsplat")})'
+  run_gpu python -c 'import importlib.metadata as m, shutil, subprocess, torch; assert torch.cuda.is_available(), "CUDA is not available in Docker"; cap=torch.cuda.get_device_capability(); assert cap[0] == 12, f"Expected compute capability 12.x, got {cap}"; required=["ffmpeg","ffprobe","colmap","ns-process-data","ns-train","ns-export","ns-eval"]; missing=[x for x in required if shutil.which(x) is None]; assert not missing, f"Missing executables: {missing}"; rev=subprocess.run(["git","-C","/opt/nerfstudio","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev == "50e0e3c70c775e89333256213363badbf074f29d", rev; print({"gpu": torch.cuda.get_device_name(), "capability": cap, "torch": torch.__version__, "nerfstudio_revision": rev, "nerfstudio_package": m.version("nerfstudio"), "gsplat": m.version("gsplat")})'
+}
+
+require_quality_inputs() {
+  local scene="$1"
+  local data="$ROOT/output/$scene/nerfstudio-data"
+  local source="$ROOT/input/$scene/source.webm"
+  if [[ ! -f "$data/transforms.json" ]]; then
+    echo "Prepared Nerfstudio dataset is missing: $data/transforms.json" >&2
+    echo "Quality execution is GPU-only and will not rerun download/FFmpeg/COLMAP." >&2
+    return 1
+  fi
+  if [[ ! -f "$source" ]]; then
+    echo "Source video required for deterministic evaluation identity is missing: $source" >&2
+    echo "Quality execution does not redownload source media." >&2
+    return 1
+  fi
+}
+
+prepare_quality_runtime() {
+  check_docker
+  check_host_gpu
+  ensure_image
+}
+
+run_quality_scene() {
+  local scene="$1"
+  local iterations="$2"
+  run_gpu python -m processing.quality_sweep \
+    --data "/workspace/output/$scene/nerfstudio-data" \
+    --source-video "/workspace/input/$scene/source.webm" \
+    --output-root "/workspace/output/$scene/quality-sweep" \
+    --iterations "$iterations"
 }
 
 case "${1:-run}" in
@@ -116,26 +148,69 @@ case "${1:-run}" in
   quality)
     scene="${2:-huejotzingo}"
     iterations="${3:-30000}"
-    data="$ROOT/output/$scene/nerfstudio-data"
-    source="$ROOT/input/$scene/source.webm"
-    if [[ ! -f "$data/transforms.json" ]]; then
-      echo "Prepared Nerfstudio dataset is missing: $data/transforms.json" >&2
-      echo "Quality execution is intentionally GPU-only and will not rerun download/FFmpeg/COLMAP. Use an existing prepared dataset." >&2
-      exit 1
+    require_quality_inputs "$scene"
+    prepare_quality_runtime
+    run_quality_scene "$scene" "$iterations"
+    ;;
+  quality-pair)
+    bad_scene="${2:-}"
+    good_scene="${3:-}"
+    iterations="${4:-30000}"
+    if [[ -z "$bad_scene" || -z "$good_scene" ]]; then
+      echo "usage: ./task quality-pair <bad-scene-id> <good-control-scene-id> [iterations]" >&2
+      exit 2
     fi
-    if [[ ! -f "$source" ]]; then
-      echo "Source video required for deterministic evaluation identity is missing: $source" >&2
-      echo "Quality execution does not redownload source media; run the canonical production path that prepared this dataset." >&2
-      exit 1
+    if [[ "$bad_scene" == "$good_scene" ]]; then
+      echo "bad scene and good control must be different scene ids" >&2
+      exit 2
     fi
-    check_docker
-    check_host_gpu
-    ensure_image
-    run_gpu python -m processing.quality_sweep \
+    require_quality_inputs "$bad_scene"
+    require_quality_inputs "$good_scene"
+    prepare_quality_runtime
+    status=0
+    run_quality_scene "$bad_scene" "$iterations" || status=1
+    run_quality_scene "$good_scene" "$iterations" || status=1
+    exit "$status"
+    ;;
+  quality-culling)
+    scene="${2:-}"
+    winner="${3:-}"
+    parameter="${4:-}"
+    value="${5:-}"
+    iterations="${6:-30000}"
+    if [[ -z "$scene" || -z "$winner" || -z "$parameter" || -z "$value" ]]; then
+      echo "usage: ./task quality-culling <scene-id> <default|scale-regularized|mcmc> <cull_alpha_thresh|cull_scale_thresh|cull_screen_size|stop_screen_size_at> <value> [iterations]" >&2
+      exit 2
+    fi
+    require_quality_inputs "$scene"
+    prepare_quality_runtime
+    run_gpu python -m processing.quality_followup culling \
       --data "/workspace/output/$scene/nerfstudio-data" \
       --source-video "/workspace/input/$scene/source.webm" \
-      --output-root "/workspace/output/$scene/quality-sweep" \
+      --output-root "/workspace/output/$scene/quality-culling/$winner/$parameter" \
+      --winner "$winner" \
+      --parameter "$parameter" \
+      --value "$value" \
       --iterations "$iterations"
+    ;;
+  quality-budget)
+    scene="${2:-}"
+    winner="${3:-}"
+    current_iterations="${4:-}"
+    increased_iterations="${5:-}"
+    if [[ -z "$scene" || -z "$winner" || -z "$current_iterations" || -z "$increased_iterations" ]]; then
+      echo "usage: ./task quality-budget <scene-id> <default|scale-regularized|mcmc> <current-iterations> <increased-iterations>" >&2
+      exit 2
+    fi
+    require_quality_inputs "$scene"
+    prepare_quality_runtime
+    run_gpu python -m processing.quality_followup budget \
+      --data "/workspace/output/$scene/nerfstudio-data" \
+      --source-video "/workspace/input/$scene/source.webm" \
+      --output-root "/workspace/output/$scene/quality-budget/$winner" \
+      --winner "$winner" \
+      --iterations "$current_iterations" \
+      --iterations "$increased_iterations"
     ;;
   clean)
     find "$ROOT/output" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
@@ -144,7 +219,7 @@ case "${1:-run}" in
     find "$ROOT/output" "$ROOT/input" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
     ;;
   *)
-    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|doctor|pull|test|image|clean|clean-all}" >&2
+    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|quality-pair <bad-scene> <good-control> [iterations]|quality-culling <scene> <winner> <parameter> <value> [iterations]|quality-budget <scene> <winner> <current-iterations> <increased-iterations>|doctor|pull|test|image|clean|clean-all}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_quality_followup.py
+++ b/tests/test_quality_followup.py
@@ -1,0 +1,159 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import dataset_identity
+from processing.quality_followup import (
+    culling_train_args,
+    run_budget_sweep,
+    run_culling_sweep,
+)
+
+
+class QualityFollowupTests(unittest.TestCase):
+    def _dataset(self, root: Path) -> tuple[Path, Path]:
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(6):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                    ],
+                }
+            )
+        (data / "transforms.json").write_text(
+            json.dumps({"frames": frames}),
+            encoding="utf-8",
+        )
+        return source, data
+
+    def _fake_experiment(self, **kwargs):
+        name = kwargs["name"]
+        result = {
+            "schema_version": 2,
+            "dataset_id": dataset_identity(kwargs["dataset"]),
+            "backend": {"name": name, "upstream_revision": "revision"},
+            "command": ["ns-train", "splatfacto"],
+            "config": dict(kwargs["config"]),
+            "return_code": 0,
+            "status": "success",
+            "failure_phase": None,
+            "artifact": {
+                "path": "artifact.ply",
+                "format": "ply",
+                "size_bytes": 1,
+                "sha256": "a" * 64,
+            },
+            "metrics": {},
+        }
+        return {"name": name, "status": "success", "metrics": {}}, result
+
+    def test_culling_changes_only_one_named_parameter_after_winner(self):
+        base = culling_train_args(winner="mcmc", iterations=30000)
+        changed = culling_train_args(
+            winner="mcmc",
+            iterations=30000,
+            parameter="cull_alpha_thresh",
+            value=0.05,
+        )
+        self.assertEqual(changed[: len(base)], base)
+        self.assertEqual(
+            changed[len(base) :],
+            ("--pipeline.model.cull-alpha-thresh", "0.05"),
+        )
+
+    def test_mcmc_rejects_default_strategy_only_culling_fields(self):
+        with self.assertRaisesRegex(ValueError, "not consumed"):
+            culling_train_args(
+                winner="mcmc",
+                iterations=30000,
+                parameter="cull_scale_thresh",
+                value=0.5,
+            )
+
+    def test_integer_culling_field_remains_integer(self):
+        args = culling_train_args(
+            winner="default",
+            iterations=30000,
+            parameter="stop_screen_size_at",
+            value=5000,
+        )
+        self.assertEqual(args[-2:], ("--pipeline.model.stop-screen-size-at", "5000"))
+
+    def test_culling_sweep_runs_baseline_plus_each_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, data = self._dataset(root)
+            with patch(
+                "processing.quality_followup.verify_gpu_runtime",
+                return_value={"gpu": "test"},
+            ), patch(
+                "processing.quality_followup.verify_research_environment",
+                return_value={"nerfstudio_revision": "revision"},
+            ), patch(
+                "processing.quality_followup._run_experiment",
+                side_effect=self._fake_experiment,
+            ) as runner:
+                result = run_culling_sweep(
+                    data,
+                    source,
+                    root / "out",
+                    winner="scale-regularized",
+                    parameter="cull_scale_thresh",
+                    values=[0.25, 0.5],
+                    holdout_count=1,
+                )
+
+        self.assertEqual(runner.call_count, 3)
+        self.assertEqual(len(result["comparison"]["results"]), 3)
+        self.assertEqual(result["status"], "success")
+
+    def test_budget_sweep_changes_only_iteration_budget(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, data = self._dataset(root)
+            with patch(
+                "processing.quality_followup.verify_gpu_runtime",
+                return_value={"gpu": "test"},
+            ), patch(
+                "processing.quality_followup.verify_research_environment",
+                return_value={"nerfstudio_revision": "revision"},
+            ), patch(
+                "processing.quality_followup._run_experiment",
+                side_effect=self._fake_experiment,
+            ) as runner:
+                result = run_budget_sweep(
+                    data,
+                    source,
+                    root / "out",
+                    winner="scale-regularized",
+                    budgets=[30000, 60000],
+                    holdout_count=1,
+                )
+
+        self.assertEqual(runner.call_count, 2)
+        first = runner.call_args_list[0].kwargs["train_args"]
+        second = runner.call_args_list[1].kwargs["train_args"]
+        self.assertEqual(first[0], "--max-num-iterations")
+        self.assertEqual(second[0], "--max-num-iterations")
+        self.assertEqual(first[1], "30000")
+        self.assertEqual(second[1], "60000")
+        self.assertEqual(first[2:], second[2:])
+        self.assertEqual(len(result["comparison"]["results"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Finish the remaining repository-side execution gaps for #40 and #48 on top of the current main, after main already gained deterministic holdout evaluation, process-tree peak GPU-memory measurement, render hashing, and quality-variant failure isolation.

Related execution authority: #59.

## Changes

- add `processing.quality_followup`;
- require an explicit #43 winner: `default`, `scale-regularized`, or `mcmc`;
- culling follow-up runs the frozen winner baseline plus exactly one changed culling parameter family;
- reject MCMC culling fields that the pinned Splatfacto MCMCStrategy does not consume, avoiding no-op experiments;
- preserve integer semantics for `stop_screen_size_at`;
- budget follow-up changes iteration count only while preserving the frozen winner configuration;
- use the same deterministic train/holdout contract and common #26 comparison schema;
- reuse current `run_splatfacto_export` peak-VRAM evidence and `ns-eval` PSNR/SSIM/LPIPS + hashed renders;
- preserve explicit failed rows without relabeling failure as success;
- expose operator commands:
  - `./task quality-pair <bad-scene> <good-control> [iterations]`
  - `./task quality-culling <scene> <winner> <parameter> <value> [iterations]`
  - `./task quality-budget <scene> <winner> <current-iterations> <increased-iterations>`
- `quality-pair` requires explicit distinct scene IDs; it never guesses bad/good identity.

## Evidence boundary

No actual GPU result is fabricated. #39/#41/#43/#40/#48 remain empirically open until the required real runs are performed. This PR removes the repository-side runner/manual-orchestration blockers only.

Related: #26, #39, #40, #41, #43, #48, #59.