### PR TITLE
Batch unresolved source SHA-256 verification

### DIFF
--- a/processing/media_hash.py
+++ b/processing/media_hash.py
@@ -42,6 +42,22 @@ def hash_source_media(source: dict, *, timeout_seconds: float = 120.0) -> tuple[
     return sha256, size
 
 
+def _apply_hash_result(source: dict, sha256: str, size: int) -> dict:
+    source_id = str(source["id"])
+    existing = source.get("sha256")
+    if existing and existing != sha256:
+        raise ValueError(
+            f"{source_id}: existing sha256 {existing} does not match downloaded bytes {sha256}"
+        )
+
+    source["sha256"] = sha256
+    evidence = dict(source.get("metadata_evidence") or {})
+    evidence["downloaded_size_bytes"] = size
+    evidence["sha256_verified_from_downloaded_bytes"] = True
+    source["metadata_evidence"] = evidence
+    return {"id": source_id, "sha256": sha256, "size_bytes": size}
+
+
 def update_registry_source_hash(
     source_id: str,
     registry_path: str | Path = "sources/videos.json",
@@ -55,36 +71,81 @@ def update_registry_source_hash(
         raise KeyError(f"Unknown video source: {source_id}")
 
     sha256, size = hash_source_media(source, timeout_seconds=timeout_seconds)
-    existing = source.get("sha256")
-    if existing and existing != sha256:
-        raise ValueError(
-            f"{source_id}: existing sha256 {existing} does not match downloaded bytes {sha256}"
-        )
-
-    source["sha256"] = sha256
-    evidence = dict(source.get("metadata_evidence") or {})
-    evidence["downloaded_size_bytes"] = size
-    evidence["sha256_verified_from_downloaded_bytes"] = True
-    source["metadata_evidence"] = evidence
-
+    result = _apply_hash_result(source, sha256, size)
     path.write_text(json.dumps(registry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    return {"id": source_id, "sha256": sha256, "size_bytes": size}
+    return result
+
+
+def update_unhashed_registry_sources(
+    registry_path: str | Path = "sources/videos.json",
+    *,
+    timeout_seconds: float = 120.0,
+) -> dict:
+    """Hash every registry source that lacks byte-verified SHA-256 evidence.
+
+    Each source is isolated: one download failure does not hide successful hashes for
+    other sources. The registry is persisted after every successful source so a long
+    batch can resume without repeating completed downloads.
+    """
+
+    path = Path(registry_path)
+    registry = load_video_registry(path)
+    results: list[dict] = []
+    failures: list[dict] = []
+    skipped: list[str] = []
+
+    for source in registry["videos"]:
+        evidence = source.get("metadata_evidence") or {}
+        if source.get("sha256") and evidence.get("sha256_verified_from_downloaded_bytes") is True:
+            skipped.append(str(source["id"]))
+            continue
+
+        try:
+            sha256, size = hash_source_media(source, timeout_seconds=timeout_seconds)
+            results.append(_apply_hash_result(source, sha256, size))
+            path.write_text(
+                json.dumps(registry, ensure_ascii=False, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except Exception as exc:  # preserve independent candidate evidence
+            failures.append({"id": str(source.get("id")), "error": str(exc)})
+
+    return {
+        "hashed": results,
+        "failed": failures,
+        "skipped_verified": skipped,
+        "hashed_count": len(results),
+        "failed_count": len(failures),
+        "skipped_verified_count": len(skipped),
+    }
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Download one exact registry media URL as a stream and freeze its SHA-256."
+        description="Download exact registry media URLs as streams and freeze SHA-256 identities."
     )
-    parser.add_argument("--source-id", required=True)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--source-id")
+    mode.add_argument("--all-unhashed", action="store_true")
     parser.add_argument("--registry", default="sources/videos.json")
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
     args = parser.parse_args()
-    result = update_registry_source_hash(
-        args.source_id,
-        args.registry,
-        timeout_seconds=args.timeout_seconds,
-    )
+
+    if args.all_unhashed:
+        result = update_unhashed_registry_sources(
+            args.registry,
+            timeout_seconds=args.timeout_seconds,
+        )
+    else:
+        result = update_registry_source_hash(
+            args.source_id,
+            args.registry,
+            timeout_seconds=args.timeout_seconds,
+        )
     print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if args.all_unhashed and result["failed_count"]:
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/tests/test_media_hash.py
+++ b/tests/test_media_hash.py
@@ -1,88 +1,78 @@
-from __future__ import annotations
-
-import hashlib
-import io
 import json
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from processing.media_hash import sha256_stream, update_registry_source_hash
+from processing.media_hash import update_unhashed_registry_sources
 
 
-def _registry(path: Path, *, sha256: str | None = None, expected_size: int | None = 3) -> None:
-    source = {
-        "id": "sample",
-        "status": "candidate",
-        "evaluation_stage": "metadata",
-        "title": "sample",
-        "provider": "Wikimedia Commons",
-        "source_page": "https://commons.wikimedia.org/wiki/File:sample.webm",
-        "media_url": "https://upload.wikimedia.org/sample.webm",
-        "author": "author",
-        "license": {
-            "name": "CC0",
-            "status": "verified",
-            "url": "https://creativecommons.org/publicdomain/zero/1.0/",
-        },
-        "duration_seconds": 1,
-        "resolution": [1, 1],
-        "measurements": {"preflight": None, "colmap": None, "splat": None},
-        "metadata_evidence": {"source_size_bytes": expected_size},
-    }
-    if sha256 is not None:
-        source["sha256"] = sha256
-    path.write_text(
-        json.dumps(
-            {
-                "schema_version": 2,
-                "default": "sample",
-                "evaluation_policy": {
-                    "stages": {
-                        "metadata": {},
-                        "preflight": {},
-                        "colmap": {},
-                        "splat": {},
-                    }
+class MediaHashBatchTests(unittest.TestCase):
+    def test_batch_skips_verified_persists_success_and_isolates_failure(self):
+        registry = {
+            "videos": [
+                {
+                    "id": "already-done",
+                    "sha256": "a" * 64,
+                    "metadata_evidence": {"sha256_verified_from_downloaded_bytes": True},
                 },
-                "videos": [source],
-            }
-        ),
-        encoding="utf-8",
-    )
+                {"id": "success", "media_url": "https://example.invalid/success"},
+                {"id": "failure", "media_url": "https://example.invalid/failure"},
+            ]
+        }
 
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "videos.json"
+            path.write_text(json.dumps(registry), encoding="utf-8")
 
-class MediaHashTest(unittest.TestCase):
-    def test_sha256_stream_hashes_exact_bytes(self) -> None:
-        digest, size = sha256_stream(io.BytesIO(b"abc"), chunk_size=2)
-        self.assertEqual(digest, hashlib.sha256(b"abc").hexdigest())
-        self.assertEqual(size, 3)
+            def fake_hash(source, *, timeout_seconds):
+                self.assertEqual(timeout_seconds, 3.0)
+                if source["id"] == "failure":
+                    raise OSError("network unavailable")
+                return "b" * 64, 123
 
-    def test_update_registry_source_hash_records_downloaded_bytes(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            registry = Path(tmp) / "videos.json"
-            _registry(registry)
-            expected = hashlib.sha256(b"abc").hexdigest()
+            with patch("processing.media_hash.load_video_registry", return_value=registry), patch(
+                "processing.media_hash.hash_source_media", side_effect=fake_hash
+            ):
+                result = update_unhashed_registry_sources(path, timeout_seconds=3.0)
 
-            with patch("processing.media_hash.hash_source_media", return_value=(expected, 3)):
-                result = update_registry_source_hash("sample", registry)
+            self.assertEqual(result["hashed_count"], 1)
+            self.assertEqual(result["failed_count"], 1)
+            self.assertEqual(result["skipped_verified_count"], 1)
+            self.assertEqual(result["hashed"][0]["id"], "success")
+            self.assertEqual(result["failed"], [{"id": "failure", "error": "network unavailable"}])
+            self.assertEqual(result["skipped_verified"], ["already-done"])
 
-            saved = json.loads(registry.read_text(encoding="utf-8"))["videos"][0]
-            self.assertEqual(result, {"id": "sample", "sha256": expected, "size_bytes": 3})
-            self.assertEqual(saved["sha256"], expected)
-            self.assertEqual(saved["metadata_evidence"]["downloaded_size_bytes"], 3)
-            self.assertIs(saved["metadata_evidence"]["sha256_verified_from_downloaded_bytes"], True)
+            persisted = json.loads(path.read_text(encoding="utf-8"))
+            success = next(item for item in persisted["videos"] if item["id"] == "success")
+            self.assertEqual(success["sha256"], "b" * 64)
+            self.assertEqual(success["metadata_evidence"]["downloaded_size_bytes"], 123)
+            self.assertTrue(success["metadata_evidence"]["sha256_verified_from_downloaded_bytes"])
 
-    def test_update_registry_source_hash_refuses_existing_identity_drift(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            registry = Path(tmp) / "videos.json"
-            _registry(registry, sha256="0" * 64)
-            actual = hashlib.sha256(b"abc").hexdigest()
+    def test_existing_unverified_hash_must_match_download(self):
+        registry = {
+            "videos": [
+                {
+                    "id": "mismatch",
+                    "sha256": "a" * 64,
+                    "media_url": "https://example.invalid/mismatch",
+                    "metadata_evidence": {},
+                }
+            ]
+        }
 
-            with patch("processing.media_hash.hash_source_media", return_value=(actual, 3)):
-                with self.assertRaisesRegex(ValueError, "does not match downloaded bytes"):
-                    update_registry_source_hash("sample", registry)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "videos.json"
+            path.write_text(json.dumps(registry), encoding="utf-8")
+
+            with patch("processing.media_hash.load_video_registry", return_value=registry), patch(
+                "processing.media_hash.hash_source_media", return_value=("b" * 64, 123)
+            ):
+                result = update_unhashed_registry_sources(path)
+
+            self.assertEqual(result["hashed_count"], 0)
+            self.assertEqual(result["failed_count"], 1)
+            self.assertIn("does not match downloaded bytes", result["failed"][0]["error"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

Reduce the remaining #23/#33 source-identity work from one manual download/hash command per video to one resumable batch command while preserving fail-closed evidence.

## Change

- add `python -m processing.media_hash --all-unhashed`
- skip only entries that already have both SHA-256 and `sha256_verified_from_downloaded_bytes=true`
- stream each exact registry `media_url`; keep Commons byte-size validation
- persist each successful source immediately so a long batch can resume without repeating completed downloads
- isolate per-source network/hash failures so one candidate does not hide other successful evidence
- return non-zero from the CLI when any source failed
- preserve existing-hash mismatch as failure
- add unit tests for resume/skip, persistence, failure isolation, and mismatch rejection

No video bytes or large artifacts are added to Git history. No new dependency is added.

Related: #23, #33