### PR TITLE
3DGS: connect VGGT camera geometry through Splatfacto comparison

### DIFF
--- a/processing/vggt_splatfacto.py
+++ b/processing/vggt_splatfacto.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from processing.backend_evaluation import (
+    artifact_record,
+    build_nerfstudio_dataset_contract,
+    dataset_identity,
+    gaussian_artifact_metrics,
+    validate_backend_result,
+    write_comparison,
+    write_nerfstudio_split_transforms,
+)
+from processing.mcmc_quality import DEFAULT_NERFSTUDIO_SOURCE, verify_research_environment
+from processing.nerfstudio import (
+    nerfstudio_process_images_command,
+    run_nerfstudio_eval,
+    run_splatfacto_export,
+)
+from processing.provenance import sha256_file, write_json
+from processing.quality_sweep import quality_sweep_train_args, verify_gpu_runtime
+
+REQUIRED_COLMAP_FILES = ("cameras.bin", "images.bin", "points3D.bin")
+
+
+def _read_json(path: str | Path) -> dict:
+    source = Path(path).expanduser().resolve()
+    value = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {source}")
+    return value
+
+
+def _hash_files(root: Path) -> dict[str, Path]:
+    by_hash: dict[str, Path] = {}
+    for path in sorted(root.iterdir()):
+        if not path.is_file():
+            continue
+        digest = sha256_file(path)
+        if digest in by_hash:
+            raise ValueError(f"duplicate frame SHA-256 in VGGT image directory: {digest}")
+        by_hash[digest] = path
+    return by_hash
+
+
+def _materialize_exact_images(dataset: Mapping, source_images: Path, destination: Path) -> list[dict]:
+    """Copy the frozen #26 image bytes into Nerfstudio's required `images/` directory."""
+    expected = {str(record["sha256"]): dict(record) for record in dataset.get("frames") or []}
+    actual = _hash_files(source_images)
+    if set(expected) != set(actual):
+        missing = sorted(set(expected) - set(actual))
+        extra = sorted(set(actual) - set(expected))
+        raise ValueError(f"VGGT images do not match the frozen dataset; missing={missing}, extra={extra}")
+
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+    records = []
+    for digest, source in sorted(actual.items()):
+        target = destination / source.name
+        shutil.copy2(source, target)
+        copied = sha256_file(target)
+        if copied != digest:
+            raise RuntimeError(f"copied frame hash mismatch: expected {digest}, got {copied}")
+        records.append({"path": str(target), "sha256": digest, "size_bytes": target.stat().st_size})
+    return records
+
+
+def _verify_colmap_sparse(sparse: Path) -> list[dict]:
+    files = []
+    for name in REQUIRED_COLMAP_FILES:
+        path = sparse / name
+        if not path.is_file() or path.stat().st_size <= 0:
+            raise ValueError(f"required VGGT COLMAP file is missing: {path}")
+        files.append({"path": str(path), "size_bytes": path.stat().st_size, "sha256": sha256_file(path)})
+    return files
+
+
+def _run_recorded(command: Sequence[str], *, cwd: Path, stdout: Path, stderr: Path) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        list(map(str, command)),
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    stdout.write_text(completed.stdout or "", encoding="utf-8")
+    stderr.write_text(completed.stderr or "", encoding="utf-8")
+    return completed
+
+
+def prepare_vggt_nerfstudio_data(
+    dataset: Mapping,
+    vggt_scene: str | Path,
+    output_dir: str | Path,
+    *,
+    process_executable: str = "ns-process-data",
+) -> dict:
+    """Convert a VGGT COLMAP model without re-running COLMAP or changing frame bytes."""
+    scene = Path(vggt_scene).expanduser().resolve()
+    source_images = scene / "images"
+    sparse = scene / "sparse"
+    if not source_images.is_dir():
+        raise ValueError(f"VGGT image directory does not exist: {source_images}")
+    sparse_files = _verify_colmap_sparse(sparse)
+
+    output = Path(output_dir).expanduser().resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    images = output / "images"
+    image_records = _materialize_exact_images(dataset, source_images, images)
+
+    command = nerfstudio_process_images_command(
+        images,
+        output,
+        executable=process_executable,
+        extra_args=(
+            "--skip-colmap",
+            "--skip-image-processing",
+            "--colmap-model-path",
+            str(sparse),
+        ),
+    )
+    completed = _run_recorded(
+        command,
+        cwd=output,
+        stdout=output / "ns-process-data.stdout.log",
+        stderr=output / "ns-process-data.stderr.log",
+    )
+    if completed.returncode != 0:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            command,
+            output=completed.stdout,
+            stderr=completed.stderr,
+        )
+    transforms = output / "transforms.json"
+    if not transforms.is_file():
+        raise RuntimeError("ns-process-data succeeded but transforms.json is missing")
+
+    return {
+        "command": command,
+        "return_code": completed.returncode,
+        "transforms_path": str(transforms),
+        "images": image_records,
+        "colmap_sparse": sparse_files,
+        "stdout_log": str(output / "ns-process-data.stdout.log"),
+        "stderr_log": str(output / "ns-process-data.stderr.log"),
+    }
+
+
+def run_vggt_splatfacto(
+    dataset_json: str | Path,
+    source_video: str | Path,
+    vggt_scene: str | Path,
+    output_root: str | Path,
+    *,
+    baseline_result_json: str | Path | None = None,
+    iterations: int = 30000,
+    nerfstudio_source: str | Path = DEFAULT_NERFSTUDIO_SOURCE,
+    timeout: float | None = None,
+) -> dict:
+    """Run VGGT camera geometry through the same default Splatfacto/eval contract as baseline."""
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+    dataset = _read_json(dataset_json)
+    source = Path(source_video).expanduser().resolve()
+    if not source.is_file():
+        raise ValueError(f"source video does not exist: {source}")
+
+    runtime = verify_gpu_runtime()
+    environment = verify_research_environment(nerfstudio_source)
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+
+    prepared = prepare_vggt_nerfstudio_data(dataset, vggt_scene, root / "nerfstudio-data")
+    rebuilt = build_nerfstudio_dataset_contract(
+        source,
+        prepared["transforms_path"],
+        holdout_count=len(dataset.get("holdout_frame_sha256") or []),
+    )
+    expected_id = dataset_identity(dataset)
+    actual_id = dataset_identity(rebuilt)
+    if actual_id != expected_id:
+        raise RuntimeError(
+            f"VGGT-derived Nerfstudio data changed the frozen dataset identity: expected {expected_id}, got {actual_id}"
+        )
+
+    split = write_nerfstudio_split_transforms(
+        prepared["transforms_path"],
+        rebuilt,
+        root / "evaluation-transforms.json",
+    )
+    split_path = Path(split["transforms_path"])
+
+    started = time.perf_counter()
+    result = run_splatfacto_export(
+        split_path,
+        root / "run",
+        train_extra_args=quality_sweep_train_args(iterations=iterations, variant="default"),
+        timeout=timeout,
+        env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+    )
+    train_export_seconds = time.perf_counter() - started
+    manifest_path = Path(result["manifest_path"])
+    run_dir = manifest_path.parent
+    ply_path = run_dir / result["output"]["ply_path"]
+    config_path = run_dir / result["training"]["config_path"]
+    evaluation = run_nerfstudio_eval(
+        config_path,
+        run_dir / "evaluation",
+        timeout=timeout,
+        env={"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD": "1"},
+    )
+
+    metrics = {
+        "reconstruction_success": True,
+        "input_frame_count": len(rebuilt["frames"]),
+        "train_frame_count": len(rebuilt["train_frame_sha256"]),
+        "holdout_frame_count": len(rebuilt["holdout_frame_sha256"]),
+        "psnr": evaluation["metrics"].get("psnr"),
+        "ssim": evaluation["metrics"].get("ssim"),
+        "lpips": evaluation["metrics"].get("lpips"),
+        "wall_clock_seconds": train_export_seconds,
+        "peak_gpu_memory_bytes": (result.get("training") or {}).get("peak_gpu_memory_bytes"),
+        "camera_pose_available": True,
+        **gaussian_artifact_metrics(ply_path),
+    }
+    backend_result = {
+        "schema_version": 2,
+        "dataset_id": expected_id,
+        "backend": {
+            "name": "vggt-colmap-splatfacto",
+            "upstream_revision": f"vggt:a288dd0f14786c93483e45524328726ab7b1b4ce;nerfstudio:{environment['nerfstudio_revision']}",
+        },
+        "command": list(result["training"]["command"]),
+        "config": {
+            "iterations": iterations,
+            "camera_backend": "vggt-colmap-research",
+            "splatfacto_variant": "default",
+            "prepared_data": prepared,
+        },
+        "return_code": 0,
+        "status": "success",
+        "failure_phase": None,
+        "artifact": artifact_record(ply_path, format="ply"),
+        "metrics": metrics,
+        "training_manifest_path": str(manifest_path),
+        "evaluation_manifest_path": evaluation["manifest_path"],
+    }
+    validate_backend_result(backend_result, rebuilt)
+    backend_path = root / "backend-result.json"
+    write_json(backend_path, backend_result)
+
+    comparison_path = None
+    if baseline_result_json is not None:
+        baseline = _read_json(baseline_result_json)
+        validate_backend_result(baseline, rebuilt)
+        comparison_path = root / "comparison.json"
+        write_comparison(comparison_path, [baseline, backend_result], rebuilt)
+
+    summary = {
+        "schema_version": 1,
+        "status": "success",
+        "dataset_id": expected_id,
+        "runtime": runtime,
+        "environment": environment,
+        "prepared": prepared,
+        "backend_result_path": str(backend_path),
+        "comparison_path": None if comparison_path is None else str(comparison_path),
+        "ply_path": str(ply_path),
+        "ply_sha256": result["output"]["sha256"],
+        "ply_size_bytes": result["output"]["size_bytes"],
+        "metrics": metrics,
+        "render_count": evaluation.get("render_count"),
+        "renders": evaluation.get("renders"),
+    }
+    summary_path = root / "vggt-splatfacto.json"
+    summary["manifest_path"] = str(summary_path)
+    write_json(summary_path, summary)
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert the pinned VGGT COLMAP result to Nerfstudio, run default Splatfacto, and evaluate it."
+    )
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--source-video", required=True)
+    parser.add_argument("--vggt-scene", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--baseline-result")
+    parser.add_argument("--iterations", type=int, default=30000)
+    parser.add_argument("--nerfstudio-source", default=str(DEFAULT_NERFSTUDIO_SOURCE))
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_vggt_splatfacto(
+        args.dataset,
+        args.source_video,
+        args.vggt_scene,
+        args.output_root,
+        baseline_result_json=args.baseline_result,
+        iterations=args.iterations,
+        nerfstudio_source=args.nerfstudio_source,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/task
+++ b/task
@@ -143,6 +143,16 @@ require_quality_inputs() {
   fi
 }
 
+require_frozen_dataset() {
+  local scene="$1"
+  local dataset="$ROOT/output/$scene/quality-sweep/evaluation-dataset.json"
+  if [[ ! -f "$dataset" ]]; then
+    echo "Frozen #26 dataset contract is missing: $dataset" >&2
+    echo "Run ./task quality $scene first; research backends do not invent a second train/hold-out split." >&2
+    return 1
+  fi
+}
+
 prepare_quality_runtime() {
   check_docker
   check_host_gpu
@@ -156,6 +166,45 @@ run_quality_scene() {
     --data "/workspace/output/$scene/nerfstudio-data" \
     --source-video "/workspace/input/$scene/source.webm" \
     --output-root "/workspace/output/$scene/quality-sweep" \
+    --iterations "$iterations"
+}
+
+run_vggt_research_scene() {
+  local scene="$1"
+  local mode="$2"
+  local extra=()
+  if [[ "$mode" == "ba" ]]; then
+    extra+=(--use-ba)
+  elif [[ "$mode" != "feedforward" ]]; then
+    echo "VGGT mode must be feedforward or ba" >&2
+    return 2
+  fi
+  run_vggt_gpu python -m processing.vggt_backend \
+    --dataset "/workspace/output/$scene/quality-sweep/evaluation-dataset.json" \
+    --transforms "/workspace/output/$scene/nerfstudio-data/transforms.json" \
+    --checkout /opt/vggt \
+    --output-root "/workspace/output/$scene/vggt-colmap" \
+    "${extra[@]}"
+}
+
+run_vggt_splatfacto_scene() {
+  local scene="$1"
+  local iterations="$2"
+  local baseline="/workspace/output/$scene/quality-sweep/default/backend-result.json"
+  if [[ ! -f "$ROOT/output/$scene/quality-sweep/default/backend-result.json" ]]; then
+    echo "Default Splatfacto baseline result is missing: $ROOT/output/$scene/quality-sweep/default/backend-result.json" >&2
+    return 1
+  fi
+  if [[ ! -f "$ROOT/output/$scene/vggt-colmap/scene/sparse/cameras.bin" ]]; then
+    echo "VGGT COLMAP result is missing. Run ./task vggt-research $scene first." >&2
+    return 1
+  fi
+  run_gpu python -m processing.vggt_splatfacto \
+    --dataset "/workspace/output/$scene/quality-sweep/evaluation-dataset.json" \
+    --source-video "/workspace/input/$scene/source.webm" \
+    --vggt-scene "/workspace/output/$scene/vggt-colmap/scene" \
+    --output-root "/workspace/output/$scene/vggt-splatfacto" \
+    --baseline-result "$baseline" \
     --iterations "$iterations"
 }
 
@@ -271,28 +320,40 @@ case "${1:-run}" in
       exit 2
     fi
     require_quality_inputs "$scene"
-    dataset="$ROOT/output/$scene/quality-sweep/evaluation-dataset.json"
-    if [[ ! -f "$dataset" ]]; then
-      echo "Frozen #26 dataset contract is missing: $dataset" >&2
-      echo "Run ./task quality $scene first; VGGT does not invent a second train/hold-out split." >&2
-      exit 1
-    fi
+    require_frozen_dataset "$scene"
     check_docker
     check_host_gpu
     ensure_vggt_image
-    extra=()
-    if [[ "$mode" == "ba" ]]; then
-      extra+=(--use-ba)
-    elif [[ "$mode" != "feedforward" ]]; then
-      echo "VGGT mode must be feedforward or ba" >&2
+    run_vggt_research_scene "$scene" "$mode"
+    ;;
+  vggt-splatfacto)
+    scene="${2:-}"
+    iterations="${3:-30000}"
+    if [[ -z "$scene" ]]; then
+      echo "usage: ./task vggt-splatfacto <scene-id> [iterations]" >&2
       exit 2
     fi
-    run_vggt_gpu python -m processing.vggt_backend \
-      --dataset "/workspace/output/$scene/quality-sweep/evaluation-dataset.json" \
-      --transforms "/workspace/output/$scene/nerfstudio-data/transforms.json" \
-      --checkout /opt/vggt \
-      --output-root "/workspace/output/$scene/vggt-colmap" \
-      "${extra[@]}"
+    require_quality_inputs "$scene"
+    require_frozen_dataset "$scene"
+    prepare_quality_runtime
+    run_vggt_splatfacto_scene "$scene" "$iterations"
+    ;;
+  vggt-compare)
+    scene="${2:-}"
+    mode="${3:-feedforward}"
+    iterations="${4:-30000}"
+    if [[ -z "$scene" ]]; then
+      echo "usage: ./task vggt-compare <scene-id> [feedforward|ba] [iterations]" >&2
+      exit 2
+    fi
+    require_quality_inputs "$scene"
+    require_frozen_dataset "$scene"
+    check_docker
+    check_host_gpu
+    ensure_vggt_image
+    ensure_image
+    run_vggt_research_scene "$scene" "$mode"
+    run_vggt_splatfacto_scene "$scene" "$iterations"
     ;;
   clean)
     find "$ROOT/output" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
@@ -301,7 +362,7 @@ case "${1:-run}" in
     find "$ROOT/output" "$ROOT/input" -mindepth 1 -maxdepth 1 ! -name .gitignore -exec rm -rf -- {} +
     ;;
   *)
-    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|quality-pair <bad-scene> <good-control> [iterations]|quality-culling <scene> <winner> <parameter> <value> [iterations]|quality-budget <scene> <winner> <current-iterations> <increased-iterations>|vggt-research <scene> [feedforward|ba]|doctor|pull|vggt-pull|test|image|vggt-image|clean|clean-all}" >&2
+    echo "usage: ./task {run|run-all|quality [scene-id] [iterations]|quality-pair <bad-scene> <good-control> [iterations]|quality-culling <scene> <winner> <parameter> <value> [iterations]|quality-budget <scene> <winner> <current-iterations> <increased-iterations>|vggt-research <scene> [feedforward|ba]|vggt-splatfacto <scene> [iterations]|vggt-compare <scene> [feedforward|ba] [iterations]|doctor|pull|vggt-pull|test|image|vggt-image|clean|clean-all}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_vggt_splatfacto.py
+++ b/tests/test_vggt_splatfacto.py
@@ -51,7 +51,12 @@ class VggtSplatfactoTests(unittest.TestCase):
         sparse.mkdir(parents=True)
         by_hash = {record["sha256"]: record for record in dataset["frames"]}
         for index, (digest, _) in enumerate(sorted(by_hash.items()), start=1):
-            source_image = next(path for path in images.iterdir() if __import__("processing.provenance", fromlist=["sha256_file"]).sha256_file(path) == digest)
+            source_image = next(
+                path
+                for path in images.iterdir()
+                if __import__("processing.provenance", fromlist=["sha256_file"]).sha256_file(path)
+                == digest
+            )
             target = vggt_images / f"{index:04d}-{digest[:12]}.jpg"
             target.write_bytes(source_image.read_bytes())
         for name in ("cameras.bin", "images.bin", "points3D.bin"):
@@ -71,11 +76,18 @@ class VggtSplatfactoTests(unittest.TestCase):
                 frames = [
                     {
                         "file_path": f"./images/{path.name}",
-                        "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                        "transform_matrix": [
+                            [1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, 1],
+                        ],
                     }
                     for path in sorted(images_dir.iterdir())
                 ]
-                (output_dir / "transforms.json").write_text(json.dumps({"frames": frames}), encoding="utf-8")
+                (output_dir / "transforms.json").write_text(
+                    json.dumps({"frames": frames}), encoding="utf-8"
+                )
                 return subprocess.CompletedProcess(command, 0, "ok", "")
 
             with patch("processing.vggt_splatfacto._run_recorded", side_effect=fake_run):
@@ -88,7 +100,7 @@ class VggtSplatfactoTests(unittest.TestCase):
     def test_e2e_reuses_dataset_identity_and_writes_two_backend_comparison(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            source, dataset, dataset_path, transforms, scene = self._fixture(root)
+            source, dataset, dataset_path, _, scene = self._fixture(root)
             prepared_root = root / "prepared-source"
             prepared_images = prepared_root / "images"
             prepared_images.mkdir(parents=True)
@@ -97,12 +109,19 @@ class VggtSplatfactoTests(unittest.TestCase):
             prepared_frames = [
                 {
                     "file_path": f"images/{path.name}",
-                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                    "transform_matrix": [
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                    ],
                 }
                 for path in sorted(prepared_images.iterdir())
             ]
             prepared_transforms = prepared_root / "transforms.json"
-            prepared_transforms.write_text(json.dumps({"frames": prepared_frames}), encoding="utf-8")
+            prepared_transforms.write_text(
+                json.dumps({"frames": prepared_frames}), encoding="utf-8"
+            )
 
             baseline_artifact = root / "baseline.ply"
             baseline_artifact.write_bytes(b"baseline")
@@ -199,7 +218,9 @@ class VggtSplatfactoTests(unittest.TestCase):
             self.assertEqual(result["dataset_id"], dataset_identity(dataset))
             self.assertEqual(result["metrics"]["psnr"], 24.0)
             self.assertEqual(result["metrics"]["peak_gpu_memory_bytes"], 123)
-            comparison = json.loads(Path(result["comparison_path"]).read_text(encoding="utf-8"))
+            comparison = json.loads(
+                Path(result["comparison_path"]).read_text(encoding="utf-8")
+            )
             self.assertEqual(len(comparison["results"]), 2)
             self.assertEqual(
                 [row["backend"] for row in comparison["results"]],
@@ -213,20 +234,38 @@ class VggtSplatfactoTests(unittest.TestCase):
             prepared = root / "changed"
             images = prepared / "images"
             images.mkdir(parents=True)
-            (images / "wrong.jpg").write_bytes(b"wrong")
+            changed_frames = []
+            for index in range(2):
+                image = images / f"wrong-{index}.jpg"
+                image.write_bytes(f"wrong-{index}".encode())
+                changed_frames.append(
+                    {
+                        "file_path": f"images/{image.name}",
+                        "transform_matrix": [
+                            [1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, 1],
+                        ],
+                    }
+                )
             transforms = prepared / "transforms.json"
             transforms.write_text(
-                json.dumps({"frames": [{"file_path": "images/wrong.jpg", "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}]}),
+                json.dumps({"frames": changed_frames}),
                 encoding="utf-8",
             )
             with patch(
                 "processing.vggt_splatfacto.prepare_vggt_nerfstudio_data",
                 return_value={"transforms_path": str(transforms)},
-            ), patch("processing.vggt_splatfacto.verify_gpu_runtime", return_value={}), patch(
+            ), patch(
+                "processing.vggt_splatfacto.verify_gpu_runtime", return_value={}
+            ), patch(
                 "processing.vggt_splatfacto.verify_research_environment",
                 return_value={"nerfstudio_revision": "ns-rev"},
             ), patch("processing.vggt_splatfacto.run_splatfacto_export") as train:
-                with self.assertRaisesRegex(RuntimeError, "changed the frozen dataset identity"):
+                with self.assertRaisesRegex(
+                    RuntimeError, "changed the frozen dataset identity"
+                ):
                     run_vggt_splatfacto(dataset_path, source, scene, root / "out")
                 train.assert_not_called()
 

--- a/tests/test_vggt_splatfacto.py
+++ b/tests/test_vggt_splatfacto.py
@@ -1,0 +1,235 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import (
+    artifact_record,
+    build_nerfstudio_dataset_contract,
+    dataset_identity,
+)
+from processing.vggt_splatfacto import (
+    prepare_vggt_nerfstudio_data,
+    run_vggt_splatfacto,
+)
+
+
+class VggtSplatfactoTests(unittest.TestCase):
+    def _fixture(self, root: Path):
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        original = root / "original"
+        images = original / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(5):
+            image = images / f"image-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [
+                        [1, 0, 0, 0],
+                        [0, 1, 0, 0],
+                        [0, 0, 1, 0],
+                        [0, 0, 0, 1],
+                    ],
+                }
+            )
+        transforms = original / "transforms.json"
+        transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+        dataset = build_nerfstudio_dataset_contract(source, transforms, holdout_count=1)
+        dataset_path = root / "dataset.json"
+        dataset_path.write_text(json.dumps(dataset), encoding="utf-8")
+
+        scene = root / "vggt" / "scene"
+        vggt_images = scene / "images"
+        sparse = scene / "sparse"
+        vggt_images.mkdir(parents=True)
+        sparse.mkdir(parents=True)
+        by_hash = {record["sha256"]: record for record in dataset["frames"]}
+        for index, (digest, _) in enumerate(sorted(by_hash.items()), start=1):
+            source_image = next(path for path in images.iterdir() if __import__("processing.provenance", fromlist=["sha256_file"]).sha256_file(path) == digest)
+            target = vggt_images / f"{index:04d}-{digest[:12]}.jpg"
+            target.write_bytes(source_image.read_bytes())
+        for name in ("cameras.bin", "images.bin", "points3D.bin"):
+            (sparse / name).write_bytes(name.encode())
+        return source, dataset, dataset_path, transforms, scene
+
+    def test_prepare_uses_existing_colmap_and_preserves_image_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, dataset, _, _, scene = self._fixture(root)
+
+            def fake_run(command, *, cwd, stdout, stderr):
+                self.assertIn("--skip-colmap", command)
+                self.assertIn("--skip-image-processing", command)
+                output_dir = Path(command[command.index("--output-dir") + 1])
+                images_dir = output_dir / "images"
+                frames = [
+                    {
+                        "file_path": f"./images/{path.name}",
+                        "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                    }
+                    for path in sorted(images_dir.iterdir())
+                ]
+                (output_dir / "transforms.json").write_text(json.dumps({"frames": frames}), encoding="utf-8")
+                return subprocess.CompletedProcess(command, 0, "ok", "")
+
+            with patch("processing.vggt_splatfacto._run_recorded", side_effect=fake_run):
+                prepared = prepare_vggt_nerfstudio_data(dataset, scene, root / "prepared")
+
+            self.assertEqual(prepared["return_code"], 0)
+            self.assertEqual(len(prepared["images"]), 5)
+            self.assertTrue(Path(prepared["transforms_path"]).is_file())
+
+    def test_e2e_reuses_dataset_identity_and_writes_two_backend_comparison(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, dataset, dataset_path, transforms, scene = self._fixture(root)
+            prepared_root = root / "prepared-source"
+            prepared_images = prepared_root / "images"
+            prepared_images.mkdir(parents=True)
+            for path in sorted((scene / "images").iterdir()):
+                (prepared_images / path.name).write_bytes(path.read_bytes())
+            prepared_frames = [
+                {
+                    "file_path": f"images/{path.name}",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+                for path in sorted(prepared_images.iterdir())
+            ]
+            prepared_transforms = prepared_root / "transforms.json"
+            prepared_transforms.write_text(json.dumps({"frames": prepared_frames}), encoding="utf-8")
+
+            baseline_artifact = root / "baseline.ply"
+            baseline_artifact.write_bytes(b"baseline")
+            baseline = {
+                "schema_version": 2,
+                "dataset_id": dataset_identity(dataset),
+                "backend": {"name": "splatfacto-default", "upstream_revision": "ns-rev"},
+                "command": ["ns-train", "splatfacto"],
+                "config": {"variant": "default"},
+                "return_code": 0,
+                "status": "success",
+                "failure_phase": None,
+                "artifact": artifact_record(baseline_artifact, format="ply"),
+                "metrics": {},
+            }
+            baseline_path = root / "baseline.json"
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+            def fake_train(data, output_root, **kwargs):
+                run_dir = Path(output_root) / "splatfacto" / "run"
+                (run_dir / "export").mkdir(parents=True)
+                ply = run_dir / "export" / "splat.ply"
+                ply.write_bytes(b"vggt-ply")
+                config = run_dir / "config.yml"
+                config.write_text("config", encoding="utf-8")
+                manifest = run_dir / "manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "training": {
+                        "command": ["ns-train", "splatfacto"],
+                        "config_path": "config.yml",
+                        "peak_gpu_memory_bytes": 123,
+                    },
+                    "output": {
+                        "ply_path": "export/splat.ply",
+                        "sha256": "b" * 64,
+                        "size_bytes": 8,
+                    },
+                }
+
+            def fake_eval(config, output_root, **kwargs):
+                out = Path(output_root)
+                out.mkdir(parents=True)
+                manifest = out / "eval-manifest.json"
+                manifest.write_text("{}", encoding="utf-8")
+                return {
+                    "manifest_path": str(manifest),
+                    "metrics": {"psnr": 24.0, "ssim": 0.88, "lpips": 0.12},
+                    "render_count": 1,
+                    "renders": [],
+                }
+
+            artifact_metrics = {
+                "primitive_count": 10,
+                "output_size_bytes": 8,
+                "low_opacity_primitive_count": 1,
+                "low_opacity_primitive_ratio": 0.1,
+                "scale_anisotropy_above_10_count": 2,
+                "scale_anisotropy_above_10_ratio": 0.2,
+            }
+            with patch(
+                "processing.vggt_splatfacto.prepare_vggt_nerfstudio_data",
+                return_value={
+                    "transforms_path": str(prepared_transforms),
+                    "command": ["ns-process-data"],
+                    "return_code": 0,
+                },
+            ), patch(
+                "processing.vggt_splatfacto.verify_gpu_runtime",
+                return_value={"gpu": "test"},
+            ), patch(
+                "processing.vggt_splatfacto.verify_research_environment",
+                return_value={"nerfstudio_revision": "ns-rev"},
+            ), patch(
+                "processing.vggt_splatfacto.run_splatfacto_export",
+                side_effect=fake_train,
+            ), patch(
+                "processing.vggt_splatfacto.run_nerfstudio_eval",
+                side_effect=fake_eval,
+            ), patch(
+                "processing.vggt_splatfacto.gaussian_artifact_metrics",
+                return_value=artifact_metrics,
+            ):
+                result = run_vggt_splatfacto(
+                    dataset_path,
+                    source,
+                    scene,
+                    root / "out",
+                    baseline_result_json=baseline_path,
+                    iterations=30000,
+                )
+
+            self.assertEqual(result["dataset_id"], dataset_identity(dataset))
+            self.assertEqual(result["metrics"]["psnr"], 24.0)
+            self.assertEqual(result["metrics"]["peak_gpu_memory_bytes"], 123)
+            comparison = json.loads(Path(result["comparison_path"]).read_text(encoding="utf-8"))
+            self.assertEqual(len(comparison["results"]), 2)
+            self.assertEqual(
+                [row["backend"] for row in comparison["results"]],
+                ["splatfacto-default", "vggt-colmap-splatfacto"],
+            )
+
+    def test_changed_frame_set_is_rejected_before_training(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source, _, dataset_path, _, scene = self._fixture(root)
+            prepared = root / "changed"
+            images = prepared / "images"
+            images.mkdir(parents=True)
+            (images / "wrong.jpg").write_bytes(b"wrong")
+            transforms = prepared / "transforms.json"
+            transforms.write_text(
+                json.dumps({"frames": [{"file_path": "images/wrong.jpg", "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}]}),
+                encoding="utf-8",
+            )
+            with patch(
+                "processing.vggt_splatfacto.prepare_vggt_nerfstudio_data",
+                return_value={"transforms_path": str(transforms)},
+            ), patch("processing.vggt_splatfacto.verify_gpu_runtime", return_value={}), patch(
+                "processing.vggt_splatfacto.verify_research_environment",
+                return_value={"nerfstudio_revision": "ns-rev"},
+            ), patch("processing.vggt_splatfacto.run_splatfacto_export") as train:
+                with self.assertRaisesRegex(RuntimeError, "changed the frozen dataset identity"):
+                    run_vggt_splatfacto(dataset_path, source, scene, root / "out")
+                train.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Finish #27's repository-side end-to-end path. The existing VGGT research adapter produced a hashed COLMAP sparse model; this PR connects that exact result to Nerfstudio Splatfacto and the existing #26 comparison contract without re-running COLMAP or changing the frozen frame set.

## Changes

- add `processing.vggt_splatfacto`:
  - requires the existing frozen `quality-sweep/evaluation-dataset.json`;
  - verifies VGGT `cameras.bin`, `images.bin`, and `points3D.bin`;
  - copies the exact VGGT scene image bytes into a Nerfstudio `images/` directory and re-verifies SHA-256;
  - runs `ns-process-data images` with `--skip-colmap --skip-image-processing` and the VGGT sparse model;
  - rebuilds the dataset contract from generated transforms and rejects any dataset-identity drift before training;
  - writes explicit train/val/test split transforms from the same #26 hashes;
  - runs **default Splatfacto only** (not a redundant 3-way strategy sweep);
  - runs `ns-eval`, records PSNR/SSIM/LPIPS, hashed render evidence through the existing eval path, PLY metrics, wall-clock, and child-process peak GPU memory;
  - emits a validated `vggt-colmap-splatfacto` backend result;
  - when the existing default baseline result is supplied, writes a two-row #26 `comparison.json` (`splatfacto-default` vs `vggt-colmap-splatfacto`).
- add tests for:
  - skip-COLMAP/skip-image-processing conversion;
  - exact byte/hash preservation;
  - frozen dataset identity reuse;
  - two-backend comparison output;
  - fail-before-training on changed frame identity.
- add task entrypoints:
  - `./task vggt-splatfacto <scene> [iterations]`
  - `./task vggt-compare <scene> [feedforward|ba] [iterations]`
- `vggt-compare` runs the dedicated VGGT image first and the canonical Splatfacto quality image second; neither image is built implicitly during the GPU run.

## Evidence boundary

This closes the repository/orchestration gap, not the actual target-GPU result. The pinned official VGGT demo still uses the non-commercial research checkpoint and remains `production_eligible=false`. Actual close of #27 requires the two-backend result on a real frozen dataset.

Related: #26, #27.