### PR TITLE
3DGS: prove a Blackwell-compatible EFA-GS research image

### DIFF
--- a/.github/workflows/efa-image.yml
+++ b/.github/workflows/efa-image.yml
@@ -1,0 +1,55 @@
+name: EFA Image
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile.efa
+      - requirements.txt
+      - processing/efa_gs_backend.py
+      - processing/external_research.py
+      - .github/workflows/efa-image.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.efa
+      - requirements.txt
+      - processing/efa_gs_backend.py
+      - processing/external_research.py
+      - .github/workflows/efa-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.efa
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: |
+            ghcr.io/kafka2306/autophotogrammetry:efa-57f330f-sm120-v1
+            ghcr.io/kafka2306/autophotogrammetry:efa-sha-${{ github.sha }}
+          build-args: |
+            EFA_REVISION=57f330f6f9b12d2684c6df0f0359ffec8f60976d
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Verify research image contract
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm ghcr.io/kafka2306/autophotogrammetry:efa-57f330f-sm120-v1 \
+            python -c 'import subprocess,torch,diff_gaussian_rasterization; from simple_knn import _C; rev=subprocess.run(["git","-C","/opt/efa-gs","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev=="57f330f6f9b12d2684c6df0f0359ffec8f60976d"; assert torch.__version__.startswith("2.7.1"); print({"revision":rev,"torch":torch.__version__,"cuda":torch.version.cuda})'

--- a/Dockerfile.efa
+++ b/Dockerfile.efa
@@ -1,0 +1,69 @@
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG EFA_REVISION=57f330f6f9b12d2684c6df0f0359ffec8f60976d
+ENV CUDA_HOME=/usr/local/cuda \
+    TORCH_CUDA_ARCH_LIST=12.0 \
+    MAX_JOBS=4 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+LABEL org.opencontainers.image.source="https://github.com/KAFKA2306/AutoPhotogrammetry" \
+      org.opencontainers.image.description="Pinned EFA-GS research backend ported to Blackwell-compatible PyTorch/CUDA"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        python3 \
+        python3-dev \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
+
+# Upstream pins torch 2.0.1+cu117. Keep the exact EFA source revision but replace
+# that legacy runtime explicitly for the target sm_120/Blackwell execution path.
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel ninja \
+    && python -m pip install --no-cache-dir \
+        torch==2.7.1 torchvision==0.22.1 \
+        --index-url https://download.pytorch.org/whl/cu128
+
+RUN git init /opt/efa-gs \
+    && git -C /opt/efa-gs remote add origin https://github.com/jcwang-gh/EFA-GS.git \
+    && git -C /opt/efa-gs fetch --depth 1 origin "${EFA_REVISION}" \
+    && git -C /opt/efa-gs checkout --detach FETCH_HEAD \
+    && test "$(git -C /opt/efa-gs rev-parse HEAD)" = "${EFA_REVISION}"
+
+RUN python -m pip install --no-cache-dir \
+        GPUtil==1.4.0 \
+        opencv-python-headless==4.10.0.84 \
+        plyfile==1.1.2 \
+        numpy==1.26.4 \
+        tqdm==4.66.5 \
+    && python -m pip install --no-cache-dir --no-build-isolation \
+        /opt/efa-gs/3DGS/submodules/diff-gaussian-rasterization \
+        /opt/efa-gs/3DGS/submodules/simple-knn
+
+COPY requirements.txt /tmp/autophotogrammetry-requirements.txt
+RUN python -m pip install --no-cache-dir -r /tmp/autophotogrammetry-requirements.txt \
+    && python -m pip check
+
+COPY . /opt/autophotogrammetry
+WORKDIR /opt/autophotogrammetry
+
+RUN python - <<'PY'
+import subprocess
+import torch
+import diff_gaussian_rasterization
+from simple_knn import _C as simple_knn_cuda
+
+revision = subprocess.run(
+    ["git", "-C", "/opt/efa-gs", "rev-parse", "HEAD"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+assert revision == "57f330f6f9b12d2684c6df0f0359ffec8f60976d", revision
+assert torch.__version__.startswith("2.7.1"), torch.__version__
+print({"efa_revision": revision, "torch": torch.__version__, "cuda": torch.version.cuda})
+PY

--- a/Dockerfile.efa
+++ b/Dockerfile.efa
@@ -34,6 +34,14 @@ RUN git init /opt/efa-gs \
     && git -C /opt/efa-gs checkout --detach FETCH_HEAD \
     && test "$(git -C /opt/efa-gs rev-parse HEAD)" = "${EFA_REVISION}"
 
+# CUDA 12.8 no longer leaves FLT_MAX visible transitively for this pinned legacy
+# simple-knn source. Apply one repository-owned compile-compatibility patch only;
+# the upstream algorithm/source revision remains recorded separately and unchanged.
+COPY patches/efa-simple-knn-cuda12.8.patch /tmp/efa-simple-knn-cuda12.8.patch
+RUN git -C /opt/efa-gs apply --check /tmp/efa-simple-knn-cuda12.8.patch \
+    && git -C /opt/efa-gs apply /tmp/efa-simple-knn-cuda12.8.patch \
+    && grep -F '#include <cfloat>' /opt/efa-gs/3DGS/submodules/simple-knn/simple_knn.cu
+
 RUN python -m pip install --no-cache-dir \
         GPUtil==1.4.0 \
         opencv-python-headless==4.10.0.84 \
@@ -65,5 +73,12 @@ revision = subprocess.run(
 ).stdout.strip()
 assert revision == "57f330f6f9b12d2684c6df0f0359ffec8f60976d", revision
 assert torch.__version__.startswith("2.7.1"), torch.__version__
-print({"efa_revision": revision, "torch": torch.__version__, "cuda": torch.version.cuda})
+patch_diff = subprocess.run(
+    ["git", "-C", "/opt/efa-gs", "diff", "--", "3DGS/submodules/simple-knn/simple_knn.cu"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout
+assert '#include <cfloat>' in patch_diff, patch_diff
+print({"efa_revision": revision, "torch": torch.__version__, "cuda": torch.version.cuda, "compat_patch": "efa-simple-knn-cuda12.8.patch"})
 PY

--- a/patches/efa-simple-knn-cuda12.8.patch
+++ b/patches/efa-simple-knn-cuda12.8.patch
@@ -1,0 +1,11 @@
+diff --git a/3DGS/submodules/simple-knn/simple_knn.cu b/3DGS/submodules/simple-knn/simple_knn.cu
+--- a/3DGS/submodules/simple-knn/simple_knn.cu
++++ b/3DGS/submodules/simple-knn/simple_knn.cu
+@@ -10,6 +10,7 @@
+  */
+ 
+ #define BOX_SIZE 1024
++#include <cfloat>
+ 
+ #include "cuda_runtime.h"
+ #include "device_launch_parameters.h"


### PR DESCRIPTION
## Goal

Resolve #46's target-sm_120 execution-environment blocker with a real PR Docker-build gate, while preserving the exact pinned EFA-GS algorithm/source authority and its research-only license boundary.

## Upstream/runtime boundary

Pinned source:
- `jcwang-gh/EFA-GS@57f330f6f9b12d2684c6df0f0359ffec8f60976d`

Upstream `3DGS/requirements.txt` pins legacy:
- `torch==2.0.1+cu117`
- `torchvision==0.15.2+cu117`

Target port:
- CUDA 12.8.1
- PyTorch 2.7.1 / torchvision 0.22.1 cu128
- `TORCH_CUDA_ARCH_LIST=12.0`

This runtime deviation is explicit; it is not represented as upstream's original environment.

## First build evidence and compatibility fix

The first EFA image build reached CUDA extension compilation. The pinned diff-gaussian rasterizer compiled, but pinned `3DGS/submodules/simple-knn/simple_knn.cu` failed under CUDA 12.8 because it uses `FLT_MAX` without directly including the standard header that defines it.

Repository-owned patch:
- `patches/efa-simple-knn-cuda12.8.patch`
- exact semantic change: add `#include <cfloat>`

The Docker build:
- applies the patch with `git apply --check` first;
- keeps the recorded upstream Git HEAD unchanged;
- verifies the patched diff explicitly;
- makes no algorithm/threshold/data-layout change.

This is a compile-compatibility patch, not an EFA method modification.

## Changes

- `Dockerfile.efa`
  - exact EFA checkout revision
  - Blackwell-capable PyTorch/CUDA runtime
  - exact vendored diff-gaussian-rasterization/simple-knn compilation
  - `pip check`
  - import/revision/compat-patch assertions
- `EFA Image` workflow
  - PR: build/load image and execute import/revision smoke test
  - main: publish `ghcr.io/kafka2306/autophotogrammetry:efa-57f330f-sm120-v1` and SHA tag

## Evidence boundary

A green image workflow proves dependency compilation/import under the declared toolchain. It does **not** prove an actual EFA training run on the target GPU. #46 remains empirically open until real bad/control execution.

Pinned EFA license remains research/evaluation-only for this use; commercial production requires separate rights.

Related: #46.