### PR TITLE
Harden hf-cache-hub producer integration

### DIFF
--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -30,9 +30,10 @@ def git_revision(runner: Callable[..., subprocess.CompletedProcess] = subprocess
 
 
 def _hf_cache_command(hf_cache_hub_root: str | Path | None) -> list[str]:
-    root = Path(hf_cache_hub_root or os.environ.get("HF_CACHE_HUB_ROOT", "")).expanduser()
-    if not str(root):
+    root_value = hf_cache_hub_root or os.environ.get("HF_CACHE_HUB_ROOT")
+    if not root_value:
         raise ArtifactPublishError("HF_CACHE_HUB_ROOT or --hf-cache-hub-root is required")
+    root = Path(root_value).expanduser()
     script = root / "scripts" / "artifact_manager.py"
     if not script.is_file():
         raise ArtifactPublishError(f"hf-cache-hub artifact CLI not found: {script}")

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
 
-from processing.artifact_publish import ArtifactPublishError, publish_run_splat
+from processing.artifact_publish import ArtifactPublishError, _hf_cache_command, publish_run_splat
 
 
 class ArtifactPublishTest(unittest.TestCase):
@@ -40,6 +42,11 @@ class ArtifactPublishTest(unittest.TestCase):
         (hf_root / "scripts").mkdir(parents=True)
         (hf_root / "scripts" / "artifact_manager.py").write_text("# cli", encoding="utf-8")
         return manifest, ply, sha, hf_root
+
+    def test_missing_hf_cache_hub_root_fails_with_required_error(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ArtifactPublishError, "HF_CACHE_HUB_ROOT"):
+                _hf_cache_command(None)
 
     def test_publish_records_remote_verified_provenance(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Improves the AutoPhotogrammetry producer integration with hf-cache-hub.

- fails explicitly when `HF_CACHE_HUB_ROOT` / `--hf-cache-hub-root` is missing instead of accidentally resolving `.`
- adds regression coverage for the missing-root case
- keeps existing local PLY hash/size validation and remote readback semantics unchanged

The companion artifact-storage guide is already on main at `docs/artifact-storage.md`.