### PR TITLE
3DGS: finalize exactly 20 real PLY handoff after run-all

### DIFF
--- a/processing/exhibition_manifest.py
+++ b/processing/exhibition_manifest.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Mapping
+
+from processing.gaussian_ply import gaussian_ply_metrics
+from processing.provenance import image_records, sha256_file, write_json
+from processing.video_sources import load_video_registry
+
+FINAL_EXHIBITION_COUNT = 20
+
+
+def _read_json(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def _required_text(value: object, *, field: str, scene_id: str) -> str:
+    text = str(value or "").strip()
+    if not text or text.lower() in {"unknown", "unverified", "needs_review", "none", "null"}:
+        raise ValueError(f"{scene_id}: verified {field} is required")
+    return text
+
+
+def _license_record(source: Mapping, *, scene_id: str) -> dict:
+    value = source.get("license") or {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{scene_id}: license must be an object")
+    return {
+        "name": _required_text(value.get("name"), field="license.name", scene_id=scene_id),
+        "url": _required_text(value.get("url"), field="license.url", scene_id=scene_id),
+    }
+
+
+def _resolve_existing_path(value: object, *, output_root: Path, scene_root: Path) -> Path:
+    path = Path(str(value or ""))
+    candidates = []
+    if path.is_absolute():
+        candidates.append(path)
+        # Container manifests often preserve /workspace/output/... paths. The
+        # portable fallback below re-roots the suffix at the caller's output_root.
+        parts = list(path.parts)
+        if "output" in parts:
+            index = parts.index("output")
+            candidates.append(output_root.joinpath(*parts[index + 1 :]))
+    else:
+        candidates.extend((scene_root / path, output_root / path))
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve()
+        if resolved.exists():
+            return resolved
+    raise ValueError(f"referenced path does not exist: {value}")
+
+
+def _splatfacto_manifest(outer: Mapping, *, output_root: Path, scene_root: Path) -> tuple[dict, Path]:
+    splat = outer.get("splatfacto") or {}
+    if not isinstance(splat, Mapping):
+        raise ValueError(f"{scene_root.name}: splatfacto result is missing")
+    manifest_path = _resolve_existing_path(
+        splat.get("manifest_path"),
+        output_root=output_root,
+        scene_root=scene_root,
+    )
+    manifest = _read_json(manifest_path)
+    if manifest.get("status") != "success":
+        raise ValueError(f"{scene_root.name}: Splatfacto manifest is not success")
+    return manifest, manifest_path
+
+
+def _ply_record(
+    outer: Mapping,
+    child: Mapping,
+    child_manifest_path: Path,
+    *,
+    output_root: Path,
+    scene_root: Path,
+) -> dict:
+    splat = outer.get("splatfacto") or {}
+    child_output = child.get("output") or {}
+    declared_path = splat.get("ply_path") or child_output.get("ply_path")
+    if not declared_path:
+        raise ValueError(f"{scene_root.name}: PLY path is missing")
+
+    path = Path(str(declared_path))
+    if path.is_absolute():
+        ply = _resolve_existing_path(path, output_root=output_root, scene_root=scene_root)
+    else:
+        child_candidate = (child_manifest_path.parent / path).resolve()
+        if child_candidate.is_file():
+            ply = child_candidate
+        else:
+            ply = _resolve_existing_path(path, output_root=output_root, scene_root=scene_root)
+    if not ply.is_file() or ply.stat().st_size <= 0:
+        raise ValueError(f"{scene_root.name}: PLY is missing or empty: {ply}")
+
+    expected_sha = str(splat.get("ply_sha256") or child_output.get("sha256") or "").lower()
+    expected_size = splat.get("ply_size_bytes") or child_output.get("size_bytes")
+    if len(expected_sha) != 64:
+        raise ValueError(f"{scene_root.name}: PLY SHA-256 is missing")
+    actual_sha = sha256_file(ply)
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"{scene_root.name}: PLY SHA-256 mismatch: expected {expected_sha}, got {actual_sha}"
+        )
+    if not isinstance(expected_size, int) or expected_size <= 0:
+        raise ValueError(f"{scene_root.name}: positive PLY size is required")
+    if ply.stat().st_size != expected_size:
+        raise ValueError(
+            f"{scene_root.name}: PLY size mismatch: expected {expected_size}, got {ply.stat().st_size}"
+        )
+
+    # Parsing representation-level metrics is also the final readability gate.
+    metrics = gaussian_ply_metrics(ply)
+    try:
+        relative = ply.relative_to(output_root)
+        materialization_path = f"output/{relative.as_posix()}"
+    except ValueError:
+        materialization_path = str(ply)
+    return {
+        "path": materialization_path,
+        "size_bytes": expected_size,
+        "sha256": actual_sha,
+        "primitive_count": metrics["primitive_count"],
+    }
+
+
+def _playback_record(source: Mapping, outer: Mapping, *, scene_id: str) -> dict:
+    explicit = source.get("playback_url")
+    if explicit:
+        if "requires_untrusted_urls" not in source:
+            raise ValueError(
+                f"{scene_id}: explicit playback_url requires explicit requires_untrusted_urls"
+            )
+        return {
+            "playback_url": str(explicit),
+            "requires_untrusted_urls": bool(source["requires_untrusted_urls"]),
+            "authority": "registry",
+        }
+
+    resolution = outer.get("source_resolution") or {}
+    original_media = source.get("media_url") or (
+        resolution.get("media_url") if isinstance(resolution, Mapping) else None
+    )
+    original_media = _required_text(
+        original_media,
+        field="original media URL for playback fallback",
+        scene_id=scene_id,
+    )
+    return {
+        "playback_url": original_media,
+        "requires_untrusted_urls": True,
+        "authority": "original-media-fallback",
+    }
+
+
+def build_final_exhibition_manifest(
+    registry_path: str | Path = "sources/videos.json",
+    output_root: str | Path = "output",
+    *,
+    expected_count: int = FINAL_EXHIBITION_COUNT,
+    output_path: str | Path | None = None,
+) -> dict:
+    """Build the sole final-20 downstream handoff, failing on any missing real evidence."""
+    if expected_count <= 0:
+        raise ValueError("expected_count must be positive")
+    registry = load_video_registry(registry_path)
+    if len(registry) != expected_count:
+        raise ValueError(
+            f"final exhibition requires exactly {expected_count} registry entries, got {len(registry)}"
+        )
+    ids = [str(source.get("id") or "") for source in registry]
+    if any(not scene_id for scene_id in ids) or len(set(ids)) != len(ids):
+        raise ValueError("final exhibition registry requires unique non-empty ids")
+
+    root = Path(output_root).expanduser().resolve()
+    entries = []
+    for order, source in enumerate(registry, start=1):
+        scene_id = str(source["id"])
+        scene_root = root / scene_id
+        outer_path = scene_root / "manifest.json"
+        if not outer_path.is_file():
+            raise ValueError(f"{scene_id}: production manifest is missing: {outer_path}")
+        outer = _read_json(outer_path)
+        if outer.get("status") != "success":
+            raise ValueError(f"{scene_id}: production manifest is not success")
+        if str(outer.get("dataset") or "") != scene_id:
+            raise ValueError(f"{scene_id}: production manifest dataset identity mismatch")
+
+        source_page = _required_text(
+            source.get("source_page"), field="source_page", scene_id=scene_id
+        )
+        author = _required_text(
+            source.get("author"), field="author", scene_id=scene_id
+        )
+        license_record = _license_record(source, scene_id=scene_id)
+        source_record = outer.get("source") or {}
+        source_sha = str(
+            source_record.get("sha256") if isinstance(source_record, Mapping) else ""
+        ).lower()
+        if len(source_sha) != 64:
+            raise ValueError(f"{scene_id}: source video SHA-256 is missing")
+
+        child, child_path = _splatfacto_manifest(
+            outer, output_root=root, scene_root=scene_root
+        )
+        ply = _ply_record(
+            outer,
+            child,
+            child_path,
+            output_root=root,
+            scene_root=scene_root,
+        )
+        selected_dir = scene_root / "selected"
+        selected = image_records(selected_dir)
+        if not selected:
+            raise ValueError(f"{scene_id}: selected frame evidence is missing")
+
+        training = child.get("training") or {}
+        export = child.get("export") or {}
+        versions = child.get("versions") or {}
+        if not isinstance(training, Mapping) or not isinstance(export, Mapping):
+            raise ValueError(f"{scene_id}: train/export evidence is missing")
+        train_command = training.get("command")
+        export_command = export.get("command")
+        if not isinstance(train_command, list) or not train_command:
+            raise ValueError(f"{scene_id}: exact training command is missing")
+        if not isinstance(export_command, list) or not export_command:
+            raise ValueError(f"{scene_id}: exact export command is missing")
+        if training.get("return_code") != 0 or export.get("return_code") != 0:
+            raise ValueError(f"{scene_id}: train/export return code is not zero")
+
+        playback = _playback_record(source, outer, scene_id=scene_id)
+        probe = outer.get("probe") or {}
+        entries.append(
+            {
+                "id": scene_id,
+                "display_order": order,
+                "title": str(source.get("title") or scene_id),
+                "target": str(source.get("target") or source.get("title") or scene_id),
+                "source_page": source_page,
+                "author": author,
+                "license": license_record,
+                "source_video": {
+                    "sha256": source_sha,
+                    "duration_seconds": probe.get("duration_seconds") if isinstance(probe, Mapping) else None,
+                    "width": probe.get("width") if isinstance(probe, Mapping) else None,
+                    "height": probe.get("height") if isinstance(probe, Mapping) else None,
+                },
+                "selected_frames": selected,
+                "reconstruction": {
+                    "backend": "nerfstudio-splatfacto",
+                    "nerfstudio_version": versions.get("nerfstudio") if isinstance(versions, Mapping) else None,
+                    "gsplat_version": versions.get("gsplat") if isinstance(versions, Mapping) else None,
+                    "training_command": list(train_command),
+                    "export_command": list(export_command),
+                },
+                "ply": ply,
+                **playback,
+            }
+        )
+
+    manifest = {
+        "schema_version": 1,
+        "status": "ready",
+        "entry_count": len(entries),
+        "entries": entries,
+        "contract": {
+            "expected_count": expected_count,
+            "all_entries_require_real_ply": True,
+            "unknown_playback_urls_are_not_fabricated": True,
+        },
+    }
+    destination = (
+        Path(output_path).expanduser().resolve()
+        if output_path is not None
+        else root / "final-exhibition-manifest.json"
+    )
+    write_json(destination, manifest)
+    return {**manifest, "manifest_path": str(destination)}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build the fail-closed exactly-20 AutoPhotogrammetry downstream exhibition manifest."
+    )
+    parser.add_argument("--registry", default="sources/videos.json")
+    parser.add_argument("--output-root", default="output")
+    parser.add_argument("--expected-count", type=int, default=FINAL_EXHIBITION_COUNT)
+    parser.add_argument("--output")
+    args = parser.parse_args()
+    result = build_final_exhibition_manifest(
+        args.registry,
+        args.output_root,
+        expected_count=args.expected_count,
+        output_path=args.output,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/production_batch.py
+++ b/processing/production_batch.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from processing.batch import run_all_videos
+from processing.exhibition_manifest import build_final_exhibition_manifest
+
+
+def run_production_batch(
+    *,
+    registry_path: str = "sources/videos.json",
+    input_root: str = "input",
+    output_root: str = "output",
+    train_iterations: int = 2000,
+    timeout: float | None = None,
+    fresh: bool = False,
+) -> dict:
+    """Run the full registry and finalize the downstream handoff only at exact 20/20 success."""
+    batch = run_all_videos(
+        registry_path=registry_path,
+        input_root=input_root,
+        output_root=output_root,
+        ids=None,
+        train_iterations=train_iterations,
+        timeout=timeout,
+        fresh=fresh,
+    )
+    if batch.get("status") != "success":
+        return {
+            "status": "failed",
+            "failed_phase": "batch",
+            "batch": batch,
+            "final_exhibition_manifest": None,
+        }
+
+    try:
+        final_manifest = build_final_exhibition_manifest(
+            registry_path,
+            output_root,
+        )
+    except Exception as exc:
+        return {
+            "status": "failed",
+            "failed_phase": "final-exhibition-manifest",
+            "error": f"{type(exc).__name__}: {exc}",
+            "batch": batch,
+            "final_exhibition_manifest": None,
+        }
+
+    return {
+        "status": "success",
+        "failed_phase": None,
+        "batch": batch,
+        "final_exhibition_manifest": {
+            "path": final_manifest["manifest_path"],
+            "entry_count": final_manifest["entry_count"],
+            "status": final_manifest["status"],
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run all registered production videos and emit the final exactly-20 exhibition manifest."
+        )
+    )
+    parser.add_argument("--registry", default="sources/videos.json")
+    parser.add_argument("--input-root", default="input")
+    parser.add_argument("--output-root", default="output")
+    parser.add_argument("--train-iterations", type=int, default=2000)
+    parser.add_argument("--timeout", type=float)
+    parser.add_argument("--fresh", action="store_true")
+    args = parser.parse_args()
+    result = run_production_batch(
+        registry_path=args.registry,
+        input_root=args.input_root,
+        output_root=args.output_root,
+        train_iterations=args.train_iterations,
+        timeout=args.timeout,
+        fresh=args.fresh,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if result["status"] != "success":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_exhibition_manifest.py
+++ b/tests/test_exhibition_manifest.py
@@ -1,0 +1,150 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.exhibition_manifest import build_final_exhibition_manifest
+from processing.provenance import sha256_file
+
+
+class ExhibitionManifestTests(unittest.TestCase):
+    def _source(self, index: int) -> dict:
+        return {
+            "id": f"scene-{index:02d}",
+            "title": f"Scene {index:02d}",
+            "target": f"Target {index:02d}",
+            "source_page": f"https://example.test/source/{index}",
+            "author": "Example Author",
+            "license": {
+                "name": "CC BY 4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/",
+            },
+        }
+
+    def _write_scene(self, root: Path, source: dict) -> None:
+        scene = root / source["id"]
+        selected = scene / "selected"
+        selected.mkdir(parents=True)
+        (selected / "frame-000001.jpg").write_bytes(b"frame")
+
+        run = scene / "runs" / "splatfacto" / "run"
+        export = run / "export"
+        export.mkdir(parents=True)
+        ply = export / "splat.ply"
+        ply.write_bytes(b"real-ply-bytes")
+        child = {
+            "status": "success",
+            "versions": {"nerfstudio": "test-ns", "gsplat": "test-gsplat"},
+            "training": {
+                "command": ["ns-train", "splatfacto", "--data", "data"],
+                "return_code": 0,
+            },
+            "export": {
+                "command": ["ns-export", "gaussian-splat"],
+                "return_code": 0,
+            },
+            "output": {
+                "ply_path": "export/splat.ply",
+                "size_bytes": ply.stat().st_size,
+                "sha256": sha256_file(ply),
+            },
+        }
+        child_path = run / "manifest.json"
+        child_path.write_text(json.dumps(child), encoding="utf-8")
+        outer = {
+            "dataset": source["id"],
+            "status": "success",
+            "source_resolution": {
+                "media_url": f"https://upload.wikimedia.org/example/{source['id']}.webm"
+            },
+            "source": {"sha256": "a" * 64},
+            "probe": {"duration_seconds": 120.0, "width": 1920, "height": 1080},
+            "splatfacto": {
+                "manifest_path": str(child_path),
+                "ply_path": str(ply),
+                "ply_sha256": sha256_file(ply),
+                "ply_size_bytes": ply.stat().st_size,
+            },
+        }
+        (scene / "manifest.json").write_text(json.dumps(outer), encoding="utf-8")
+
+    def test_exactly_twenty_real_entries_produce_one_ready_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sources = [self._source(index) for index in range(1, 21)]
+            for source in sources:
+                self._write_scene(root, source)
+            metrics = {"primitive_count": 123}
+            with patch(
+                "processing.exhibition_manifest.load_video_registry",
+                return_value=sources,
+            ), patch(
+                "processing.exhibition_manifest.gaussian_ply_metrics",
+                return_value=metrics,
+            ):
+                result = build_final_exhibition_manifest(
+                    "registry.json",
+                    root,
+                )
+
+            self.assertEqual(result["status"], "ready")
+            self.assertEqual(result["entry_count"], 20)
+            self.assertEqual(
+                [entry["display_order"] for entry in result["entries"]],
+                list(range(1, 21)),
+            )
+            self.assertTrue(all(entry["ply"]["sha256"] for entry in result["entries"]))
+            self.assertTrue(
+                all(entry["requires_untrusted_urls"] for entry in result["entries"])
+            )
+            self.assertTrue(Path(result["manifest_path"]).is_file())
+
+    def test_missing_twentieth_ply_fails_instead_of_emitting_partial_ready(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sources = [self._source(index) for index in range(1, 21)]
+            for source in sources:
+                self._write_scene(root, source)
+            missing = root / "scene-20" / "runs" / "splatfacto" / "run" / "export" / "splat.ply"
+            missing.unlink()
+            with patch(
+                "processing.exhibition_manifest.load_video_registry",
+                return_value=sources,
+            ), patch(
+                "processing.exhibition_manifest.gaussian_ply_metrics",
+                return_value={"primitive_count": 1},
+            ):
+                with self.assertRaisesRegex(ValueError, "referenced path does not exist|PLY"):
+                    build_final_exhibition_manifest("registry.json", root)
+            self.assertFalse((root / "final-exhibition-manifest.json").exists())
+
+    def test_registry_count_must_be_exactly_twenty(self):
+        sources = [self._source(index) for index in range(1, 20)]
+        with tempfile.TemporaryDirectory() as tmp, patch(
+            "processing.exhibition_manifest.load_video_registry",
+            return_value=sources,
+        ):
+            with self.assertRaisesRegex(ValueError, "exactly 20"):
+                build_final_exhibition_manifest("registry.json", tmp)
+
+    def test_explicit_playback_url_requires_explicit_trust_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sources = [self._source(index) for index in range(1, 21)]
+            sources[0]["playback_url"] = "https://example.test/video.mp4"
+            for source in sources:
+                self._write_scene(root, source)
+            with patch(
+                "processing.exhibition_manifest.load_video_registry",
+                return_value=sources,
+            ), patch(
+                "processing.exhibition_manifest.gaussian_ply_metrics",
+                return_value={"primitive_count": 1},
+            ):
+                with self.assertRaisesRegex(ValueError, "requires_untrusted_urls"):
+                    build_final_exhibition_manifest("registry.json", root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_production_batch.py
+++ b/tests/test_production_batch.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from processing.production_batch import run_production_batch
+
+
+class ProductionBatchTests(unittest.TestCase):
+    def test_batch_failure_never_attempts_final_ready_manifest(self):
+        with patch(
+            "processing.production_batch.run_all_videos",
+            return_value={"status": "failed", "results": []},
+        ), patch(
+            "processing.production_batch.build_final_exhibition_manifest"
+        ) as finalizer:
+            result = run_production_batch()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["failed_phase"], "batch")
+        finalizer.assert_not_called()
+
+    def test_full_batch_success_requires_final_twenty_manifest_success(self):
+        with patch(
+            "processing.production_batch.run_all_videos",
+            return_value={"status": "success", "results": [object()] * 20},
+        ), patch(
+            "processing.production_batch.build_final_exhibition_manifest",
+            return_value={
+                "status": "ready",
+                "entry_count": 20,
+                "manifest_path": "output/final-exhibition-manifest.json",
+            },
+        ):
+            result = run_production_batch()
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["final_exhibition_manifest"]["entry_count"], 20)
+
+    def test_finalizer_failure_is_not_relabelled_as_batch_success(self):
+        with patch(
+            "processing.production_batch.run_all_videos",
+            return_value={"status": "success", "results": [object()] * 20},
+        ), patch(
+            "processing.production_batch.build_final_exhibition_manifest",
+            side_effect=ValueError("scene-20: PLY missing"),
+        ):
+            result = run_production_batch()
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["failed_phase"], "final-exhibition-manifest")
+        self.assertIn("PLY missing", result["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Goal

Remove the last repository-side manual handoff step in #33. A successful full production batch must now be able to emit one fail-closed exactly-20 downstream manifest; 9/20 or any missing/corrupt evidence must remain failure rather than being presented as ready.

## Changes

Add `processing.exhibition_manifest`:
- requires registry count = exactly 20 with unique stable IDs;
- requires every `output/<id>/manifest.json` to be actual `success` for the matching dataset;
- requires verified source page / author / license name+URL / source video SHA-256;
- requires selected-frame evidence and records per-frame SHA-256;
- follows the actual Splatfacto child manifest and requires zero train/export return codes and exact commands;
- verifies the real PLY exists, positive size matches, SHA-256 matches, and parses it through the existing Gaussian PLY metric reader as a readability gate;
- records portable output-relative PLY materialization path + hash/size/primitive count;
- uses an explicit registry `playback_url` only when `requires_untrusted_urls` is also explicit;
- otherwise uses the actually resolved original media URL as the documented untrusted fallback (`requires_untrusted_urls=true`) rather than fabricating YouTube/Vimeo/VRCDN hosting;
- writes exactly one `output/final-exhibition-manifest.json` only after all 20 entries validate.

Add `processing.production_batch`:
- runs the existing full `run_all_videos` production path;
- never attempts finalization if the batch failed;
- treats final-manifest failure as overall failure;
- returns success only for full batch success + exactly-20 ready handoff.

## Tests

Covers:
- exactly 20 ready entries;
- missing 20th PLY remains failure and does not write a partial ready manifest;
- registry count != 20 fails;
- explicit playback URL without explicit trust state fails;
- batch failure never runs finalizer;
- finalizer failure is not relabeled success.

## Evidence boundary

This does not claim the missing 11 PLYs already exist. Current empirical state remains 9/20 until `./task run-all` actually generates the remaining artifacts on a GPU. This PR makes the eventual 20/20 completion mechanically provable and removes manual manifest authoring.

Related: #33, #14, #15, downstream vrmine #72/#73.