### PR TITLE
3DGS: add pinned VGGT research backend for Blackwell

### DIFF
--- a/.github/workflows/vggt-image.yml
+++ b/.github/workflows/vggt-image.yml
@@ -1,0 +1,43 @@
+name: VGGT Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.vggt
+      - requirements.txt
+      - processing/vggt_backend.py
+      - processing/backend_evaluation.py
+      - processing/provenance.py
+      - task
+      - .github/workflows/vggt-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.vggt
+          push: true
+          tags: |
+            ghcr.io/kafka2306/autophotogrammetry:vggt-a288dd0-sm120-v1
+            ghcr.io/kafka2306/autophotogrammetry:vggt-sha-${{ github.sha }}
+          build-args: |
+            VGGT_REVISION=a288dd0f14786c93483e45524328726ab7b1b4ce
+            LIGHTGLUE_REVISION=746fac2c042e05d1865315b1413419f1c1e7ba55
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv/
 .ruff_cache/
+.cache/
 __pycache__/
 *.py[cod]
 .DS_Store

--- a/Dockerfile.vggt
+++ b/Dockerfile.vggt
@@ -1,0 +1,89 @@
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG VGGT_REVISION=a288dd0f14786c93483e45524328726ab7b1b4ce
+ARG LIGHTGLUE_REVISION=746fac2c042e05d1865315b1413419f1c1e7ba55
+ENV CUDA_HOME=/usr/local/cuda \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+LABEL org.opencontainers.image.source="https://github.com/KAFKA2306/AutoPhotogrammetry" \
+      org.opencontainers.image.description="Pinned VGGT COLMAP research backend adapted to Blackwell-compatible PyTorch/CUDA"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        python3 \
+        python3-dev \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
+
+# Upstream VGGT still pins torch 2.3.1 in requirements.txt. That runtime predates
+# Blackwell support, so the execution image intentionally preserves the exact
+# VGGT source revision while using the same CUDA 12.8 / PyTorch 2.7.1 runtime as
+# AutoPhotogrammetry's sm_120 quality image. The deviation is explicit and tested.
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
+    && python -m pip install --no-cache-dir \
+        torch==2.7.1 torchvision==0.22.1 \
+        --index-url https://download.pytorch.org/whl/cu128
+
+RUN git init /opt/vggt \
+    && git -C /opt/vggt remote add origin https://github.com/facebookresearch/vggt.git \
+    && git -C /opt/vggt fetch --depth 1 origin "${VGGT_REVISION}" \
+    && git -C /opt/vggt checkout --detach FETCH_HEAD \
+    && test "$(git -C /opt/vggt rev-parse HEAD)" = "${VGGT_REVISION}"
+
+RUN git init /opt/lightglue \
+    && git -C /opt/lightglue remote add origin https://github.com/cvg/LightGlue.git \
+    && git -C /opt/lightglue fetch --depth 1 origin "${LIGHTGLUE_REVISION}" \
+    && git -C /opt/lightglue checkout --detach FETCH_HEAD \
+    && test "$(git -C /opt/lightglue rev-parse HEAD)" = "${LIGHTGLUE_REVISION}"
+
+# Install the model/demo dependencies without letting VGGT's historical torch pin
+# downgrade the Blackwell-capable runtime. demo_colmap.py imports track support at
+# module load even when --use_ba is disabled, so LightGlue is installed explicitly.
+RUN python -m pip install --no-cache-dir \
+        numpy==1.26.1 \
+        Pillow \
+        huggingface_hub \
+        einops \
+        safetensors \
+        tqdm \
+        hydra-core \
+        omegaconf \
+        opencv-python-headless \
+        scipy \
+        requests \
+        trimesh \
+        matplotlib \
+        pydantic==2.10.6 \
+        pycolmap==3.10.0 \
+        pyceres==2.3 \
+    && python -m pip install --no-cache-dir --no-deps /opt/lightglue \
+    && python -m pip install --no-cache-dir --no-deps /opt/vggt
+
+COPY requirements.txt /tmp/autophotogrammetry-requirements.txt
+RUN python -m pip install --no-cache-dir -r /tmp/autophotogrammetry-requirements.txt
+
+COPY . /opt/autophotogrammetry
+WORKDIR /opt/autophotogrammetry
+
+RUN python - <<'PY'
+import subprocess
+import torch
+import vggt
+import pycolmap
+from lightglue import ALIKED, SuperPoint
+
+vggt_rev = subprocess.run(
+    ["git", "-C", "/opt/vggt", "rev-parse", "HEAD"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+assert vggt_rev == "a288dd0f14786c93483e45524328726ab7b1b4ce", vggt_rev
+assert torch.__version__.startswith("2.7.1"), torch.__version__
+print({"vggt_revision": vggt_rev, "torch": torch.__version__, "pycolmap": pycolmap.__version__})
+PY

--- a/Dockerfile.vggt
+++ b/Dockerfile.vggt
@@ -61,11 +61,13 @@ RUN python -m pip install --no-cache-dir \
         pydantic==2.10.6 \
         pycolmap==3.10.0 \
         pyceres==2.3 \
+        kornia==0.7.4 \
     && python -m pip install --no-cache-dir --no-deps /opt/lightglue \
     && python -m pip install --no-cache-dir --no-deps /opt/vggt
 
 COPY requirements.txt /tmp/autophotogrammetry-requirements.txt
-RUN python -m pip install --no-cache-dir -r /tmp/autophotogrammetry-requirements.txt
+RUN python -m pip install --no-cache-dir -r /tmp/autophotogrammetry-requirements.txt \
+    && python -m pip check
 
 COPY . /opt/autophotogrammetry
 WORKDIR /opt/autophotogrammetry

--- a/processing/vggt_backend.py
+++ b/processing/vggt_backend.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from processing.backend_evaluation import (
+    artifact_record,
+    dataset_identity,
+    empty_metrics,
+    validate_backend_result,
+)
+from processing.provenance import sha256_file, write_json
+
+VGGT_REPOSITORY = "https://github.com/facebookresearch/vggt"
+VGGT_REVISION = "a288dd0f14786c93483e45524328726ab7b1b4ce"
+VGGT_DEMO_CHECKPOINT_ID = "facebook/VGGT-1B"
+VGGT_DEMO_CHECKPOINT_URL = "https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt"
+VGGT_DEMO_CHECKPOINT_USAGE = "non-commercial-research-only"
+VGGT_COMMERCIAL_CHECKPOINT_ID = "facebook/VGGT-1B-Commercial"
+REQUIRED_COLMAP_FILES = ("cameras.bin", "images.bin", "points3D.bin")
+
+
+def _git_head(checkout: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(checkout), "rev-parse", "HEAD"],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(f"VGGT checkout is not a readable Git checkout: {checkout}")
+    return completed.stdout.strip()
+
+
+def verify_vggt_checkout(checkout: str | Path) -> dict:
+    root = Path(checkout).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"VGGT checkout does not exist: {root}")
+    revision = _git_head(root)
+    if revision != VGGT_REVISION:
+        raise ValueError(
+            f"VGGT revision mismatch: expected {VGGT_REVISION}, got {revision}"
+        )
+    demo = root / "demo_colmap.py"
+    if not demo.is_file():
+        raise ValueError(f"pinned VGGT checkout is missing demo_colmap.py: {demo}")
+    source = demo.read_text(encoding="utf-8")
+    if VGGT_DEMO_CHECKPOINT_URL not in source:
+        raise ValueError(
+            "pinned demo_colmap.py no longer contains the expected research checkpoint URL; "
+            "re-audit checkpoint semantics before execution"
+        )
+    return {
+        "repository": VGGT_REPOSITORY,
+        "revision": revision,
+        "checkout": str(root),
+        "demo_script": str(demo),
+        "checkpoint": {
+            "id": VGGT_DEMO_CHECKPOINT_ID,
+            "url": VGGT_DEMO_CHECKPOINT_URL,
+            "usage": VGGT_DEMO_CHECKPOINT_USAGE,
+            "production_eligible": False,
+            "commercial_checkpoint_id": VGGT_COMMERCIAL_CHECKPOINT_ID,
+            "note": (
+                "The pinned official demo hard-codes VGGT-1B. It is used only for research "
+                "comparison; commercial checkpoint access is not inferred or fabricated."
+            ),
+        },
+    }
+
+
+def _read_json(path: str | Path) -> dict:
+    source = Path(path).expanduser().resolve()
+    value = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {source}")
+    return value
+
+
+def _frame_sources(transforms_json: Path) -> dict[str, Path]:
+    meta = _read_json(transforms_json)
+    frames = meta.get("frames")
+    if not isinstance(frames, list):
+        raise ValueError("Nerfstudio transforms.json requires frames")
+    by_hash: dict[str, Path] = {}
+    for frame in frames:
+        declared = frame.get("file_path")
+        if not declared:
+            raise ValueError("Nerfstudio frame is missing file_path")
+        candidate = Path(str(declared))
+        source = (candidate if candidate.is_absolute() else transforms_json.parent / candidate).resolve()
+        if not source.is_file():
+            raise ValueError(f"Nerfstudio frame does not exist: {source}")
+        digest = sha256_file(source)
+        if digest in by_hash:
+            raise ValueError(f"duplicate frame SHA-256 in transforms: {digest}")
+        by_hash[digest] = source
+    return by_hash
+
+
+def materialize_vggt_scene(
+    dataset: Mapping,
+    transforms_json: str | Path,
+    scene_dir: str | Path,
+) -> dict:
+    """Copy the exact #26 frame set into the official VGGT `<scene>/images` layout."""
+    transforms = Path(transforms_json).expanduser().resolve()
+    sources = _frame_sources(transforms)
+    scene = Path(scene_dir).expanduser().resolve()
+    if scene.exists():
+        shutil.rmtree(scene)
+    images = scene / "images"
+    images.mkdir(parents=True)
+
+    expected = {
+        str(record["sha256"]): dict(record)
+        for record in dataset.get("frames") or []
+    }
+    if not expected:
+        raise ValueError("dataset contract has no frames")
+    if set(expected) != set(sources):
+        missing = sorted(set(expected) - set(sources))
+        extra = sorted(set(sources) - set(expected))
+        raise ValueError(f"dataset/transforms frame mismatch; missing={missing}, extra={extra}")
+
+    used_names: set[str] = set()
+    records = []
+    for index, record in enumerate(dataset["frames"], start=1):
+        digest = str(record["sha256"])
+        source = sources[digest]
+        suffix = source.suffix.lower() or ".jpg"
+        name = f"{index:04d}-{digest[:12]}{suffix}"
+        if name in used_names:
+            raise ValueError(f"duplicate materialized VGGT frame name: {name}")
+        used_names.add(name)
+        destination = images / name
+        shutil.copy2(source, destination)
+        actual = sha256_file(destination)
+        if actual != digest:
+            raise RuntimeError(
+                f"materialized VGGT frame hash mismatch: expected {digest}, got {actual}"
+            )
+        records.append(
+            {
+                "name": name,
+                "source_path": str(source),
+                "sha256": digest,
+                "size_bytes": destination.stat().st_size,
+                "split": record.get("split"),
+            }
+        )
+
+    manifest = {
+        "schema_version": 1,
+        "dataset_id": dataset_identity(dataset),
+        "scene_dir": str(scene),
+        "images_dir": str(images),
+        "frame_count": len(records),
+        "frames": records,
+    }
+    write_json(scene / "input-manifest.json", manifest)
+    return manifest
+
+
+def _run_command(command: Sequence[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(map(str, command)),
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def _colmap_artifact(scene: Path) -> dict:
+    sparse = scene / "sparse"
+    files = []
+    for name in REQUIRED_COLMAP_FILES:
+        path = sparse / name
+        if not path.is_file() or path.stat().st_size <= 0:
+            raise RuntimeError(f"VGGT did not produce required COLMAP artifact: {path}")
+        files.append(
+            {
+                "path": str(path),
+                "name": name,
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+        )
+    points = sparse / "points.ply"
+    if points.is_file() and points.stat().st_size > 0:
+        files.append(
+            {
+                "path": str(points),
+                "name": points.name,
+                "size_bytes": points.stat().st_size,
+                "sha256": sha256_file(points),
+            }
+        )
+    manifest = {
+        "schema_version": 1,
+        "format": "colmap-sparse",
+        "files": files,
+    }
+    manifest_path = scene / "colmap-artifact.json"
+    write_json(manifest_path, manifest)
+    return {**manifest, "manifest_path": str(manifest_path)}
+
+
+def run_vggt_colmap(
+    dataset_json: str | Path,
+    transforms_json: str | Path,
+    checkout: str | Path,
+    output_root: str | Path,
+    *,
+    python_executable: str = "python",
+    use_ba: bool = False,
+) -> dict:
+    """Run the pinned official VGGT COLMAP exporter as a research-only backend."""
+    dataset = _read_json(dataset_json)
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    scene = root / "scene"
+    checkout_info = verify_vggt_checkout(checkout)
+    input_manifest = materialize_vggt_scene(dataset, transforms_json, scene)
+
+    command = [
+        python_executable,
+        checkout_info["demo_script"],
+        "--scene_dir",
+        str(scene),
+    ]
+    if use_ba:
+        command.append("--use_ba")
+
+    started = time.perf_counter()
+    completed = _run_command(command, cwd=Path(checkout_info["checkout"]))
+    elapsed = time.perf_counter() - started
+    (root / "vggt.stdout.log").write_text(completed.stdout or "", encoding="utf-8")
+    (root / "vggt.stderr.log").write_text(completed.stderr or "", encoding="utf-8")
+
+    metrics = empty_metrics()
+    metrics.update(
+        {
+            "input_frame_count": len(dataset.get("frames") or []),
+            "train_frame_count": len(dataset.get("train_frame_sha256") or []),
+            "holdout_frame_count": len(dataset.get("holdout_frame_sha256") or []),
+            "wall_clock_seconds": elapsed,
+            "peak_gpu_memory_bytes": None,
+            "camera_pose_available": completed.returncode == 0,
+            "reconstruction_success": completed.returncode == 0,
+        }
+    )
+
+    artifact = None
+    failure_phase = None
+    error = None
+    status = "success"
+    if completed.returncode != 0:
+        status = "failed"
+        failure_phase = "vggt-colmap"
+        error = f"VGGT demo_colmap.py exited with code {completed.returncode}"
+    else:
+        try:
+            artifact_manifest = _colmap_artifact(scene)
+            artifact = artifact_record(
+                artifact_manifest["manifest_path"],
+                format="colmap-sparse-manifest",
+            )
+        except Exception as exc:
+            status = "failed"
+            failure_phase = "artifact-validation"
+            metrics["reconstruction_success"] = False
+            metrics["camera_pose_available"] = False
+            error = f"{type(exc).__name__}: {exc}"
+
+    result = {
+        "schema_version": 1,
+        "dataset_id": dataset_identity(dataset),
+        "backend": {
+            "name": "vggt-colmap-research",
+            "upstream_revision": checkout_info["revision"],
+        },
+        "command": command,
+        "config": {
+            "use_ba": use_ba,
+            "checkpoint": checkout_info["checkpoint"],
+            "input_manifest": str(scene / "input-manifest.json"),
+            "production_eligible": False,
+        },
+        "return_code": completed.returncode,
+        "status": status,
+        "failure_phase": failure_phase,
+        "artifact": artifact,
+        "metrics": metrics,
+        "error": error,
+        "upstream": checkout_info,
+        "input": input_manifest,
+        "stdout_log": str(root / "vggt.stdout.log"),
+        "stderr_log": str(root / "vggt.stderr.log"),
+    }
+    validate_backend_result(result, dataset)
+    result_path = root / "backend-result.json"
+    write_json(result_path, result)
+    return {**result, "manifest_path": str(result_path)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the pinned official VGGT demo_colmap.py as a research-only camera/geometry backend."
+        )
+    )
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--transforms", required=True)
+    parser.add_argument("--checkout", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--python", default="python")
+    parser.add_argument("--use-ba", action="store_true")
+    args = parser.parse_args()
+    result = run_vggt_colmap(
+        args.dataset,
+        args.transforms,
+        args.checkout,
+        args.output_root,
+        python_executable=args.python,
+        use_ba=args.use_ba,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if result["status"] != "success":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/task
+++ b/task
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE="${AUTOPHOTOGRAMMETRY_IMAGE:-ghcr.io/kafka2306/autophotogrammetry:quality-ns50e0e3-sm120-v1}"
+VGGT_IMAGE="${AUTOPHOTOGRAMMETRY_VGGT_IMAGE:-ghcr.io/kafka2306/autophotogrammetry:vggt-a288dd0-sm120-v1}"
 HOST_GPU_ARCH="${AUTOPHOTOGRAMMETRY_CUDA_ARCH:-12.0}"
 
 check_docker() {
@@ -20,8 +21,17 @@ build_image() {
   docker build --pull --build-arg "CUDA_ARCH_LIST=$HOST_GPU_ARCH" -t "$IMAGE" "$ROOT"
 }
 
-pull_image() {
-  if docker pull "$IMAGE"; then
+build_vggt_image() {
+  docker build --pull \
+    -f "$ROOT/Dockerfile.vggt" \
+    --build-arg VGGT_REVISION=a288dd0f14786c93483e45524328726ab7b1b4ce \
+    --build-arg LIGHTGLUE_REVISION=746fac2c042e05d1865315b1413419f1c1e7ba55 \
+    -t "$VGGT_IMAGE" "$ROOT"
+}
+
+pull_named_image() {
+  local image="$1"
+  if docker pull "$image"; then
     return 0
   fi
 
@@ -30,12 +40,17 @@ pull_image() {
     login="$(gh api user --jq .login)"
     token="$(gh auth token)"
     printf '%s' "$token" | docker login ghcr.io -u "$login" --password-stdin >/dev/null
-    docker pull "$IMAGE"
+    docker pull "$image"
     return 0
   fi
 
-  echo "Prebuilt GPU image is unavailable. The local quality path intentionally does not build dependencies; publish the GPU Image workflow or authenticate gh/docker to GHCR." >&2
+  echo "Prebuilt image is unavailable: $image" >&2
+  echo "Publish the matching image workflow or authenticate gh/docker to GHCR. The local GPU path does not build dependencies implicitly." >&2
   return 1
+}
+
+pull_image() {
+  pull_named_image "$IMAGE"
 }
 
 ensure_image() {
@@ -45,13 +60,20 @@ ensure_image() {
   pull_image
 }
 
+ensure_vggt_image() {
+  if docker image inspect "$VGGT_IMAGE" >/dev/null 2>&1; then
+    return 0
+  fi
+  pull_named_image "$VGGT_IMAGE"
+}
+
 check_host_gpu() {
   if ! command -v nvidia-smi >/dev/null 2>&1; then
     return 0
   fi
   HOST_GPU_ARCH="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n 1 | tr -d '[:space:]')"
   if ! awk -v capability="$HOST_GPU_ARCH" 'BEGIN { exit !(capability >= 12.0 && capability < 13.0) }'; then
-    echo "GPU compute capability ${HOST_GPU_ARCH:-unknown} does not match the prebuilt sm_120 quality image. Override AUTOPHOTOGRAMMETRY_IMAGE/CUDA_ARCH only with another explicitly built image." >&2
+    echo "GPU compute capability ${HOST_GPU_ARCH:-unknown} does not match the prebuilt sm_120 images. Override the image/CUDA_ARCH only with another explicitly built image." >&2
     return 1
   fi
 }
@@ -70,6 +92,24 @@ run_gpu() {
     -v "$ROOT/output:/workspace/output" \
     -w /opt/autophotogrammetry \
     "$IMAGE" "$@"
+}
+
+run_vggt_gpu() {
+  local image_id
+  image_id="$(docker image inspect --format '{{.Id}}' "$VGGT_IMAGE" 2>/dev/null || true)"
+  mkdir -p "$ROOT/input" "$ROOT/output" "$ROOT/.cache/vggt"
+  docker run --rm --gpus all --shm-size=12g \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
+    -e TORCH_HOME=/tmp/.cache/torch \
+    -e HF_HOME=/tmp/.cache/huggingface \
+    -e AUTOPHOTOGRAMMETRY_VGGT_IMAGE_REF="$VGGT_IMAGE" \
+    -e AUTOPHOTOGRAMMETRY_VGGT_IMAGE_ID="$image_id" \
+    -v "$ROOT/input:/workspace/input" \
+    -v "$ROOT/output:/workspace/output" \
+    -v "$ROOT/.cache/vggt:/tmp/.cache" \
+    -w /opt/autophotogrammetry \
+    "$VGGT_IMAGE" "$@"
 }
 
 run_cpu() {
@@ -125,9 +165,18 @@ case "${1:-run}" in
     check_host_gpu
     build_image
     ;;
+  vggt-image)
+    check_docker
+    check_host_gpu
+    build_vggt_image
+    ;;
   pull)
     check_docker
     pull_image
+    ;;
+  vggt-pull)
+    check_docker
+    pull_named_image "$VGGT_IMAGE"
     ;;
   doctor)
     doctor
@@ -214,6 +263,37 @@ case "${1:-run}" in
       --iterations "$current_iterations" \
       --iterations "$increased_iterations"
     ;;
+  vggt-research)
+    scene="${2:-}"
+    mode="${3:-feedforward}"
+    if [[ -z "$scene" ]]; then
+      echo "usage: ./task vggt-research <scene-id> [feedforward|ba]" >&2
+      exit 2
+    fi
+    require_quality_inputs "$scene"
+    dataset="$ROOT/output/$scene/quality-sweep/evaluation-dataset.json"
+    if [[ ! -f "$dataset" ]]; then
+      echo "Frozen #26 dataset contract is missing: $dataset" >&2
+      echo "Run ./task quality $scene first; VGGT does not invent a second train/hold-out split." >&2
+      exit 1
+    fi
+    check_docker
+    check_host_gpu
+    ensure_vggt_image
+    extra=()
+    if [[ "$mode" == "ba" ]]; then
+      extra+=(--use-ba)
+    elif [[ "$mode" != "feedforward" ]]; then
+      echo "VGGT mode must be feedforward or ba" >&2
+      exit 2
+    fi
+    run_vggt_gpu python -m processing.vggt_backend \
+      --dataset "/workspace/output/$scene/quality-sweep/evaluation-dataset.json" \
+      --transforms "/workspace/output/$scene/nerfstudio-data/transforms.json" \
+      --checkout /opt/vggt \
+      --output-root "/workspace/output/$scene/vggt-colmap" \
+      "${extra[@]}"
+    ;;
   clean)
     find "$ROOT/output" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
     ;;
@@ -221,7 +301,7 @@ case "${1:-run}" in
     find "$ROOT/output" "$ROOT/input" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
     ;;
   *)
-    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|quality-pair <bad-scene> <good-control> [iterations]|quality-culling <scene> <winner> <parameter> <value> [iterations]|quality-budget <scene> <winner> <current-iterations> <increased-iterations>|doctor|pull|test|image|clean|clean-all}" >&2
+    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|quality-pair <bad-scene> <good-control> [iterations]|quality-culling <scene> <winner> <parameter> <value> [iterations]|quality-budget <scene> <winner> <current-iterations> <increased-iterations>|vggt-research <scene> [feedforward|ba]|doctor|pull|vggt-pull|test|image|vggt-image|clean|clean-all}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_vggt_backend.py
+++ b/tests/test_vggt_backend.py
@@ -1,0 +1,137 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import build_nerfstudio_dataset_contract
+from processing.vggt_backend import (
+    VGGT_DEMO_CHECKPOINT_URL,
+    VGGT_REVISION,
+    materialize_vggt_scene,
+    run_vggt_colmap,
+    verify_vggt_checkout,
+)
+
+
+class VggtBackendTests(unittest.TestCase):
+    def _fixture(self, root: Path):
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(4):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                    ],
+                }
+            )
+        transforms = data / "transforms.json"
+        transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+        dataset = build_nerfstudio_dataset_contract(source, transforms, holdout_count=1)
+        dataset_path = root / "dataset.json"
+        dataset_path.write_text(json.dumps(dataset), encoding="utf-8")
+
+        checkout = root / "vggt"
+        checkout.mkdir()
+        (checkout / "demo_colmap.py").write_text(
+            f'_URL = "{VGGT_DEMO_CHECKPOINT_URL}"\n', encoding="utf-8"
+        )
+        return dataset, dataset_path, transforms, checkout
+
+    def test_checkout_requires_exact_revision_and_research_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, _, _, checkout = self._fixture(root)
+            with patch("processing.vggt_backend._git_head", return_value=VGGT_REVISION):
+                info = verify_vggt_checkout(checkout)
+            self.assertEqual(info["revision"], VGGT_REVISION)
+            self.assertFalse(info["checkpoint"]["production_eligible"])
+            self.assertEqual(info["checkpoint"]["usage"], "non-commercial-research-only")
+
+            with patch("processing.vggt_backend._git_head", return_value="wrong"):
+                with self.assertRaisesRegex(ValueError, "revision mismatch"):
+                    verify_vggt_checkout(checkout)
+
+    def test_materialization_preserves_dataset_hashes_and_split(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset, _, transforms, _ = self._fixture(root)
+            manifest = materialize_vggt_scene(dataset, transforms, root / "scene")
+            self.assertEqual(manifest["frame_count"], 4)
+            self.assertEqual(
+                {entry["sha256"] for entry in manifest["frames"]},
+                {entry["sha256"] for entry in dataset["frames"]},
+            )
+            self.assertEqual(
+                sum(entry["split"] == "holdout" for entry in manifest["frames"]),
+                1,
+            )
+
+    def test_success_records_colmap_artifact_and_never_claims_production(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset, dataset_path, transforms, checkout = self._fixture(root)
+
+            def fake_run(command, *, cwd):
+                scene = Path(command[command.index("--scene_dir") + 1])
+                sparse = scene / "sparse"
+                sparse.mkdir(parents=True)
+                for name in ("cameras.bin", "images.bin", "points3D.bin"):
+                    (sparse / name).write_bytes(name.encode())
+                (sparse / "points.ply").write_bytes(b"ply")
+                return subprocess.CompletedProcess(command, 0, "ok", "")
+
+            with patch("processing.vggt_backend._git_head", return_value=VGGT_REVISION), patch(
+                "processing.vggt_backend._run_command", side_effect=fake_run
+            ):
+                result = run_vggt_colmap(
+                    dataset_path,
+                    transforms,
+                    checkout,
+                    root / "out",
+                )
+
+            self.assertEqual(result["status"], "success")
+            self.assertTrue(result["metrics"]["camera_pose_available"])
+            self.assertEqual(result["artifact"]["format"], "colmap-sparse-manifest")
+            self.assertFalse(result["config"]["production_eligible"])
+            self.assertEqual(
+                result["dataset_id"],
+                __import__("processing.backend_evaluation", fromlist=["dataset_identity"]).dataset_identity(dataset),
+            )
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+
+    def test_command_failure_is_explicit_failed_result(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, dataset_path, transforms, checkout = self._fixture(root)
+            failed = subprocess.CompletedProcess(["python"], 9, "", "gpu failed")
+            with patch("processing.vggt_backend._git_head", return_value=VGGT_REVISION), patch(
+                "processing.vggt_backend._run_command", return_value=failed
+            ):
+                result = run_vggt_colmap(
+                    dataset_path,
+                    transforms,
+                    checkout,
+                    root / "out",
+                )
+            self.assertEqual(result["status"], "failed")
+            self.assertEqual(result["failure_phase"], "vggt-colmap")
+            self.assertFalse(result["metrics"]["reconstruction_success"])
+            self.assertIsNone(result["artifact"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Remove the repository-side adapter/environment gap in #27 without pretending the pinned official demo is commercially deployable.

## Upstream facts fixed by this PR

- VGGT source revision: `a288dd0f14786c93483e45524328726ab7b1b4ce`
- official `demo_colmap.py` exports COLMAP sparse models
- the pinned official demo hard-codes `https://huggingface.co/facebook/VGGT-1B/resolve/main/model.pt`
- that checkpoint is treated as research/non-commercial in this execution path
- `facebook/VGGT-1B-Commercial` is recorded only as the separate commercial checkpoint authority; access is never fabricated
- upstream `requirements.txt` still pins Torch 2.3.1, which is not used for the sm_120 target image; the source revision stays exact while the dedicated execution image uses PyTorch 2.7.1/cu128

## Changes

- add `processing.vggt_backend`:
  - verifies exact VGGT checkout HEAD
  - verifies the expected hard-coded research checkpoint URL is still present
  - materializes the exact existing #26 dataset frame hashes into official `<scene>/images` layout
  - never creates a second train/hold-out split
  - runs official `demo_colmap.py` with `shell=False`
  - verifies/hashes `cameras.bin`, `images.bin`, `points3D.bin` and optional `points.ply`
  - emits a validated #26 backend-result row and explicit failure phase
  - always records `production_eligible=false` for this pinned official-demo path
- add unit tests for revision mismatch, exact-frame materialization, successful COLMAP evidence, and explicit failure
- add `Dockerfile.vggt`, isolated from the Splatfacto production/quality image
  - CUDA 12.8.1
  - PyTorch 2.7.1/cu128 for Blackwell/sm_120
  - exact VGGT source revision
  - exact LightGlue revision `746fac2...` (the upstream commit explicitly tested Torch 2.7.1 compatibility)
  - demo dependencies including pycolmap/pyceres
- add `VGGT Image` GHCR workflow
- add `./task vggt-research <scene-id> [feedforward|ba]`
  - requires the pre-existing `quality-sweep/evaluation-dataset.json`
  - one GPU container invocation
  - persistent local model cache under ignored `.cache/vggt`
  - never builds dependencies implicitly during the GPU run

## Evidence boundary

This PR supplies repository/test evidence, not an actual target-GPU VGGT result. The official demo path remains research-only. A production VGGT path requires a commercially permitted checkpoint and a separately validated execution path; this PR does not patch the official demo to silently swap checkpoints.

Related: #26, #27.