### PR TITLE
3DGS: add exact LongSplat and EFA-GS research adapters

### DIFF
--- a/processing/efa_gs_backend.py
+++ b/processing/efa_gs_backend.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from processing.backend_evaluation import (
+    artifact_record,
+    dataset_identity,
+    empty_metrics,
+    gaussian_artifact_metrics,
+    validate_backend_result,
+)
+from processing.external_research import (
+    materialize_frozen_images,
+    read_json_object,
+    require_success,
+    run_recorded_gpu_step,
+    verify_checkout,
+    write_tree_manifest,
+)
+from processing.provenance import write_json
+
+EFA_REPOSITORY = "https://github.com/jcwang-gh/EFA-GS"
+EFA_REVISION = "57f330f6f9b12d2684c6df0f0359ffec8f60976d"
+EFA_LICENSE_STATE = "research-evaluation-only-commercial-consent-required"
+
+
+def verify_efa_checkout(checkout: str | Path) -> dict:
+    info = verify_checkout(
+        checkout,
+        expected_revision=EFA_REVISION,
+        required_paths=(
+            "3DGS/train.py",
+            "3DGS/render.py",
+            "3DGS/metrics.py",
+            "LICENSE.md",
+        ),
+    )
+    return {
+        **info,
+        "repository": EFA_REPOSITORY,
+        "license_state": EFA_LICENSE_STATE,
+        "production_eligible": False,
+        "implementation_root": str(Path(info["checkout"]) / "3DGS"),
+    }
+
+
+def _copy_colmap_model(source: Path, destination: Path) -> dict:
+    required_groups = (
+        ("cameras.bin", "cameras.txt"),
+        ("images.bin", "images.txt"),
+        ("points3D.bin", "points3D.txt"),
+    )
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+    copied = []
+    for options in required_groups:
+        candidate = next((source / name for name in options if (source / name).is_file()), None)
+        if candidate is None:
+            raise ValueError(f"COLMAP model is missing one of {options}: {source}")
+        target = destination / candidate.name
+        shutil.copy2(candidate, target)
+        copied.append(str(target))
+    return write_tree_manifest(destination, destination.parent / "colmap-model.json")
+
+
+def _native_metrics(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def run_efa_gs(
+    dataset_json: str | Path,
+    transforms_json: str | Path,
+    colmap_model: str | Path,
+    checkout: str | Path,
+    output_root: str | Path,
+    *,
+    python_executable: str = "python",
+    iterations: int = 30000,
+    resolution: int = 1,
+    port: int = 12109,
+    init_scaling_multiplier_max: float = 1.5,
+    init_scaling_multiplier_min: float = 1.0,
+    interval_times: int = 2,
+    diffscale: bool = True,
+    tolerance: float = 1e-5,
+    timeout: float | None = None,
+) -> dict:
+    """Run pinned EFA-GS 3DGS on the exact frozen input frame bytes.
+
+    The official method's own `--eval` split is retained as native evidence and is not
+    relabeled as the #26 deterministic hold-out.
+    """
+    if iterations <= 0 or resolution <= 0 or interval_times <= 0:
+        raise ValueError("iterations, resolution and interval_times must be positive")
+    dataset = read_json_object(dataset_json)
+    upstream = verify_efa_checkout(checkout)
+    impl = Path(upstream["implementation_root"])
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    scene = root / "input-scene"
+    images_manifest = materialize_frozen_images(
+        dataset,
+        transforms_json,
+        scene / "images",
+        preserve_basename=True,
+    )
+    write_json(scene / "input-manifest.json", images_manifest)
+    colmap_manifest = _copy_colmap_model(
+        Path(colmap_model).expanduser().resolve(),
+        scene / "sparse" / "0",
+    )
+
+    model = root / "model"
+    if model.exists():
+        shutil.rmtree(model)
+    logs = root / "logs"
+    train_command = [
+        python_executable,
+        str(impl / "train.py"),
+        "-s",
+        str(scene),
+        "-m",
+        str(model),
+        "--eval",
+        "-r",
+        str(resolution),
+        "--port",
+        str(port),
+        "--iterations",
+        str(iterations),
+        "--init_scaling_multiplier_max",
+        str(init_scaling_multiplier_max),
+        "--init_scaling_multiplier_min",
+        str(init_scaling_multiplier_min),
+        "--interval_times",
+        str(interval_times),
+        "--tolerance",
+        str(tolerance),
+        "--diffscale",
+        "True" if diffscale else "False",
+    ]
+    steps = []
+    train = run_recorded_gpu_step(
+        train_command,
+        cwd=impl,
+        log_root=logs,
+        name="train",
+        timeout=timeout,
+        env={"OMP_NUM_THREADS": "4"},
+    )
+    steps.append(train)
+    require_success(train)
+
+    render = run_recorded_gpu_step(
+        [python_executable, str(impl / "render.py"), "-m", str(model), "--skip_train"],
+        cwd=impl,
+        log_root=logs,
+        name="render",
+        timeout=timeout,
+        env={"OMP_NUM_THREADS": "4"},
+    )
+    steps.append(render)
+    require_success(render)
+
+    metrics_step = run_recorded_gpu_step(
+        [python_executable, str(impl / "metrics.py"), "-m", str(model)],
+        cwd=impl,
+        log_root=logs,
+        name="metrics",
+        timeout=timeout,
+        env={"OMP_NUM_THREADS": "4"},
+    )
+    steps.append(metrics_step)
+    require_success(metrics_step)
+
+    ply = model / "point_cloud" / f"iteration_{iterations}" / "point_cloud.ply"
+    artifact_metrics = gaussian_artifact_metrics(ply)
+    common = empty_metrics()
+    common.update(
+        {
+            "reconstruction_success": True,
+            "input_frame_count": len(dataset.get("frames") or []),
+            "train_frame_count": len(dataset.get("train_frame_sha256") or []),
+            "holdout_frame_count": len(dataset.get("holdout_frame_sha256") or []),
+            "wall_clock_seconds": sum(float(step["wall_clock_seconds"]) for step in steps),
+            "peak_gpu_memory_bytes": max(
+                (int(step["peak_gpu_memory_bytes"]) for step in steps if step.get("peak_gpu_memory_bytes") is not None),
+                default=None,
+            ),
+            "camera_pose_available": True,
+            **artifact_metrics,
+        }
+    )
+    result = {
+        "schema_version": 2,
+        "dataset_id": dataset_identity(dataset),
+        "backend": {"name": "efa-gs-3dgs-research", "upstream_revision": EFA_REVISION},
+        "command": train_command,
+        "config": {
+            "license_state": EFA_LICENSE_STATE,
+            "production_eligible": False,
+            "iterations": iterations,
+            "resolution": resolution,
+            "init_scaling_multiplier_max": init_scaling_multiplier_max,
+            "init_scaling_multiplier_min": init_scaling_multiplier_min,
+            "interval_times": interval_times,
+            "diffscale": diffscale,
+            "tolerance": tolerance,
+            "native_eval_semantics": "EFA-GS/3DGS --eval; not relabeled as #26 deterministic hold-out",
+            "colmap_model_manifest": colmap_manifest["manifest_path"],
+        },
+        "return_code": 0,
+        "status": "success",
+        "failure_phase": None,
+        "artifact": artifact_record(ply, format="ply"),
+        "metrics": common,
+        "native_metrics": _native_metrics(model / "results.json"),
+        "input_manifest": str(scene / "input-manifest.json"),
+        "steps": steps,
+        "upstream": upstream,
+    }
+    validate_backend_result(result, dataset)
+    path = root / "backend-result.json"
+    write_json(path, result)
+    return {**result, "manifest_path": str(path)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run pinned EFA-GS/3DGS as a non-commercial research backend.")
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--transforms", required=True)
+    parser.add_argument("--colmap-model", required=True)
+    parser.add_argument("--checkout", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--python", default="python")
+    parser.add_argument("--iterations", type=int, default=30000)
+    parser.add_argument("--resolution", type=int, default=1)
+    parser.add_argument("--port", type=int, default=12109)
+    parser.add_argument("--init-scaling-multiplier-max", type=float, default=1.5)
+    parser.add_argument("--init-scaling-multiplier-min", type=float, default=1.0)
+    parser.add_argument("--interval-times", type=int, default=2)
+    parser.add_argument("--diffscale", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--tolerance", type=float, default=1e-5)
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_efa_gs(
+        args.dataset,
+        args.transforms,
+        args.colmap_model,
+        args.checkout,
+        args.output_root,
+        python_executable=args.python,
+        iterations=args.iterations,
+        resolution=args.resolution,
+        port=args.port,
+        init_scaling_multiplier_max=args.init_scaling_multiplier_max,
+        init_scaling_multiplier_min=args.init_scaling_multiplier_min,
+        interval_times=args.interval_times,
+        diffscale=args.diffscale,
+        tolerance=args.tolerance,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/external_research.py
+++ b/processing/external_research.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from processing.backend_evaluation import dataset_identity
+from processing.nerfstudio import _run_recorded_command_with_peak_gpu_memory
+from processing.provenance import sha256_file, write_json
+
+
+def read_json_object(path: str | Path) -> dict:
+    source = Path(path).expanduser().resolve()
+    value = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {source}")
+    return value
+
+
+def git_head(checkout: str | Path) -> str:
+    root = Path(checkout).expanduser().resolve()
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        shell=False,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(f"not a readable Git checkout: {root}")
+    return completed.stdout.strip()
+
+
+def verify_checkout(
+    checkout: str | Path,
+    *,
+    expected_revision: str,
+    required_paths: Sequence[str] = (),
+) -> dict:
+    root = Path(checkout).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"checkout does not exist: {root}")
+    revision = git_head(root)
+    if revision != expected_revision:
+        raise ValueError(
+            f"checkout revision mismatch: expected {expected_revision}, got {revision}"
+        )
+    missing = [path for path in required_paths if not (root / path).exists()]
+    if missing:
+        raise ValueError(f"pinned checkout is missing required paths: {missing}")
+    return {"checkout": str(root), "revision": revision}
+
+
+def _frame_sources(transforms_json: Path) -> dict[str, Path]:
+    meta = read_json_object(transforms_json)
+    frames = meta.get("frames")
+    if not isinstance(frames, list) or not frames:
+        raise ValueError("Nerfstudio transforms.json requires one or more frames")
+    by_hash: dict[str, Path] = {}
+    for frame in frames:
+        if not isinstance(frame, Mapping) or not frame.get("file_path"):
+            raise ValueError("Nerfstudio frame is missing file_path")
+        declared = Path(str(frame["file_path"]))
+        source = (
+            declared if declared.is_absolute() else transforms_json.parent / declared
+        ).resolve()
+        if not source.is_file():
+            raise ValueError(f"Nerfstudio frame does not exist: {source}")
+        digest = sha256_file(source)
+        if digest in by_hash:
+            raise ValueError(f"duplicate frame SHA-256 in transforms: {digest}")
+        by_hash[digest] = source
+    return by_hash
+
+
+def materialize_frozen_images(
+    dataset: Mapping,
+    transforms_json: str | Path,
+    images_dir: str | Path,
+    *,
+    preserve_basename: bool = True,
+) -> dict:
+    """Materialize exactly the frozen #26 frame bytes without inventing a new split."""
+    transforms = Path(transforms_json).expanduser().resolve()
+    sources = _frame_sources(transforms)
+    records = dataset.get("frames") or []
+    expected = {str(record["sha256"]): dict(record) for record in records}
+    if not expected:
+        raise ValueError("dataset contract has no frames")
+    if set(expected) != set(sources):
+        missing = sorted(set(expected) - set(sources))
+        extra = sorted(set(sources) - set(expected))
+        raise ValueError(
+            f"dataset/transforms frame mismatch; missing={missing}, extra={extra}"
+        )
+
+    destination = Path(images_dir).expanduser().resolve()
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+    used_names: set[str] = set()
+    materialized = []
+    for index, record in enumerate(records, start=1):
+        digest = str(record["sha256"])
+        source = sources[digest]
+        if preserve_basename:
+            name = source.name
+        else:
+            name = f"{index:04d}-{digest[:12]}{source.suffix.lower() or '.jpg'}"
+        if name in used_names:
+            raise ValueError(f"duplicate materialized frame name: {name}")
+        used_names.add(name)
+        target = destination / name
+        shutil.copy2(source, target)
+        actual = sha256_file(target)
+        if actual != digest:
+            raise RuntimeError(
+                f"materialized frame hash mismatch: expected {digest}, got {actual}"
+            )
+        materialized.append(
+            {
+                "name": name,
+                "path": str(target),
+                "sha256": digest,
+                "size_bytes": target.stat().st_size,
+                "split": record.get("split"),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "dataset_id": dataset_identity(dataset),
+        "images_dir": str(destination),
+        "frame_count": len(materialized),
+        "frames": materialized,
+    }
+
+
+def run_recorded_gpu_step(
+    command: Sequence[str],
+    *,
+    cwd: str | Path,
+    log_root: str | Path,
+    name: str,
+    timeout: float | None = None,
+    env: Mapping[str, str] | None = None,
+) -> dict:
+    """Run one external argv with logs and best-effort process-tree peak GPU memory."""
+    root = Path(log_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    workdir = Path(cwd).expanduser().resolve()
+    started = time.perf_counter()
+    completed, peak_gpu_memory = _run_recorded_command_with_peak_gpu_memory(
+        list(map(str, command)),
+        cwd=workdir,
+        timeout=timeout,
+        env=None if env is None else {**os.environ, **dict(env)},
+    )
+    elapsed = time.perf_counter() - started
+    stdout = root / f"{name}.stdout.log"
+    stderr = root / f"{name}.stderr.log"
+    stdout.write_text(completed.stdout or "", encoding="utf-8")
+    stderr.write_text(completed.stderr or "", encoding="utf-8")
+    return {
+        "name": name,
+        "command": list(map(str, command)),
+        "cwd": str(workdir),
+        "return_code": completed.returncode,
+        "wall_clock_seconds": elapsed,
+        "peak_gpu_memory_bytes": peak_gpu_memory,
+        "stdout_log": str(stdout),
+        "stderr_log": str(stderr),
+    }
+
+
+def require_success(step: Mapping) -> None:
+    return_code = step.get("return_code")
+    if return_code != 0:
+        raise subprocess.CalledProcessError(
+            int(return_code if isinstance(return_code, int) else 1),
+            list(step.get("command") or [str(step.get("name") or "external-step")]),
+        )
+
+
+def file_record(path: str | Path) -> dict:
+    artifact = Path(path).expanduser().resolve()
+    if not artifact.is_file() or artifact.stat().st_size <= 0:
+        raise ValueError(f"artifact is missing or empty: {artifact}")
+    return {
+        "path": str(artifact),
+        "size_bytes": artifact.stat().st_size,
+        "sha256": sha256_file(artifact),
+    }
+
+
+def write_tree_manifest(
+    root: str | Path,
+    output_path: str | Path,
+    *,
+    suffixes: Sequence[str] | None = None,
+) -> dict:
+    source = Path(root).expanduser().resolve()
+    if not source.is_dir():
+        raise ValueError(f"artifact directory does not exist: {source}")
+    allowed = None if suffixes is None else {suffix.lower() for suffix in suffixes}
+    files = []
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        if allowed is not None and path.suffix.lower() not in allowed:
+            continue
+        files.append(
+            {
+                "path": path.relative_to(source).as_posix(),
+                "size_bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+        )
+    if not files:
+        raise ValueError(f"artifact directory contains no selected files: {source}")
+    manifest = {
+        "schema_version": 1,
+        "root": str(source),
+        "file_count": len(files),
+        "files": files,
+    }
+    write_json(output_path, manifest)
+    return {**manifest, "manifest_path": str(Path(output_path).expanduser().resolve())}

--- a/processing/longsplat_backend.py
+++ b/processing/longsplat_backend.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+from processing.backend_evaluation import (
+    artifact_record,
+    dataset_identity,
+    empty_metrics,
+    gaussian_artifact_metrics,
+    validate_backend_result,
+)
+from processing.external_research import (
+    materialize_frozen_images,
+    read_json_object,
+    require_success,
+    run_recorded_gpu_step,
+    verify_checkout,
+    write_tree_manifest,
+)
+from processing.provenance import write_json
+
+LONGSPLAT_REPOSITORY = "https://github.com/NVlabs/LongSplat"
+LONGSPLAT_REVISION = "19750775a9d19f30aa05a8333c4c6c231b2d5f4a"
+LONGSPLAT_LICENSE_STATE = "research-evaluation-only-noncommercial"
+
+
+def verify_longsplat_checkout(checkout: str | Path) -> dict:
+    info = verify_checkout(
+        checkout,
+        expected_revision=LONGSPLAT_REVISION,
+        required_paths=(
+            "train.py",
+            "render.py",
+            "metrics.py",
+            "convert_3dgs.py",
+            "scripts/train_custom.sh",
+            "LICENSE.md",
+        ),
+    )
+    return {
+        **info,
+        "repository": LONGSPLAT_REPOSITORY,
+        "license_state": LONGSPLAT_LICENSE_STATE,
+        "production_eligible": False,
+    }
+
+
+def _native_metrics(path: Path) -> dict | None:
+    if not path.is_file():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def run_longsplat(
+    dataset_json: str | Path,
+    transforms_json: str | Path,
+    checkout: str | Path,
+    output_root: str | Path,
+    *,
+    python_executable: str = "python",
+    resolution: int = 4,
+    pose_iterations: int = 100,
+    local_iterations: int = 200,
+    global_iterations: int = 500,
+    conversion_iterations: int = 10000,
+    prune_ratio: float = 0.6,
+    port: int = 12009,
+    timeout: float | None = None,
+) -> dict:
+    """Run pinned LongSplat on the exact frozen input frames and export standard 3DGS.
+
+    LongSplat's own `--eval` split is method-native and is not relabeled as the #26
+    deterministic hold-out. Native metrics are retained separately; common PSNR/SSIM/
+    LPIPS remain null unless a future evaluator proves identical hold-out semantics.
+    """
+    if resolution <= 0:
+        raise ValueError("resolution must be positive")
+    if any(value <= 0 for value in (pose_iterations, local_iterations, global_iterations, conversion_iterations)):
+        raise ValueError("iteration counts must be positive")
+    if not 0 <= prune_ratio < 1:
+        raise ValueError("prune_ratio must be in [0, 1)")
+
+    dataset = read_json_object(dataset_json)
+    upstream = verify_longsplat_checkout(checkout)
+    source_root = Path(upstream["checkout"])
+    root = Path(output_root).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    scene = root / "input-scene"
+    input_manifest = materialize_frozen_images(
+        dataset,
+        transforms_json,
+        scene / "images",
+        preserve_basename=True,
+    )
+    write_json(scene / "input-manifest.json", input_manifest)
+
+    model = root / "model"
+    if model.exists():
+        shutil.rmtree(model)
+    logs = root / "logs"
+    steps = []
+
+    train_command = [
+        python_executable,
+        str(source_root / "train.py"),
+        "--eval",
+        "-s",
+        str(scene),
+        "-m",
+        str(model),
+        "--port",
+        str(port),
+        "--images",
+        "images",
+        "--mode",
+        "custom",
+        "-r",
+        str(resolution),
+        "--pose_iteration",
+        str(pose_iterations),
+        "--local_iter",
+        str(local_iterations),
+        "--global_iter",
+        str(global_iterations),
+    ]
+    train = run_recorded_gpu_step(
+        train_command,
+        cwd=source_root,
+        log_root=logs,
+        name="train",
+        timeout=timeout,
+    )
+    steps.append(train)
+    require_success(train)
+
+    render = run_recorded_gpu_step(
+        [python_executable, str(source_root / "render.py"), "-m", str(model)],
+        cwd=source_root,
+        log_root=logs,
+        name="render",
+        timeout=timeout,
+    )
+    steps.append(render)
+    require_success(render)
+
+    metrics_step = run_recorded_gpu_step(
+        [python_executable, str(source_root / "metrics.py"), "-m", str(model)],
+        cwd=source_root,
+        log_root=logs,
+        name="metrics",
+        timeout=timeout,
+    )
+    steps.append(metrics_step)
+    require_success(metrics_step)
+    native_metrics = _native_metrics(model / "results.json")
+
+    convert = run_recorded_gpu_step(
+        [
+            python_executable,
+            str(source_root / "convert_3dgs.py"),
+            "-m",
+            str(model),
+            "--iteration",
+            str(conversion_iterations),
+            "--prune_ratio",
+            str(prune_ratio),
+        ],
+        cwd=source_root,
+        log_root=logs,
+        name="convert-3dgs",
+        timeout=timeout,
+    )
+    steps.append(convert)
+    require_success(convert)
+
+    ply = model / "converted_3dgs" / "point_cloud.ply"
+    artifact_metrics = gaussian_artifact_metrics(ply)
+    native_manifest = write_tree_manifest(
+        model,
+        root / "native-model.json",
+        suffixes=(".json", ".ply", ".pth"),
+    )
+    common = empty_metrics()
+    common.update(
+        {
+            "reconstruction_success": True,
+            "input_frame_count": len(dataset.get("frames") or []),
+            "train_frame_count": len(dataset.get("train_frame_sha256") or []),
+            "holdout_frame_count": len(dataset.get("holdout_frame_sha256") or []),
+            "wall_clock_seconds": sum(float(step["wall_clock_seconds"]) for step in steps),
+            "peak_gpu_memory_bytes": max(
+                (int(step["peak_gpu_memory_bytes"]) for step in steps if step.get("peak_gpu_memory_bytes") is not None),
+                default=None,
+            ),
+            "camera_pose_available": True,
+            **artifact_metrics,
+        }
+    )
+    result = {
+        "schema_version": 2,
+        "dataset_id": dataset_identity(dataset),
+        "backend": {
+            "name": "longsplat-research-converted-3dgs",
+            "upstream_revision": LONGSPLAT_REVISION,
+        },
+        "command": train_command,
+        "config": {
+            "license_state": LONGSPLAT_LICENSE_STATE,
+            "production_eligible": False,
+            "resolution": resolution,
+            "pose_iterations": pose_iterations,
+            "local_iterations": local_iterations,
+            "global_iterations": global_iterations,
+            "conversion_iterations": conversion_iterations,
+            "prune_ratio": prune_ratio,
+            "native_eval_semantics": "LongSplat --eval; not relabeled as #26 deterministic hold-out",
+        },
+        "return_code": 0,
+        "status": "success",
+        "failure_phase": None,
+        "artifact": artifact_record(ply, format="ply"),
+        "metrics": common,
+        "native_metrics": native_metrics,
+        "native_model_manifest": native_manifest["manifest_path"],
+        "input_manifest": str(scene / "input-manifest.json"),
+        "steps": steps,
+        "upstream": upstream,
+    }
+    validate_backend_result(result, dataset)
+    path = root / "backend-result.json"
+    write_json(path, result)
+    return {**result, "manifest_path": str(path)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run pinned LongSplat as a non-commercial research backend and export standard 3DGS."
+    )
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--transforms", required=True)
+    parser.add_argument("--checkout", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--python", default="python")
+    parser.add_argument("--resolution", type=int, default=4)
+    parser.add_argument("--pose-iterations", type=int, default=100)
+    parser.add_argument("--local-iterations", type=int, default=200)
+    parser.add_argument("--global-iterations", type=int, default=500)
+    parser.add_argument("--conversion-iterations", type=int, default=10000)
+    parser.add_argument("--prune-ratio", type=float, default=0.6)
+    parser.add_argument("--port", type=int, default=12009)
+    parser.add_argument("--timeout", type=float)
+    args = parser.parse_args()
+    result = run_longsplat(
+        args.dataset,
+        args.transforms,
+        args.checkout,
+        args.output_root,
+        python_executable=args.python,
+        resolution=args.resolution,
+        pose_iterations=args.pose_iterations,
+        local_iterations=args.local_iterations,
+        global_iterations=args.global_iterations,
+        conversion_iterations=args.conversion_iterations,
+        prune_ratio=args.prune_ratio,
+        port=args.port,
+        timeout=args.timeout,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_efa_gs_backend.py
+++ b/tests/test_efa_gs_backend.py
@@ -1,0 +1,118 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import build_nerfstudio_dataset_contract, dataset_identity
+from processing.efa_gs_backend import EFA_REVISION, run_efa_gs
+
+
+class EfaGsBackendTests(unittest.TestCase):
+    def _fixture(self, root: Path):
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(4):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+            )
+        transforms = data / "transforms.json"
+        transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+        dataset = build_nerfstudio_dataset_contract(source, transforms, holdout_count=1)
+        dataset_path = root / "dataset.json"
+        dataset_path.write_text(json.dumps(dataset), encoding="utf-8")
+
+        colmap = root / "colmap" / "0"
+        colmap.mkdir(parents=True)
+        for name in ("cameras.bin", "images.bin", "points3D.bin"):
+            (colmap / name).write_bytes(name.encode())
+
+        checkout = root / "efa"
+        for relative in ("3DGS/train.py", "3DGS/render.py", "3DGS/metrics.py", "LICENSE.md"):
+            path = checkout / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("", encoding="utf-8")
+        return dataset, dataset_path, transforms, colmap, checkout
+
+    def test_runs_official_efa_sequence_and_preserves_native_metrics_separately(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset, dataset_path, transforms, colmap, checkout = self._fixture(root)
+
+            def fake_step(command, *, cwd, log_root, name, **kwargs):
+                model = root / "out" / "model"
+                model.mkdir(parents=True, exist_ok=True)
+                if name == "train":
+                    ply = model / "point_cloud" / "iteration_30000" / "point_cloud.ply"
+                    ply.parent.mkdir(parents=True, exist_ok=True)
+                    ply.write_bytes(b"ply")
+                if name == "metrics":
+                    (model / "results.json").write_text(
+                        json.dumps({"ours_30000": {"PSNR": 22.0, "SSIM": 0.81, "LPIPS": 0.19}}),
+                        encoding="utf-8",
+                    )
+                return {
+                    "name": name,
+                    "command": list(command),
+                    "return_code": 0,
+                    "wall_clock_seconds": 2.0,
+                    "peak_gpu_memory_bytes": 200 if name == "train" else 80,
+                    "stdout_log": str(root / f"{name}.out"),
+                    "stderr_log": str(root / f"{name}.err"),
+                }
+
+            metrics = {
+                "primitive_count": 20,
+                "output_size_bytes": 3,
+                "low_opacity_primitive_count": 2,
+                "low_opacity_primitive_ratio": 0.1,
+                "scale_anisotropy_above_10_count": 3,
+                "scale_anisotropy_above_10_ratio": 0.15,
+            }
+            with patch("processing.external_research.git_head", return_value=EFA_REVISION), patch(
+                "processing.efa_gs_backend.run_recorded_gpu_step", side_effect=fake_step
+            ), patch(
+                "processing.efa_gs_backend.gaussian_artifact_metrics", return_value=metrics
+            ):
+                result = run_efa_gs(
+                    dataset_path,
+                    transforms,
+                    colmap,
+                    checkout,
+                    root / "out",
+                )
+
+            self.assertEqual(result["dataset_id"], dataset_identity(dataset))
+            self.assertFalse(result["config"]["production_eligible"])
+            self.assertEqual(result["metrics"]["peak_gpu_memory_bytes"], 200)
+            self.assertIsNone(result["metrics"]["psnr"])
+            self.assertIsNotNone(result["native_metrics"])
+            self.assertEqual(result["artifact"]["format"], "ply")
+            self.assertEqual(len(result["steps"]), 3)
+
+    def test_invalid_iteration_count_fails_before_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, dataset_path, transforms, colmap, checkout = self._fixture(root)
+            with self.assertRaisesRegex(ValueError, "positive"):
+                run_efa_gs(
+                    dataset_path,
+                    transforms,
+                    colmap,
+                    checkout,
+                    root / "out",
+                    iterations=0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_external_research.py
+++ b/tests/test_external_research.py
@@ -1,0 +1,59 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import build_nerfstudio_dataset_contract, dataset_identity
+from processing.external_research import materialize_frozen_images, verify_checkout
+
+
+class ExternalResearchTests(unittest.TestCase):
+    def _dataset(self, root: Path):
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(3):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+            )
+        transforms = data / "transforms.json"
+        transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+        dataset = build_nerfstudio_dataset_contract(source, transforms, holdout_count=1)
+        return dataset, transforms
+
+    def test_materialize_preserves_exact_frozen_bytes_and_split(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset, transforms = self._dataset(root)
+            result = materialize_frozen_images(dataset, transforms, root / "out")
+            self.assertEqual(result["dataset_id"], dataset_identity(dataset))
+            self.assertEqual(result["frame_count"], 3)
+            self.assertEqual(
+                {row["sha256"] for row in result["frames"]},
+                {row["sha256"] for row in dataset["frames"]},
+            )
+            self.assertEqual(sum(row["split"] == "holdout" for row in result["frames"]), 1)
+
+    def test_checkout_requires_exact_revision_and_required_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "train.py").write_text("", encoding="utf-8")
+            with patch("processing.external_research.git_head", return_value="abc"):
+                result = verify_checkout(root, expected_revision="abc", required_paths=("train.py",))
+            self.assertEqual(result["revision"], "abc")
+            with patch("processing.external_research.git_head", return_value="wrong"):
+                with self.assertRaisesRegex(ValueError, "revision mismatch"):
+                    verify_checkout(root, expected_revision="abc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_longsplat_backend.py
+++ b/tests/test_longsplat_backend.py
@@ -1,0 +1,119 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.backend_evaluation import build_nerfstudio_dataset_contract, dataset_identity
+from processing.longsplat_backend import LONGSPLAT_REVISION, run_longsplat
+
+
+class LongSplatBackendTests(unittest.TestCase):
+    def _fixture(self, root: Path):
+        source = root / "source.webm"
+        source.write_bytes(b"video")
+        data = root / "data"
+        images = data / "images"
+        images.mkdir(parents=True)
+        frames = []
+        for index in range(4):
+            image = images / f"frame-{index:03d}.jpg"
+            image.write_bytes(f"image-{index}".encode())
+            frames.append(
+                {
+                    "file_path": f"images/{image.name}",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+            )
+        transforms = data / "transforms.json"
+        transforms.write_text(json.dumps({"frames": frames}), encoding="utf-8")
+        dataset = build_nerfstudio_dataset_contract(source, transforms, holdout_count=1)
+        dataset_path = root / "dataset.json"
+        dataset_path.write_text(json.dumps(dataset), encoding="utf-8")
+        checkout = root / "longsplat"
+        for relative in (
+            "train.py",
+            "render.py",
+            "metrics.py",
+            "convert_3dgs.py",
+            "scripts/train_custom.sh",
+            "LICENSE.md",
+        ):
+            path = checkout / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("", encoding="utf-8")
+        return dataset, dataset_path, transforms, checkout
+
+    def test_runs_official_sequence_and_records_research_only_artifact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dataset, dataset_path, transforms, checkout = self._fixture(root)
+
+            def fake_step(command, *, cwd, log_root, name, **kwargs):
+                output_root = root / "out"
+                model = output_root / "model"
+                model.mkdir(parents=True, exist_ok=True)
+                if name == "metrics":
+                    (model / "results.json").write_text(
+                        json.dumps({"ours": {"PSNR": 20.0, "SSIM": 0.8, "LPIPS": 0.2}}),
+                        encoding="utf-8",
+                    )
+                if name == "convert-3dgs":
+                    converted = model / "converted_3dgs"
+                    converted.mkdir(parents=True, exist_ok=True)
+                    (converted / "point_cloud.ply").write_bytes(b"ply")
+                return {
+                    "name": name,
+                    "command": list(command),
+                    "return_code": 0,
+                    "wall_clock_seconds": 1.0,
+                    "peak_gpu_memory_bytes": 100 if name == "train" else 50,
+                    "stdout_log": str(root / f"{name}.out"),
+                    "stderr_log": str(root / f"{name}.err"),
+                }
+
+            metrics = {
+                "primitive_count": 10,
+                "output_size_bytes": 3,
+                "low_opacity_primitive_count": 1,
+                "low_opacity_primitive_ratio": 0.1,
+                "scale_anisotropy_above_10_count": 2,
+                "scale_anisotropy_above_10_ratio": 0.2,
+            }
+            with patch("processing.external_research.git_head", return_value=LONGSPLAT_REVISION), patch(
+                "processing.longsplat_backend.run_recorded_gpu_step", side_effect=fake_step
+            ), patch(
+                "processing.longsplat_backend.gaussian_artifact_metrics", return_value=metrics
+            ):
+                result = run_longsplat(
+                    dataset_path,
+                    transforms,
+                    checkout,
+                    root / "out",
+                )
+
+            self.assertEqual(result["dataset_id"], dataset_identity(dataset))
+            self.assertEqual(result["status"], "success")
+            self.assertFalse(result["config"]["production_eligible"])
+            self.assertIsNone(result["metrics"]["psnr"])
+            self.assertEqual(result["metrics"]["peak_gpu_memory_bytes"], 100)
+            self.assertEqual(len(result["steps"]), 4)
+            self.assertEqual(result["artifact"]["format"], "ply")
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+
+    def test_rejects_invalid_prune_ratio_before_execution(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _, dataset_path, transforms, checkout = self._fixture(root)
+            with self.assertRaisesRegex(ValueError, "prune_ratio"):
+                run_longsplat(
+                    dataset_path,
+                    transforms,
+                    checkout,
+                    root / "out",
+                    prune_ratio=1.0,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Remove the repository-side execution-adapter gap for #28 and #46 without claiming unsupported production rights or same-holdout metrics that the upstream methods do not provide.

## Shared extraction

Three real external research consumers now exist (VGGT, LongSplat, EFA-GS), so this PR adds one small `processing.external_research` helper for responsibilities that are actually duplicated:
- exact Git checkout HEAD verification;
- frozen #26 frame-byte materialization with SHA-256 verification;
- argv execution with stdout/stderr, wall-clock and the existing best-effort process-tree peak GPU-memory measurement;
- explicit non-zero failure;
- hashed file/tree manifests.

Backend-specific commands, output semantics and license policy remain in each adapter.

## LongSplat

Pinned upstream: `NVlabs/LongSplat@19750775a9d19f30aa05a8333c4c6c231b2d5f4a`.

`processing.longsplat_backend`:
- verifies exact checkout and required official files;
- materializes exactly the frozen #26 input frame bytes into `<scene>/images`;
- runs the direct official custom-data sequence rather than editing upstream `scripts/train_custom.sh`:
  - `train.py --eval ... --mode custom ...`
  - `render.py`
  - `metrics.py`
  - `convert_3dgs.py`;
- validates `converted_3dgs/point_cloud.ply`;
- records native model tree + native `results.json` separately;
- records converted PLY metrics/hash, wall-clock and measured peak VRAM;
- does **not** copy LongSplat-native PSNR/SSIM/LPIPS into the #26 common hold-out fields, because upstream `--eval` is not the same frozen hold-out;
- records `production_eligible=false` because the pinned NVIDIA license is research/evaluation-only for this use.

## EFA-GS

Pinned upstream: `jcwang-gh/EFA-GS@57f330f6f9b12d2684c6df0f0359ffec8f60976d`.

`processing.efa_gs_backend`:
- verifies exact checkout and the official `3DGS` implementation;
- materializes frozen frame bytes preserving filenames;
- copies and hashes the supplied canonical COLMAP model into standard 3DGS `sparse/0` layout;
- uses the official EFA parameter family demonstrated by upstream (`init_scaling_multiplier_max/min`, `interval_times`, `diffscale`) with every value explicit in the manifest;
- runs train -> render -> metrics;
- validates the exact final `point_cloud/iteration_<N>/point_cloud.ply`;
- records direct PLY metrics, wall-clock, peak VRAM and native metrics separately;
- leaves common #26 PSNR/SSIM/LPIPS null because standard 3DGS `--eval` does not prove the same frozen hold-out;
- records `production_eligible=false` under the pinned Inria/MPII non-commercial research/evaluation license.

## Environment boundary

This PR intentionally does **not** invent Blackwell-compatible upstream environments:
- EFA-GS pins `torch==2.0.1+cu117` / `torchvision==0.15.2+cu117`, which is not the target sm_120 environment;
- LongSplat documents CUDA 12.1 and unpinned PyTorch plus compiled submodules. A target-sm_120 port must be built/tested before calling it runnable.

So this PR closes adapter/orchestration gaps but leaves execution-image compatibility as an explicit remaining gate. No hidden local dependency install is introduced.

## Tests

Adds tests for exact checkout, frozen-frame preservation, official command sequencing, research-only policy, converted/native metric separation, and invalid parameter fail-fast.

Related: #26, #28, #46.