### PR TITLE
3DGS: prove a Blackwell-compatible LongSplat research image

### DIFF
--- a/.github/workflows/longsplat-image.yml
+++ b/.github/workflows/longsplat-image.yml
@@ -46,11 +46,11 @@ jobs:
             ghcr.io/kafka2306/autophotogrammetry:longsplat-sha-${{ github.sha }}
           build-args: |
             LONGSPLAT_REVISION=19750775a9d19f30aa05a8333c4c6c231b2d5f4a
-            PYTORCH3D_REVISION=97bc85b6d23c9b161f1e3efff676666a3c6c5af3
+            PYTORCH3D_REVISION=33824be3cbc87a7dd1db0f6a9a9de9ac81b2d0ba
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Verify research image contract
         if: github.event_name == 'pull_request'
         run: |
           docker run --rm ghcr.io/kafka2306/autophotogrammetry:longsplat-1975077-sm120-v1 \
-            python -c 'import subprocess,torch,torch_scatter,pytorch3d,diff_gaussian_rasterization,fused_ssim; from simple_knn import _C; rev=subprocess.run(["git","-C","/opt/longsplat","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev=="19750775a9d19f30aa05a8333c4c6c231b2d5f4a"; assert torch.__version__.startswith("2.7.1"); print({"revision":rev,"torch":torch.__version__,"cuda":torch.version.cuda})'
+            python -c 'import subprocess,torch,torch_scatter,pytorch3d,diff_gaussian_rasterization,fused_ssim; from simple_knn import _C; rev=subprocess.run(["git","-C","/opt/longsplat","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev=="19750775a9d19f30aa05a8333c4c6c231b2d5f4a"; assert torch.__version__.startswith("2.7.1"); print({"revision":rev,"pytorch3d_revision":"33824be3cbc87a7dd1db0f6a9a9de9ac81b2d0ba","torch":torch.__version__,"cuda":torch.version.cuda})'

--- a/.github/workflows/longsplat-image.yml
+++ b/.github/workflows/longsplat-image.yml
@@ -1,0 +1,56 @@
+name: LongSplat Image
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile.longsplat
+      - requirements.txt
+      - processing/longsplat_backend.py
+      - processing/external_research.py
+      - .github/workflows/longsplat-image.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile.longsplat
+      - requirements.txt
+      - processing/longsplat_backend.py
+      - processing/external_research.py
+      - .github/workflows/longsplat-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.longsplat
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: |
+            ghcr.io/kafka2306/autophotogrammetry:longsplat-1975077-sm120-v1
+            ghcr.io/kafka2306/autophotogrammetry:longsplat-sha-${{ github.sha }}
+          build-args: |
+            LONGSPLAT_REVISION=19750775a9d19f30aa05a8333c4c6c231b2d5f4a
+            PYTORCH3D_REVISION=97bc85b6d23c9b161f1e3efff676666a3c6c5af3
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Verify research image contract
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm ghcr.io/kafka2306/autophotogrammetry:longsplat-1975077-sm120-v1 \
+            python -c 'import subprocess,torch,torch_scatter,pytorch3d,diff_gaussian_rasterization,fused_ssim; from simple_knn import _C; rev=subprocess.run(["git","-C","/opt/longsplat","rev-parse","HEAD"],check=True,capture_output=True,text=True).stdout.strip(); assert rev=="19750775a9d19f30aa05a8333c4c6c231b2d5f4a"; assert torch.__version__.startswith("2.7.1"); print({"revision":rev,"torch":torch.__version__,"cuda":torch.version.cuda})'

--- a/Dockerfile.longsplat
+++ b/Dockerfile.longsplat
@@ -1,0 +1,94 @@
+FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LONGSPLAT_REVISION=19750775a9d19f30aa05a8333c4c6c231b2d5f4a
+ARG PYTORCH3D_REVISION=97bc85b6d23c9b161f1e3efff676666a3c6c5af3
+ENV CUDA_HOME=/usr/local/cuda \
+    TORCH_CUDA_ARCH_LIST=12.0 \
+    MAX_JOBS=4 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+LABEL org.opencontainers.image.source="https://github.com/KAFKA2306/AutoPhotogrammetry" \
+      org.opencontainers.image.description="Pinned LongSplat research backend ported to Blackwell-compatible PyTorch/CUDA"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        git \
+        ninja-build \
+        python3 \
+        python3-dev \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/bin/python3 /usr/local/bin/python
+
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel ninja \
+    && python -m pip install --no-cache-dir \
+        torch==2.7.1 torchvision==0.22.1 \
+        --index-url https://download.pytorch.org/whl/cu128
+
+RUN git init /opt/longsplat \
+    && git -C /opt/longsplat remote add origin https://github.com/NVlabs/LongSplat.git \
+    && git -C /opt/longsplat fetch --depth 1 origin "${LONGSPLAT_REVISION}" \
+    && git -C /opt/longsplat checkout --detach FETCH_HEAD \
+    && test "$(git -C /opt/longsplat rev-parse HEAD)" = "${LONGSPLAT_REVISION}" \
+    && git -C /opt/longsplat submodule update --init --recursive --depth 1
+
+# Upstream requirements leave torch/torchvision/torch_scatter and pytorch3d@stable
+# unresolved for the target runtime. Keep the pinned LongSplat requirements for the
+# pure-Python dependencies, but own these GPU-sensitive packages explicitly below.
+RUN python - <<'PY'
+from pathlib import Path
+src = Path('/opt/longsplat/requirements.txt').read_text(encoding='utf-8').splitlines()
+filtered = []
+for line in src:
+    stripped = line.strip()
+    if not stripped or stripped.startswith('#'):
+        continue
+    lowered = stripped.lower()
+    if lowered in {'torch', 'torchvision', 'torch_scatter'}:
+        continue
+    if 'facebookresearch/pytorch3d' in lowered:
+        continue
+    filtered.append(stripped)
+Path('/tmp/longsplat-requirements.txt').write_text('\n'.join(filtered) + '\n', encoding='utf-8')
+PY
+
+RUN python -m pip install --no-cache-dir -r /tmp/longsplat-requirements.txt \
+    && python -m pip install --no-cache-dir --no-build-isolation torch_scatter==2.1.2 \
+    && python -m pip install --no-cache-dir --no-build-isolation \
+        "git+https://github.com/facebookresearch/pytorch3d.git@${PYTORCH3D_REVISION}" \
+    && python -m pip install --no-cache-dir --no-build-isolation \
+        /opt/longsplat/submodules/simple-knn \
+        /opt/longsplat/submodules/diff-gaussian-rasterization \
+        /opt/longsplat/submodules/fused-ssim
+
+COPY requirements.txt /tmp/autophotogrammetry-requirements.txt
+RUN python -m pip install --no-cache-dir -r /tmp/autophotogrammetry-requirements.txt \
+    && python -m pip check \
+    && python -m pip freeze > /opt/longsplat-environment.txt
+
+COPY . /opt/autophotogrammetry
+WORKDIR /opt/autophotogrammetry
+
+RUN python - <<'PY'
+import subprocess
+import torch
+import torch_scatter
+import pytorch3d
+import diff_gaussian_rasterization
+from simple_knn import _C as simple_knn_cuda
+import fused_ssim
+
+revision = subprocess.run(
+    ['git', '-C', '/opt/longsplat', 'rev-parse', 'HEAD'],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+assert revision == '19750775a9d19f30aa05a8333c4c6c231b2d5f4a', revision
+assert torch.__version__.startswith('2.7.1'), torch.__version__
+print({'longsplat_revision': revision, 'torch': torch.__version__, 'cuda': torch.version.cuda})
+PY

--- a/Dockerfile.longsplat
+++ b/Dockerfile.longsplat
@@ -2,7 +2,7 @@ FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG LONGSPLAT_REVISION=19750775a9d19f30aa05a8333c4c6c231b2d5f4a
-ARG PYTORCH3D_REVISION=97bc85b6d23c9b161f1e3efff676666a3c6c5af3
+ARG PYTORCH3D_REVISION=33824be3cbc87a7dd1db0f6a9a9de9ac81b2d0ba
 ENV CUDA_HOME=/usr/local/cuda \
     TORCH_CUDA_ARCH_LIST=12.0 \
     MAX_JOBS=4 \
@@ -90,5 +90,5 @@ revision = subprocess.run(
 ).stdout.strip()
 assert revision == '19750775a9d19f30aa05a8333c4c6c231b2d5f4a', revision
 assert torch.__version__.startswith('2.7.1'), torch.__version__
-print({'longsplat_revision': revision, 'torch': torch.__version__, 'cuda': torch.version.cuda})
+print({'longsplat_revision': revision, 'pytorch3d_revision': '33824be3cbc87a7dd1db0f6a9a9de9ac81b2d0ba', 'torch': torch.__version__, 'cuda': torch.version.cuda})
 PY


### PR DESCRIPTION
## Goal

Resolve #28's target-sm_120 execution-environment blocker with a real PR Docker-build gate, while keeping LongSplat research-only under its pinned license.

## Pins and deviations

- LongSplat source: `NVlabs/LongSplat@19750775a9d19f30aa05a8333c4c6c231b2d5f4a`
- PyTorch3D: exact official v0.7.9 release commit `33824be3cbc87a7dd1db0f6a9a9de9ac81b2d0ba` instead of upstream floating `pytorch3d@stable`
- torch-scatter: `2.1.2`
- target runtime: CUDA 12.8.1 + PyTorch 2.7.1 / torchvision 0.22.1 cu128 + `TORCH_CUDA_ARCH_LIST=12.0`

The source revision and exact submodule commits stay pinned by the LongSplat Git tree. The runtime deviation from upstream's CUDA-12.1-era environment is explicit and build-tested rather than hidden.

The first image attempt used an incorrect PyTorch3D SHA and failed during Git checkout before dependency compilation. The current branch corrects this to the actual v0.7.9 release commit above; that earlier failure is not represented as CUDA/runtime evidence.

## Changes

- add `Dockerfile.longsplat`:
  - exact LongSplat checkout + recursive exact submodules;
  - removes only GPU-sensitive floating/unpinned lines (`torch`, `torchvision`, `torch_scatter`, `pytorch3d@stable`) from the pinned upstream requirements and owns them explicitly;
  - compiles `simple-knn`, LongSplat pose-aware diff-gaussian-rasterization and fused-ssim against the sm_120 runtime;
  - runs `pip check` and import/revision assertions;
  - records the resolved environment inside the image at `/opt/longsplat-environment.txt`.
- add `LongSplat Image` workflow:
  - PR build + load + import/revision smoke test;
  - main push publish to `ghcr.io/kafka2306/autophotogrammetry:longsplat-1975077-sm120-v1` and a SHA tag.

## Evidence boundary

Passing this workflow proves dependency/source compilation and Python imports for the declared target toolchain. It does not prove a real LongSplat training run on the RTX target. #28 remains open until actual dataset execution.

Commercial production remains excluded under the pinned LongSplat license.

Related: #28.