### PR TITLE
Nordic: fix exact 8-region Commons seed authority

### DIFF
--- a/processing/nordic_seeds.py
+++ b/processing/nordic_seeds.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+EXPECTED_REGION_IDS = (
+    "norway",
+    "sweden",
+    "finland",
+    "denmark",
+    "iceland",
+    "greenland",
+    "faroe-islands",
+    "aland",
+)
+SEED_TYPES = {"drone", "aerial", "general-video"}
+
+
+def load_nordic_seeds(path: str | Path = "sources/discovery/nordic-seeds.json") -> dict:
+    source = Path(path)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    validate_nordic_seeds(payload)
+    return payload
+
+
+def validate_nordic_seeds(payload: Mapping) -> None:
+    if payload.get("schema_version") != 1:
+        raise ValueError("Nordic seed schema_version must be 1")
+    regions = payload.get("regions")
+    if not isinstance(regions, list):
+        raise ValueError("Nordic seed regions must be a list")
+
+    region_ids = [region.get("id") for region in regions if isinstance(region, Mapping)]
+    if tuple(region_ids) != EXPECTED_REGION_IDS:
+        raise ValueError(
+            f"Nordic seed coverage/order must be exactly {EXPECTED_REGION_IDS}; got {region_ids}"
+        )
+
+    categories: set[str] = set()
+    for region in regions:
+        if not isinstance(region, Mapping):
+            raise ValueError("Every Nordic region must be an object")
+        status = region.get("status")
+        seeds = region.get("seeds")
+        if status not in {"configured", "missing"} or not isinstance(seeds, list):
+            raise ValueError(f"Invalid Nordic seed region: {region.get('id')}")
+
+        if status == "missing":
+            if seeds:
+                raise ValueError(f"Missing region cannot have active seeds: {region.get('id')}")
+            if not region.get("missing_reason"):
+                raise ValueError(f"Missing region requires missing_reason: {region.get('id')}")
+            continue
+
+        if not seeds:
+            raise ValueError(f"Configured region requires at least one seed: {region.get('id')}")
+        for seed in seeds:
+            if not isinstance(seed, Mapping):
+                raise ValueError(f"Invalid seed object in {region.get('id')}")
+            title = seed.get("category_title")
+            source_url = seed.get("source_url")
+            seed_type = seed.get("seed_type")
+            if not isinstance(title, str) or not title.startswith("Category:"):
+                raise ValueError(f"Seed must use an exact Commons Category title: {title!r}")
+            if title in categories:
+                raise ValueError(f"Duplicate Commons seed category: {title}")
+            categories.add(title)
+            if seed.get("enabled") is not True:
+                raise ValueError(f"Configured seed must be explicitly enabled: {title}")
+            if seed_type not in SEED_TYPES:
+                raise ValueError(f"Unsupported seed_type {seed_type!r}: {title}")
+            if not isinstance(source_url, str) or not source_url.startswith(
+                "https://commons.wikimedia.org/wiki/Category:"
+            ):
+                raise ValueError(f"Seed requires a confirmed Commons category URL: {title}")
+
+
+def enabled_seed_categories(payload: Mapping) -> list[dict[str, str]]:
+    validate_nordic_seeds(payload)
+    result: list[dict[str, str]] = []
+    for region in payload["regions"]:
+        for seed in region["seeds"]:
+            result.append(
+                {
+                    "region_id": region["id"],
+                    "region_name": region["display_name"],
+                    "category_title": seed["category_title"],
+                    "seed_type": seed["seed_type"],
+                    "source_url": seed["source_url"],
+                }
+            )
+    return result

--- a/sources/discovery/nordic-seeds.json
+++ b/sources/discovery/nordic-seeds.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "authority": "Wikimedia Commons category pages confirmed in issue #84",
+  "regions": [
+    {
+      "id": "norway",
+      "display_name": "Norway",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Norway",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Norway"
+        }
+      ]
+    },
+    {
+      "id": "sweden",
+      "display_name": "Sweden",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Sweden",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Sweden"
+        }
+      ]
+    },
+    {
+      "id": "finland",
+      "display_name": "Finland",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Finland",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Finland"
+        }
+      ]
+    },
+    {
+      "id": "denmark",
+      "display_name": "Denmark",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Denmark",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Denmark"
+        },
+        {
+          "category_title": "Category:Aerial videos from Denmark",
+          "seed_type": "aerial",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Aerial_videos_from_Denmark"
+        }
+      ]
+    },
+    {
+      "id": "iceland",
+      "display_name": "Iceland",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Iceland",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Iceland"
+        }
+      ]
+    },
+    {
+      "id": "greenland",
+      "display_name": "Greenland",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Drone videos from Greenland",
+          "seed_type": "drone",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_Greenland"
+        }
+      ]
+    },
+    {
+      "id": "faroe-islands",
+      "display_name": "Faroe Islands",
+      "status": "configured",
+      "seeds": [
+        {
+          "category_title": "Category:Videos from the Faroe Islands",
+          "seed_type": "general-video",
+          "enabled": true,
+          "source_url": "https://commons.wikimedia.org/wiki/Category:Videos_from_the_Faroe_Islands"
+        }
+      ]
+    },
+    {
+      "id": "aland",
+      "display_name": "Åland",
+      "status": "missing",
+      "missing_reason": "No confirmed long-form drone/aerial video category authority was identified in issue #84; do not synthesize a category name.",
+      "seeds": []
+    }
+  ]
+}

--- a/tests/test_nordic_seeds.py
+++ b/tests/test_nordic_seeds.py
@@ -1,0 +1,54 @@
+import copy
+import unittest
+
+from processing.nordic_seeds import (
+    EXPECTED_REGION_IDS,
+    enabled_seed_categories,
+    load_nordic_seeds,
+    validate_nordic_seeds,
+)
+
+
+class NordicSeedTests(unittest.TestCase):
+    def test_exact_eight_region_coverage_and_explicit_missing_aland(self) -> None:
+        payload = load_nordic_seeds()
+        self.assertEqual(tuple(region["id"] for region in payload["regions"]), EXPECTED_REGION_IDS)
+        self.assertEqual(len(payload["regions"]), 8)
+        aland = next(region for region in payload["regions"] if region["id"] == "aland")
+        self.assertEqual(aland["status"], "missing")
+        self.assertEqual(aland["seeds"], [])
+        self.assertTrue(aland["missing_reason"])
+
+    def test_enabled_seeds_are_exact_declared_categories(self) -> None:
+        payload = load_nordic_seeds()
+        seeds = enabled_seed_categories(payload)
+        self.assertGreaterEqual(len(seeds), 7)
+        self.assertEqual(len({seed["category_title"] for seed in seeds}), len(seeds))
+        self.assertTrue(
+            all(seed["source_url"].startswith("https://commons.wikimedia.org/wiki/Category:") for seed in seeds)
+        )
+
+    def test_duplicate_category_is_rejected(self) -> None:
+        payload = load_nordic_seeds()
+        duplicate = copy.deepcopy(payload["regions"][0]["seeds"][0])
+        payload["regions"][1]["seeds"].append(duplicate)
+        with self.assertRaisesRegex(ValueError, "Duplicate Commons seed category"):
+            validate_nordic_seeds(payload)
+
+    def test_missing_region_cannot_hide_a_guessed_seed(self) -> None:
+        payload = load_nordic_seeds()
+        aland = next(region for region in payload["regions"] if region["id"] == "aland")
+        aland["seeds"] = [
+            {
+                "category_title": "Category:Drone videos from Åland",
+                "seed_type": "drone",
+                "enabled": True,
+                "source_url": "https://commons.wikimedia.org/wiki/Category:Drone_videos_from_%C3%85land",
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, "Missing region cannot have active seeds"):
+            validate_nordic_seeds(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nordic_seeds.py
+++ b/tests/test_nordic_seeds.py
@@ -25,7 +25,10 @@ class NordicSeedTests(unittest.TestCase):
         self.assertGreaterEqual(len(seeds), 7)
         self.assertEqual(len({seed["category_title"] for seed in seeds}), len(seeds))
         self.assertTrue(
-            all(seed["source_url"].startswith("https://commons.wikimedia.org/wiki/Category:") for seed in seeds)
+            all(
+                seed["source_url"].startswith("https://commons.wikimedia.org/wiki/Category:")
+                for seed in seeds
+            )
         )
 
     def test_duplicate_category_is_rejected(self) -> None:


### PR DESCRIPTION
Closes #85.

## Contract
- `sources/discovery/nordic-seeds.json` is the sole declarative seed authority.
- Exactly 8 regions are represented in a fixed order.
- Confirmed Commons categories are explicit; category names are never synthesized from region names.
- Åland is preserved as explicit `missing` coverage rather than a guessed active category.
- Denmark may carry both confirmed drone and aerial seed categories.
- duplicate Commons categories, missing reasons, invalid source URLs and unsupported seed types fail validation.
- `enabled_seed_categories()` exposes only the declared config for downstream #86 discovery.

No candidate rank/score is introduced and #33 final-20 semantics are unchanged.