### PR TITLE
Business: publish readiness service CTAs and empty KPI evidence contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ python main.py audit --dataset <dataset-id>
 
 このコマンドは元画像を削除せず、`readiness-report.json`、`readiness-report.html`、`selected-manifest.json` と別の `selected/` を生成します。登録画像率、再投影誤差、mesh completenessを未測定のまま3D品質保証には使いません。
 
-博物館・資料館、EC商品制作、メーカー、3D制作会社向けの利用範囲とPoC相談方法は [`docs/business/photogrammetry-input-audit.md`](docs/business/photogrammetry-input-audit.md) を参照してください。
+実装上の監査仕様は [`docs/business/photogrammetry-input-audit.md`](docs/business/photogrammetry-input-audit.md)、無料sample・有償PoC・batch相談・権利条件・3つのCTA・60日KPI契約は [`docs/business/photogrammetry-readiness-service.md`](docs/business/photogrammetry-readiness-service.md) を参照してください。
 
 ## 軽量な開発環境
 
@@ -157,38 +157,3 @@ metadata
 - local input: 1920×1080 VP9 transcode
 - SHA-256: `c9723df1af171d40a5bf1f9530aa3ea881c6f95252ef3f2004f0f1013ab92e30`
 - COLMAP: **78 / 78 registered**, **1 model**, **32,782 sparse points**, **0.370830 px mean reprojection error**
-
-探索元: [Wikimedia Commons — Drone videos from Mexico](https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Mexico)
-
-## Output
-
-```text
-output/huejotzingo/
-├── frames/
-├── selected/
-├── colmap/
-├── nerfstudio-data/
-├── runs/
-└── manifest.json
-```
-
-E2E成功条件:
-
-```json
-{
-  "status": "success",
-  "output": {
-    "ply_path": "...",
-    "ply_sha256": "...",
-    "ply_size_bytes": 123456
-  }
-}
-```
-
-PLY hashが得られるまで成功扱いにしません。
-
-## Scope
-
-このrepoの終点は **Gaussian Splat PLY + provenance** です。
-
-PLYのWeb / Unity / VRChat利用は [`KAFKA2306/vrmine`](https://github.com/KAFKA2306/vrmine) が担当します。

--- a/docs/business/photogrammetry-readiness-service.md
+++ b/docs/business/photogrammetry-readiness-service.md
@@ -1,0 +1,94 @@
+# Photogrammetry readiness audit service
+
+AutoPhotogrammetry can turn a rights-cleared photo set into an auditable pre-reconstruction package: a JSON/HTML readiness report, a non-destructively selected image set, provenance evidence, and—when explicitly included—an external reconstruction run manifest.
+
+This service is for museums and archives, product/EC teams and manufacturers, and 3D production teams that already control the submitted photographs or have confirmed permission to use them.
+
+## What is being sold
+
+The initial service is a **photo-set audit and reconstruction-preparation service**, not a guarantee that a complete or metrically accurate 3D model will be produced.
+
+The audit can report evidence such as:
+
+- input and selected image counts
+- exact and near-duplicate evidence
+- low-sharpness warnings
+- provenance coverage and SHA-256
+- image dimensions/content types
+- a non-destructive selected set and manifest
+- `generated_views_used=false`
+- an explicitly supplied backend run status/manifest when a reconstruction is part of the engagement
+- measurements that remain unavailable rather than replacing them with inferred scores
+
+Registration rate, reprojection error, geometry completeness and texture quality are not promised when they have not actually been measured.
+
+## Required material and rights
+
+For a customer dataset:
+
+1. The customer must control the submitted photographs or provide a confirmed license/permission basis for the intended processing.
+2. Do not submit private photographs, personal information, credentials, unpublished contract terms or other confidential material through a public GitHub issue.
+3. A private transfer method must be agreed before customer image bytes are transferred.
+4. Customer images are not converted into public repository fixtures without separate explicit permission.
+
+## Free sample
+
+The free sample is intended to demonstrate the report format and evidence contract using a small redistribution-safe or synthetic dataset. It does not include a commitment to a full reconstruction or a private customer-data transfer.
+
+Typical sample output:
+
+- readiness JSON/HTML
+- selected-manifest JSON
+- reason-code summary
+- provenance and hash fields
+- explicit unmeasured-quality fields
+
+See `sample-readiness-report.json` in this directory for an illustrative, non-customer sample record.
+
+## Paid one-object PoC
+
+A paid PoC can cover one customer-controlled object/asset and an agreed photo set, typically tens to hundreds of images. Scope is agreed before transfer and can include:
+
+- readiness audit
+- selected backend-input set
+- provenance/SHA-256 evidence available from the submitted manifest
+- one agreed reconstruction backend run when the required environment is available
+- backend run manifest and artifact inventory
+- explicit notes about failed or unmeasured criteria
+
+Pricing, turnaround time, image count, reconstruction backend, confidentiality requirements and the rights basis are agreed per PoC. No automatic payment or SaaS subscription is required for the first validation stage.
+
+## Batch / deployment discussion
+
+For 10+ objects, the discussion can cover repeatable batch processing, capture guidance, recapture rounds and/or private deployment of the CLI. A batch request is not treated as proven demand until an actual qualified inquiry is recorded.
+
+## Calls to action
+
+These public issue links collect **non-confidential qualification information only**.
+
+### 撮影セットを監査する
+
+[Open an input-audit inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+input+audit+inquiry&body=Organization+type+%28museum%2Farchive%2FEC%2Fmanufacturer%2F3D+production%2Fother%29%3A%0AObject+or+asset+type%3A%0AApproximate+image+count%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0AWhat+would+you+like+the+audit+to+check%3F%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
+
+### 1対象物のPoCを相談する
+
+[Open a one-object PoC inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+one-object+PoC+inquiry&body=Organization+type%3A%0AObject+or+asset+type%3A%0AApproximate+image+count%3A%0AIntended+3D+use%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0ADesired+timing%3A%0AWhat+decision+should+the+PoC+support%3F%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
+
+### 大量3D化を相談する
+
+[Open a batch/deployment inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+batch+or+deployment+inquiry&body=Organization+type%3A%0AApproximate+object+count%3A%0AApproximate+images+per+object%3A%0ACapture+workflow%3A%0AIntended+3D+use%3A%0APreferred+operation+%28managed+batch%2Fprivate+CLI%2Fprivate+deployment%2Funsure%29%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
+
+## Measurement contract
+
+Only the following funnel events are counted for the initial validation:
+
+- `service_page_viewed`
+- `sample_report_opened`
+- `audit_inquiry_started`
+- `qualified_inquiry`
+- `pilot_booked`
+- `paid_pilot`
+
+These events must not contain customer image bytes, names, email addresses, phone numbers, issue-body text or other personal/confidential payloads. `readiness-service-kpi-template.json` defines the 60-day targets and the empty evidence slots. Empty/null evidence means **not yet measured**, not zero success.
+
+The external success criteria in Issue #3 remain empirical. Publishing this page or adding tracking infrastructure does not count as a proposal, qualified inquiry, booked pilot or paid pilot.

--- a/docs/business/readiness-service-kpi-template.json
+++ b/docs/business/readiness-service-kpi-template.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": 1,
+  "measurement_window_days": 60,
+  "launch_date": null,
+  "window_end_date": null,
+  "status": "not_started",
+  "privacy": {
+    "allow_personal_data": false,
+    "allow_customer_image_bytes": false,
+    "allow_confidential_issue_text": false
+  },
+  "events": {
+    "service_page_viewed": {
+      "count": null,
+      "evidence": null
+    },
+    "sample_report_opened": {
+      "count": null,
+      "evidence": null
+    },
+    "audit_inquiry_started": {
+      "count": null,
+      "evidence": null
+    },
+    "qualified_inquiry": {
+      "count": null,
+      "evidence": null
+    },
+    "pilot_booked": {
+      "count": null,
+      "evidence": null
+    },
+    "paid_pilot": {
+      "count": null,
+      "evidence": null
+    }
+  },
+  "business_kpis": {
+    "sample_report_views": {
+      "target": 150,
+      "actual": null,
+      "evidence": null
+    },
+    "direct_proposals": {
+      "target": 10,
+      "actual": null,
+      "evidence": null
+    },
+    "qualified_inquiries": {
+      "target": 3,
+      "actual": null,
+      "evidence": null
+    },
+    "customer_dataset_audit_demos": {
+      "target": 2,
+      "actual": null,
+      "evidence": null
+    },
+    "paid_pilots": {
+      "target": 1,
+      "actual": null,
+      "evidence": null
+    },
+    "batch_or_continuation_requests_10_plus_objects": {
+      "target": 1,
+      "actual": null,
+      "evidence": null
+    }
+  },
+  "notes": "Null means not measured. Do not replace missing external evidence with zero or a repository action."
+}

--- a/docs/business/sample-readiness-report.json
+++ b/docs/business/sample-readiness-report.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "sample_kind": "illustrative_synthetic_no_customer_data",
+  "asset_id": "sample-synthetic-object",
+  "generated_views_used": false,
+  "input": {
+    "count": 24,
+    "source_manifest": "sample/source-manifest.json"
+  },
+  "selection": {
+    "selected_count": 16,
+    "selected_dir": "sample/selected",
+    "reason_counts": {
+      "LOW_SHARPNESS": 3,
+      "NEAR_DUPLICATE": 5,
+      "EXACT_DUPLICATE": 2,
+      "PROVENANCE_MISSING": 0,
+      "DECODE_ERROR": 0,
+      "UNSUPPORTED_CONTENT_TYPE": 0,
+      "REVIEW_VIEW_COVERAGE": 1
+    }
+  },
+  "provenance": {
+    "covered_count": 24,
+    "coverage_ratio": 1.0
+  },
+  "backend": {
+    "status": "not_run",
+    "run_manifest_path": null
+  },
+  "quality_measurements": {
+    "registration_rate": null,
+    "reprojection_error": null,
+    "mesh_completeness": null,
+    "quality_guarantee": false
+  },
+  "notice": "Illustrative synthetic sample only. Counts are examples for the report format and are not customer results or reconstruction-performance evidence."
+}


### PR DESCRIPTION
## Goal

Close the repository/public-facing portions of #3 without claiming that external demand has already been validated.

## Changes

- add `docs/business/photogrammetry-readiness-service.md`:
  - identifies museums/archives, EC/manufacturing and 3D production as the initial customer groups;
  - separates free sample, paid one-object PoC and 10+ object batch/private-deployment discussion;
  - fixes the rights/confidential-data boundary before customer image transfer;
  - explicitly states that unmeasured registration/reprojection/completeness/texture criteria are not guaranteed;
  - provides all three required CTAs:
    - 撮影セットを監査する
    - 1対象物のPoCを相談する
    - 大量3D化を相談する
  - all public issue CTAs explicitly prohibit private image/personal/confidential payloads.
- add `sample-readiness-report.json` as an **illustrative synthetic/no-customer-data** report, with an explicit notice that its counts are examples rather than performance evidence.
- add `readiness-service-kpi-template.json`:
  - exact six funnel events from #3;
  - 60-day target values;
  - all actual/evidence fields remain `null` until observed;
  - PII/customer-image/confidential-text collection is forbidden.
- link the service contract from README while retaining the more technical input-audit document.

## Evidence boundary

This does **not** satisfy or fabricate the external success criteria: 150 sample views, 10 direct proposals, 3 qualified inquiries, 2 customer-data demos, 1 paid pilot, or 1 batch/continuation request. Those remain empirical and must be backed by actual external evidence.

Related: #3.