### PR TITLE
Record generation-time revision for artifact provenance

### DIFF
--- a/.github/workflows/gpu-image.yml
+++ b/.github/workflows/gpu-image.yml
@@ -40,5 +40,6 @@ jobs:
             CUDA_ARCH_LIST=12.0
             NERFSTUDIO_REVISION=50e0e3c70c775e89333256213363badbf074f29d
             GSPLAT_REVISION=v1.4.0
+            AUTOPHOTOGRAMMETRY_REVISION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CUDA_ARCH_LIST=12.0
 ARG NERFSTUDIO_REVISION=50e0e3c70c775e89333256213363badbf074f29d
 ARG GSPLAT_REVISION=v1.4.0
+ARG AUTOPHOTOGRAMMETRY_REVISION
 ENV CUDA_HOME=/usr/local/cuda \
     TORCH_CUDA_ARCH_LIST=${CUDA_ARCH_LIST} \
     TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 \
     MAX_JOBS=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    AUTOPHOTOGRAMMETRY_SOURCE_REVISION=${AUTOPHOTOGRAMMETRY_REVISION}
 
 LABEL org.opencontainers.image.source="https://github.com/KAFKA2306/AutoPhotogrammetry" \
-      org.opencontainers.image.description="Pinned AutoPhotogrammetry CUDA environment for Splatfacto quality experiments"
+      org.opencontainers.image.description="Pinned AutoPhotogrammetry CUDA environment for Splatfacto quality experiments" \
+      org.opencontainers.image.revision="${AUTOPHOTOGRAMMETRY_REVISION}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \

--- a/main.py
+++ b/main.py
@@ -74,6 +74,10 @@ def main() -> None:
     publish_parser.add_argument("--run-manifest", required=True)
     publish_parser.add_argument("--bucket", default=os.environ.get("HF_ARTIFACT_BUCKET"))
     publish_parser.add_argument("--hf-cache-hub-root", default=os.environ.get("HF_CACHE_HUB_ROOT"))
+    publish_parser.add_argument(
+        "--source-revision",
+        help="Explicit generation revision for audited legacy manifests that do not record source_revision.",
+    )
 
     dataset_parser = subparsers.add_parser(
         "evaluation-dataset",
@@ -145,6 +149,7 @@ def main() -> None:
                 args.run_manifest,
                 bucket=args.bucket,
                 hf_cache_hub_root=args.hf_cache_hub_root,
+                source_revision=args.source_revision,
             )
         except ArtifactPublishError as exc:
             print(json.dumps({"status": "failed", "error": str(exc)}, ensure_ascii=False, indent=2))

--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Callable, Sequence
 
 import yaml
@@ -16,17 +16,57 @@ class ArtifactPublishError(RuntimeError):
     pass
 
 
-def git_revision(runner: Callable[..., subprocess.CompletedProcess] = subprocess.run) -> str:
-    result = runner(
-        ["git", "rev-parse", "HEAD"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    revision = result.stdout.strip()
+def _validate_revision(value: str, label: str) -> str:
+    revision = value.strip()
     if len(revision) != 40 or any(c not in "0123456789abcdef" for c in revision):
-        raise ArtifactPublishError(f"git rev-parse did not return a full lowercase commit SHA: {revision!r}")
+        raise ArtifactPublishError(f"{label} must be a full lowercase 40-character Git commit SHA")
     return revision
+
+
+def _recorded_revision(run_manifest: dict, explicit_revision: str | None) -> str:
+    recorded = run_manifest.get("source_revision")
+    if recorded is not None:
+        revision = _validate_revision(str(recorded), "run manifest source_revision")
+        if explicit_revision is not None:
+            explicit = _validate_revision(explicit_revision, "explicit source_revision")
+            if explicit != revision:
+                raise ArtifactPublishError(
+                    "explicit source_revision does not match the generation-time revision recorded in the run manifest"
+                )
+        return revision
+    if explicit_revision is None:
+        raise ArtifactPublishError(
+            "run manifest has no generation-time source_revision; provide --source-revision only for an audited legacy run"
+        )
+    return _validate_revision(explicit_revision, "explicit source_revision")
+
+
+def _resolve_run_artifact_path(run_manifest_path: Path, raw_path: str) -> Path:
+    """Resolve host and container paths without changing the recorded artifact identity."""
+    run_manifest_path = run_manifest_path.expanduser().resolve()
+    raw = Path(raw_path)
+    if raw.is_absolute() and raw.is_file():
+        return raw
+
+    output_root = run_manifest_path.parent.parent
+    repo_root = output_root.parent
+    candidates: list[Path] = []
+    if raw.is_absolute():
+        posix = PurePosixPath(raw_path)
+        workspace_output = PurePosixPath("/workspace/output")
+        try:
+            relative = posix.relative_to(workspace_output)
+        except ValueError:
+            relative = None
+        if relative is not None:
+            candidates.append(output_root.joinpath(*relative.parts))
+    else:
+        candidates.extend((run_manifest_path.parent / raw, repo_root / raw))
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise ArtifactPublishError(f"Gaussian Splat PLY cannot be resolved from run manifest path: {raw_path}")
 
 
 def _hf_cache_command(hf_cache_hub_root: str | Path | None) -> list[str]:
@@ -69,7 +109,6 @@ def build_artifact_manifest(
         "provenance": {
             "repository": "KAFKA2306/AutoPhotogrammetry",
             "revision": source_revision,
-            "source_path": str(ply_path),
             "run_id": run_id,
         },
     }
@@ -88,13 +127,13 @@ def publish_run_splat(
     source_revision: str | None = None,
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
 ) -> dict:
-    run_manifest_path = Path(run_manifest_path)
+    run_manifest_path = Path(run_manifest_path).expanduser().resolve()
     run_manifest = json.loads(run_manifest_path.read_text(encoding="utf-8"))
     if run_manifest.get("status") != "success":
         raise ArtifactPublishError("run manifest is not a successful local reconstruction")
     try:
         splat = run_manifest["splatfacto"]
-        ply_path = Path(splat["ply_path"])
+        ply_path = _resolve_run_artifact_path(run_manifest_path, str(splat["ply_path"]))
         expected_sha = splat["ply_sha256"]
         expected_size = splat["ply_size_bytes"]
     except KeyError as exc:
@@ -105,7 +144,7 @@ def publish_run_splat(
     if actual_sha != expected_sha or actual_size != expected_size:
         raise ArtifactPublishError("local PLY no longer matches the successful run manifest")
 
-    revision = source_revision or git_revision(runner)
+    revision = _recorded_revision(run_manifest, source_revision)
     registry = run_manifest.get("registry", {})
     license_info = registry.get("license") or {}
     source_url = registry.get("source_page")

--- a/processing/huejotzingo.py
+++ b/processing/huejotzingo.py
@@ -12,6 +12,7 @@ from processing.nerfstudio import nerfstudio_process_images_command, run_splatfa
 from processing.provenance import (
     VideoSource,
     sha256_file,
+    source_revision,
     utc_now,
     write_json,
     write_source_manifest,
@@ -213,6 +214,7 @@ def run_huejotzingo(
         "dataset": DATASET,
         "status": "running",
         "started_at": utc_now(),
+        "source_revision": source_revision(),
         "source": {
             "source_registry_id": SOURCE_CONFIG["id"],
             "source_page": SOURCE_PAGE,

--- a/processing/provenance.py
+++ b/processing/provenance.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Mapping
+from typing import Callable, Mapping
 
 IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff"}
 
@@ -23,6 +25,31 @@ class VideoSource:
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def source_revision(
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> str:
+    """Return the exact AutoPhotogrammetry revision executing this run."""
+    revision = os.environ.get("AUTOPHOTOGRAMMETRY_SOURCE_REVISION", "").strip()
+    if not revision:
+        try:
+            completed = runner(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise RuntimeError(
+                "AUTOPHOTOGRAMMETRY_SOURCE_REVISION is required when the runtime does not contain .git"
+            ) from exc
+        revision = completed.stdout.strip()
+    if len(revision) != 40 or any(char not in "0123456789abcdef" for char in revision):
+        raise RuntimeError(
+            "AutoPhotogrammetry source revision must be a full lowercase 40-character Git commit SHA"
+        )
+    return revision
 
 
 def sha256_file(path: str | Path) -> str:

--- a/processing/provenance.py
+++ b/processing/provenance.py
@@ -61,6 +61,15 @@ def sha256_file(path: str | Path) -> str:
 
 
 def write_json(path: str | Path, value: Mapping | list) -> None:
+    # Reconstruction run manifests share these fields. Attach the source revision
+    # before the manifest leaves the generation process so later publication never
+    # has to infer provenance from a newer checkout.
+    if (
+        isinstance(value, dict)
+        and {"dataset", "commands", "started_at", "status"}.issubset(value)
+        and "source_revision" not in value
+    ):
+        value["source_revision"] = source_revision()
     destination = Path(path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -14,8 +14,11 @@ import yaml
 from processing.artifact_publish import ArtifactPublishError, _hf_cache_command, publish_run_splat
 
 
+REVISION = "a" * 40
+
+
 class ArtifactPublishTest(unittest.TestCase):
-    def _fixture(self, root: Path):
+    def _fixture(self, root: Path, *, include_revision: bool = True, container_path: bool = False):
         ply = root / "output" / "demo" / "runs" / "r1" / "export" / "splat.ply"
         ply.parent.mkdir(parents=True)
         payload = b"ply\nsynthetic"
@@ -23,7 +26,7 @@ class ArtifactPublishTest(unittest.TestCase):
         sha = hashlib.sha256(payload).hexdigest()
         manifest = root / "output" / "demo" / "manifest.json"
         manifest.parent.mkdir(parents=True, exist_ok=True)
-        manifest.write_text(json.dumps({
+        body = {
             "schema_version": 2,
             "dataset": "demo",
             "status": "success",
@@ -33,63 +36,117 @@ class ArtifactPublishTest(unittest.TestCase):
                 "license": {"url": "https://creativecommons.org/publicdomain/zero/1.0/"},
             },
             "splatfacto": {
-                "ply_path": str(ply),
+                "ply_path": (
+                    "/workspace/output/demo/runs/r1/export/splat.ply"
+                    if container_path
+                    else str(ply)
+                ),
                 "ply_sha256": sha,
                 "ply_size_bytes": len(payload),
             },
-        }), encoding="utf-8")
+        }
+        if include_revision:
+            body["source_revision"] = REVISION
+        manifest.write_text(json.dumps(body), encoding="utf-8")
         hf_root = root / "hf-cache-hub"
         (hf_root / "scripts").mkdir(parents=True)
         (hf_root / "scripts" / "artifact_manager.py").write_text("# cli", encoding="utf-8")
         return manifest, ply, sha, hf_root
+
+    @staticmethod
+    def _successful_runner(command, **kwargs):
+        if command[:3] == ["git", "rev-parse", "HEAD"]:
+            raise AssertionError("publish must not infer provenance from current HEAD")
+        artifact_manifest = Path(command[command.index("--manifest") + 1])
+        declared = yaml.safe_load(artifact_manifest.read_text(encoding="utf-8"))["artifacts"][0]
+        result = {
+            "status": "PUBLISHED",
+            "remote_verified": True,
+            "remote_uri": f"hf://buckets/{declared['storage']['bucket']}/{declared['storage']['path']}",
+            "sha256": declared["sha256"],
+            "size_bytes": declared["size_bytes"],
+        }
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(result), stderr="")
 
     def test_missing_hf_cache_hub_root_fails_with_required_error(self):
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaisesRegex(ArtifactPublishError, "HF_CACHE_HUB_ROOT"):
                 _hf_cache_command(None)
 
-    def test_publish_records_remote_verified_provenance(self):
+    def test_publish_uses_generation_time_revision_without_git_lookup(self):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             manifest, ply, sha, hf_root = self._fixture(root)
-            calls = []
-
-            def runner(command, **kwargs):
-                calls.append(command)
-                if command[:3] == ["git", "rev-parse", "HEAD"]:
-                    return subprocess.CompletedProcess(command, 0, stdout="a" * 40 + "\n", stderr="")
-                artifact_manifest = Path(command[command.index("--manifest") + 1])
-                declared = yaml.safe_load(artifact_manifest.read_text(encoding="utf-8"))["artifacts"][0]
-                result = {
-                    "status": "PUBLISHED",
-                    "remote_verified": True,
-                    "remote_uri": f"hf://buckets/{declared['storage']['bucket']}/{declared['storage']['path']}",
-                    "sha256": declared["sha256"],
-                    "size_bytes": declared["size_bytes"],
-                }
-                return subprocess.CompletedProcess(command, 0, stdout=json.dumps(result), stderr="")
-
             result = publish_run_splat(
                 manifest,
                 bucket="k4fka/artifacts",
                 hf_cache_hub_root=hf_root,
-                runner=runner,
+                runner=self._successful_runner,
             )
             self.assertEqual("published", result["status"])
             self.assertTrue(result["remote_verified"])
             self.assertEqual(sha, result["sha256"])
-            self.assertEqual("a" * 40, result["source_revision"])
-            artifact_manifest = yaml.safe_load((manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8"))
+            self.assertEqual(REVISION, result["source_revision"])
+            artifact_manifest = yaml.safe_load(
+                (manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8")
+            )
             artifact = artifact_manifest["artifacts"][0]
             self.assertEqual("gaussian-splat", artifact["kind"])
             self.assertEqual("ply", artifact["format"])
             self.assertEqual(sha, artifact["sha256"])
-            self.assertEqual("a" * 40, artifact["provenance"]["revision"])
+            self.assertEqual(REVISION, artifact["provenance"]["revision"])
             self.assertIn("run_id", artifact["provenance"])
+            self.assertNotIn("source_path", artifact["provenance"])
             updated = json.loads(manifest.read_text(encoding="utf-8"))
             self.assertEqual("success", updated["status"])
             self.assertEqual("published", updated["artifact_publish"]["status"])
             self.assertTrue(ply.exists())
+
+    def test_container_output_path_is_resolved_on_host(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, ply, sha, hf_root = self._fixture(root, container_path=True)
+            result = publish_run_splat(
+                manifest,
+                bucket="k4fka/artifacts",
+                hf_cache_hub_root=hf_root,
+                runner=self._successful_runner,
+            )
+            self.assertEqual(sha, result["sha256"])
+            self.assertTrue(ply.exists())
+
+    def test_legacy_manifest_requires_explicit_audited_revision(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root, include_revision=False)
+            with self.assertRaisesRegex(ArtifactPublishError, "audited legacy run"):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    runner=self._successful_runner,
+                )
+            result = publish_run_splat(
+                manifest,
+                bucket="k4fka/artifacts",
+                hf_cache_hub_root=hf_root,
+                source_revision="b" * 40,
+                runner=self._successful_runner,
+            )
+            self.assertEqual("b" * 40, result["source_revision"])
+
+    def test_explicit_revision_cannot_override_recorded_revision(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root)
+            with self.assertRaisesRegex(ArtifactPublishError, "does not match"):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    source_revision="b" * 40,
+                    runner=self._successful_runner,
+                )
 
     def test_publish_failure_preserves_local_run_for_retry(self):
         with tempfile.TemporaryDirectory() as d:
@@ -97,12 +154,20 @@ class ArtifactPublishTest(unittest.TestCase):
             manifest, ply, _, hf_root = self._fixture(root)
 
             def runner(command, **kwargs):
-                if command[:3] == ["git", "rev-parse", "HEAD"]:
-                    return subprocess.CompletedProcess(command, 0, stdout="b" * 40 + "\n", stderr="")
-                return subprocess.CompletedProcess(command, 1, stdout=json.dumps({"status": "FAILED"}), stderr="")
+                return subprocess.CompletedProcess(
+                    command,
+                    1,
+                    stdout=json.dumps({"status": "FAILED"}),
+                    stderr="",
+                )
 
             with self.assertRaises(ArtifactPublishError):
-                publish_run_splat(manifest, bucket="k4fka/artifacts", hf_cache_hub_root=hf_root, runner=runner)
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    runner=runner,
+                )
             updated = json.loads(manifest.read_text(encoding="utf-8"))
             self.assertEqual("success", updated["status"])
             self.assertEqual("failed", updated["artifact_publish"]["status"])
@@ -118,7 +183,6 @@ class ArtifactPublishTest(unittest.TestCase):
                     manifest,
                     bucket="k4fka/artifacts",
                     hf_cache_hub_root=hf_root,
-                    source_revision="c" * 40,
                 )
 
     def test_generated_ply_remains_gitignored(self):

--- a/tests/test_provenance_revision.py
+++ b/tests/test_provenance_revision.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from processing.provenance import source_revision, write_json
+
+
+REVISION = "a" * 40
+
+
+class ProvenanceRevisionTest(unittest.TestCase):
+    def test_environment_revision_is_exact_authority(self):
+        with patch.dict(os.environ, {"AUTOPHOTOGRAMMETRY_SOURCE_REVISION": REVISION}, clear=False):
+            self.assertEqual(REVISION, source_revision())
+
+    def test_reconstruction_manifest_gets_source_revision_before_write(self):
+        manifest = {
+            "schema_version": 2,
+            "dataset": "demo",
+            "status": "running",
+            "started_at": "2026-08-20T00:00:00Z",
+            "commands": [],
+        }
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+            os.environ,
+            {"AUTOPHOTOGRAMMETRY_SOURCE_REVISION": REVISION},
+            clear=False,
+        ):
+            path = Path(directory) / "manifest.json"
+            write_json(path, manifest)
+            saved = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(REVISION, manifest["source_revision"])
+        self.assertEqual(REVISION, saved["source_revision"])
+
+    def test_unrelated_json_is_not_modified(self):
+        payload = {"status": "success", "value": 1}
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+            os.environ,
+            {"AUTOPHOTOGRAMMETRY_SOURCE_REVISION": REVISION},
+            clear=False,
+        ):
+            path = Path(directory) / "result.json"
+            write_json(path, payload)
+            saved = json.loads(path.read_text(encoding="utf-8"))
+        self.assertNotIn("source_revision", payload)
+        self.assertNotIn("source_revision", saved)
+
+    def test_invalid_revision_fails_closed(self):
+        with patch.dict(
+            os.environ,
+            {"AUTOPHOTOGRAMMETRY_SOURCE_REVISION": "main"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "40-character Git commit SHA"):
+                source_revision()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Make Gaussian Splat artifact provenance use the exact AutoPhotogrammetry revision that generated the run instead of inferring provenance later from the publisher checkout.

- GPU image builds now receive `${{ github.sha }}` as `AUTOPHOTOGRAMMETRY_REVISION` and expose it as `AUTOPHOTOGRAMMETRY_SOURCE_REVISION`
- reconstruction run manifests persist the exact 40-character source revision during generation
- artifact publishing uses the recorded run revision and never calls `git rev-parse HEAD` as an implicit fallback
- an explicit `--source-revision` is allowed only for audited legacy manifests that lack a recorded revision; it cannot override a recorded revision
- `/workspace/output/...` PLY paths recorded by Docker runs are mapped back to the matching host `output/...` path before hash verification/publish
- artifact manifests use `run_id` provenance and no longer embed a machine-local PLY path

## Failure semantics

A new run without an exact source revision fails closed. Existing historical run manifests without `source_revision` also fail closed unless an operator supplies an explicitly audited 40-character revision.

The normal prebuilt GPU image path receives the exact GitHub commit at image build time. Local ad-hoc images that do not provide the build argument cannot silently fabricate provenance.

## Tests

- publish never consults current Git HEAD
- recorded revision cannot be overridden
- legacy manifests require an explicit audited revision
- Docker `/workspace/output` paths resolve to the host artifact
- unrelated JSON output is not modified by the run-manifest revision hook
- invalid revision values fail closed

Related:
- https://github.com/KAFKA2306/hf-cache-hub/issues/15
- https://github.com/KAFKA2306/hf-cache-hub/issues/13