### PR TITLE
Business: bind readiness report to backend run evidence

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,10 @@ def main() -> None:
     audit_parser.add_argument("--output-root", default="output")
     audit_parser.add_argument("--sharpness-threshold", type=float, default=0.0001)
     audit_parser.add_argument("--similarity-threshold", type=float, default=0.92)
+    audit_parser.add_argument(
+        "--backend-run-manifest",
+        help="Optional existing backend run manifest to link by path and SHA-256.",
+    )
 
     huejotzingo_parser = subparsers.add_parser(
         "huejotzingo",
@@ -135,6 +139,7 @@ def main() -> None:
             output_root=args.output_root,
             sharpness_threshold=args.sharpness_threshold,
             similarity_threshold=args.similarity_threshold,
+            backend_run_manifest=args.backend_run_manifest,
         )
     elif args.command == "huejotzingo":
         result = run_huejotzingo(

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -27,6 +27,55 @@ def _read_manifest(path: Path) -> list[dict]:
     return payload
 
 
+def _backend_evidence(dataset: str, manifest_path: str | Path | None) -> dict:
+    if manifest_path is None:
+        return {
+            "asset_id": dataset,
+            "status": "not_run",
+            "run_manifest_path": None,
+            "run_manifest_sha256": None,
+            "return_code": None,
+        }
+
+    path = Path(manifest_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Backend run manifest does not exist: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Backend run manifest must be a JSON object: {path}")
+
+    identity_fields = ("asset_id", "dataset", "scene", "source_id")
+    identities = {
+        field: str(payload[field])
+        for field in identity_fields
+        if payload.get(field) not in (None, "")
+    }
+    mismatches = {field: value for field, value in identities.items() if value != dataset}
+    if mismatches:
+        raise ValueError(
+            f"Backend run manifest identity does not match asset_id {dataset!r}: {mismatches}"
+        )
+
+    return_code = payload.get("return_code")
+    declared_status = payload.get("status")
+    if isinstance(declared_status, str) and declared_status:
+        status = declared_status
+    elif return_code == 0:
+        status = "success"
+    elif isinstance(return_code, int):
+        status = "failed"
+    else:
+        status = "recorded"
+
+    return {
+        "asset_id": dataset,
+        "status": status,
+        "run_manifest_path": str(path),
+        "run_manifest_sha256": sha256_file(path),
+        "return_code": return_code if isinstance(return_code, int) else None,
+    }
+
+
 def _render_html(report: dict) -> str:
     reason_counts = report["selection"]["reason_counts"]
     dimensions = report["dimensions"]
@@ -43,6 +92,7 @@ def _render_html(report: dict) -> str:
         ),
         ("Distinct image sizes", dimensions["distinct_size_count"]),
         ("Backend execution", report["backend"]["status"]),
+        ("Backend manifest", report["backend"]["run_manifest_path"] or "not recorded"),
     ]
     table = "\n".join(
         f"<tr><th>{html.escape(str(label))}</th><td>{html.escape(str(value))}</td></tr>"
@@ -81,6 +131,7 @@ def build_readiness_report(
     output_root: str | Path = "output",
     sharpness_threshold: float = 0.0001,
     similarity_threshold: float = 0.92,
+    backend_run_manifest: str | Path | None = None,
 ) -> dict:
     image_dir = Path(input_root) / dataset / "images"
     if not image_dir.is_dir():
@@ -139,6 +190,7 @@ def build_readiness_report(
 
     missing_provenance = len(image_paths) - covered
     distinct_sizes = sorted(set(dimensions))
+    backend = _backend_evidence(dataset, backend_run_manifest)
     report = {
         "schema_version": 1,
         "asset_id": dataset,
@@ -168,10 +220,7 @@ def build_readiness_report(
             "sizes": [[width, height] for width, height in distinct_sizes],
             "content_types": dict(sorted(content_types.items())),
         },
-        "backend": {
-            "status": "not_run",
-            "run_manifest_path": None,
-        },
+        "backend": backend,
         "quality_measurements": {
             "registration_rate": None,
             "reprojection_error": None,
@@ -185,6 +234,7 @@ def build_readiness_report(
         "asset_id": dataset,
         "generated_views_used": False,
         "source_manifest": str(source_manifest_path),
+        "backend_run_manifest": backend["run_manifest_path"],
         "images": [
             {
                 "filename": path.name,

--- a/tests/test_readiness_report.py
+++ b/tests/test_readiness_report.py
@@ -20,32 +20,36 @@ class ReadinessReportTests(unittest.TestCase):
         array = np.full((128, 128, 3), 127, dtype=np.uint8)
         Image.fromarray(array, mode="RGB").save(path)
 
+    def _write_input(self, root: Path) -> Path:
+        image_dir = root / "input" / "artifact" / "images"
+        image_dir.mkdir(parents=True)
+        first = image_dir / "first.jpg"
+        duplicate = image_dir / "duplicate.jpg"
+        blurry = image_dir / "blurry.jpg"
+        self._write_checkerboard(first)
+        duplicate.write_bytes(first.read_bytes())
+        self._write_flat(blurry)
+
+        records = []
+        for path in (first, duplicate, blurry):
+            records.append(
+                {
+                    "source_page": "https://example.test/object",
+                    "image_url": f"https://example.test/{path.name}",
+                    "local_path": str(path),
+                    "sha256": sha256_file(path),
+                    "width": 128,
+                    "height": 128,
+                    "content_type": "image/jpeg",
+                }
+            )
+        write_json(image_dir / "manifest.json", records)
+        return image_dir
+
     def test_report_uses_existing_selection_and_preserves_quality_boundary(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            image_dir = root / "input" / "artifact" / "images"
-            image_dir.mkdir(parents=True)
-            first = image_dir / "first.jpg"
-            duplicate = image_dir / "duplicate.jpg"
-            blurry = image_dir / "blurry.jpg"
-            self._write_checkerboard(first)
-            duplicate.write_bytes(first.read_bytes())
-            self._write_flat(blurry)
-
-            records = []
-            for path in (first, duplicate, blurry):
-                records.append(
-                    {
-                        "source_page": "https://example.test/object",
-                        "image_url": f"https://example.test/{path.name}",
-                        "local_path": str(path),
-                        "sha256": sha256_file(path),
-                        "width": 128,
-                        "height": 128,
-                        "content_type": "image/jpeg",
-                    }
-                )
-            write_json(image_dir / "manifest.json", records)
+            self._write_input(root)
 
             result = build_readiness_report(
                 "artifact",
@@ -71,6 +75,8 @@ class ReadinessReportTests(unittest.TestCase):
             self.assertEqual(report["provenance"]["covered_count"], 3)
             self.assertEqual(report["provenance"]["coverage_ratio"], 1.0)
             self.assertFalse(report["generated_views_used"])
+            self.assertEqual(report["backend"]["status"], "not_run")
+            self.assertIsNone(report["backend"]["run_manifest_path"])
             self.assertFalse(report["quality_measurements"]["quality_guarantee"])
             self.assertIsNone(report["quality_measurements"]["registration_rate"])
             self.assertIsNone(report["quality_measurements"]["reprojection_error"])
@@ -78,6 +84,60 @@ class ReadinessReportTests(unittest.TestCase):
             self.assertEqual(selected_manifest["asset_id"], "artifact")
             self.assertEqual(len(selected_manifest["images"]), 1)
             self.assertIn("does not guarantee 3D reconstruction quality", report_html)
+
+    def test_report_links_existing_backend_manifest_by_asset_and_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_input(root)
+            backend_manifest = root / "backend-run.json"
+            write_json(
+                backend_manifest,
+                {
+                    "dataset": "artifact",
+                    "status": "success",
+                    "return_code": 0,
+                    "command": ["example-backend", "artifact"],
+                },
+            )
+
+            result = build_readiness_report(
+                "artifact",
+                input_root=root / "input",
+                output_root=root / "output",
+                backend_run_manifest=backend_manifest,
+            )
+            report = json.loads(Path(result["report_json"]).read_text(encoding="utf-8"))
+            selected_manifest = json.loads(
+                Path(result["selected_manifest"]).read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(report["backend"]["asset_id"], "artifact")
+            self.assertEqual(report["backend"]["status"], "success")
+            self.assertEqual(report["backend"]["return_code"], 0)
+            self.assertEqual(report["backend"]["run_manifest_path"], str(backend_manifest))
+            self.assertEqual(
+                report["backend"]["run_manifest_sha256"],
+                sha256_file(backend_manifest),
+            )
+            self.assertEqual(
+                selected_manifest["backend_run_manifest"],
+                str(backend_manifest),
+            )
+
+    def test_report_rejects_backend_manifest_for_another_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._write_input(root)
+            backend_manifest = root / "backend-run.json"
+            write_json(backend_manifest, {"dataset": "other", "return_code": 0})
+
+            with self.assertRaisesRegex(ValueError, "does not match asset_id"):
+                build_readiness_report(
+                    "artifact",
+                    input_root=root / "input",
+                    output_root=root / "output",
+                    backend_run_manifest=backend_manifest,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Close the remaining repository-side traceability gap in #3 without fabricating business traction.

## Change

- `audit` accepts an optional existing `--backend-run-manifest`.
- readiness JSON records the same `asset_id`, backend status, return code when present, manifest path and manifest SHA-256.
- selected manifest points to the same backend run manifest.
- if the backend manifest declares `asset_id`, `dataset`, `scene`, or `source_id`, a mismatch fails closed.
- absent backend execution remains explicit `not_run`; no quality metric is inferred from it.
- the HTML report surfaces the backend manifest path while preserving the existing no-quality-guarantee boundary.

## Tests

Covers no-backend state, valid same-asset linkage/hash, and cross-asset rejection.

This does not claim any views, inquiries, paid pilots, or other external KPI success. Those remain empirical gates in #3.