### PR TITLE
Pass exact source revision to local GPU image builds

### DIFF
--- a/task
+++ b/task
@@ -64,7 +64,12 @@ prepare_named_runtime() {
 }
 
 build_image() {
-  docker build --pull --build-arg "CUDA_ARCH_LIST=$HOST_GPU_ARCH" -t "$IMAGE" "$ROOT"
+  local source_revision
+  source_revision="$(git -C "$ROOT" rev-parse HEAD)"
+  docker build --pull \
+    --build-arg "CUDA_ARCH_LIST=$HOST_GPU_ARCH" \
+    --build-arg "AUTOPHOTOGRAMMETRY_REVISION=$source_revision" \
+    -t "$IMAGE" "$ROOT"
 }
 
 build_vggt_image() {


### PR DESCRIPTION
## Summary

Close the remaining local-image provenance gap from #76.

`./task image` and `./task test` now resolve the current repository HEAD once and pass it to Docker as `AUTOPHOTOGRAMMETRY_REVISION`. The Dockerfile added by #76 exposes that exact value as `AUTOPHOTOGRAMMETRY_SOURCE_REVISION`, so locally built production images follow the same generation-time revision contract as the GitHub Actions-built image.

No other task commands or research backends are changed.

Related: #76