### PR TITLE
Make Gaussian orientation a producer-owned artifact contract

### DIFF
--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -9,6 +9,7 @@ from pathlib import Path, PurePosixPath
 
 import yaml
 
+from processing.orientation import OrientationContractError, write_orientation_evidence
 from processing.provenance import sha256_file, write_json
 
 
@@ -71,6 +72,23 @@ def _resolve_run_artifact_path(run_manifest_path: Path, raw_path: str) -> Path:
     )
 
 
+def _resolve_transforms_path(run_manifest_path: Path, run_manifest: dict) -> Path:
+    declared = run_manifest.get("orientation_transforms_path")
+    if declared:
+        candidate = Path(str(declared)).expanduser()
+        if not candidate.is_absolute():
+            candidate = run_manifest_path.parent / candidate
+        candidate = candidate.resolve()
+    else:
+        candidate = (run_manifest_path.parent / "nerfstudio-data" / "transforms.json").resolve()
+    if not candidate.is_file():
+        raise ArtifactPublishError(
+            "Nerfstudio transforms.json is required before Gaussian artifact publish; "
+            f"expected {candidate}"
+        )
+    return candidate
+
+
 def _hf_cache_command(hf_cache_hub_root: str | Path | None) -> list[str]:
     root_value = hf_cache_hub_root or os.environ.get("HF_CACHE_HUB_ROOT")
     if not root_value:
@@ -90,12 +108,18 @@ def build_artifact_manifest(
     bucket: str,
     source_revision: str,
     run_id: str,
+    orientation: dict,
     source_url: str | None = None,
     license_url: str | None = None,
 ) -> tuple[dict, str]:
     if not ply_path.is_file() or ply_path.stat().st_size == 0:
         raise ArtifactPublishError(f"Gaussian Splat PLY is missing or empty: {ply_path}")
     sha256 = sha256_file(ply_path)
+    if orientation.get("ply_sha256") != sha256:
+        raise ArtifactPublishError("orientation evidence does not match artifact PLY SHA-256")
+    if orientation.get("status") != "accepted":
+        raise ArtifactPublishError("only accepted orientation evidence can be published")
+
     artifact_id = f"autophotogrammetry/{dataset}/splat"
     remote_path = f"autophotogrammetry/gaussian-splats/{dataset}/{sha256}.ply"
     artifact = {
@@ -109,6 +133,7 @@ def build_artifact_manifest(
         },
         "size_bytes": ply_path.stat().st_size,
         "sha256": sha256,
+        "orientation": orientation,
         "provenance": {
             "repository": "KAFKA2306/AutoPhotogrammetry",
             "revision": source_revision,
@@ -149,6 +174,19 @@ def publish_run_splat(
     if actual_sha != expected_sha or actual_size != expected_size:
         raise ArtifactPublishError("local PLY no longer matches the successful run manifest")
 
+    transforms_path = _resolve_transforms_path(run_manifest_path, run_manifest)
+    orientation_path = run_manifest_path.parent / "orientation-evidence.json"
+    try:
+        orientation = write_orientation_evidence(transforms_path, ply_path, orientation_path)
+    except OrientationContractError as exc:
+        raise ArtifactPublishError(f"orientation gate failed: {exc}") from exc
+    if orientation["ply_sha256"] != expected_sha:
+        raise ArtifactPublishError("orientation evidence was generated for a different PLY SHA-256")
+    # Keep the artifact manifest portable: the hash is authoritative; the path is run-local provenance.
+    orientation_for_manifest = dict(orientation)
+    orientation_for_manifest["evidence_path"] = orientation_path.name
+    run_manifest["orientation"] = orientation_for_manifest
+
     revision = _recorded_revision(run_manifest, source_revision)
     registry = run_manifest.get("registry", {})
     license_info = registry.get("license") or {}
@@ -161,6 +199,7 @@ def publish_run_splat(
         bucket=bucket,
         source_revision=revision,
         run_id=run_id,
+        orientation=orientation_for_manifest,
         source_url=source_url,
         license_url=license_url,
     )
@@ -215,6 +254,8 @@ def publish_run_splat(
         "sha256": expected_sha,
         "source_revision": revision,
         "run_id": run_id,
+        "orientation_status": orientation_for_manifest["status"],
+        "orientation_evidence_sha256": orientation_for_manifest["evidence_sha256"],
         "remote_verified": True,
     }
     run_manifest["artifact_publish"] = success

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -42,7 +42,9 @@ class OrientationContractError(RuntimeError):
     pass
 
 
-def _mat_vec(matrix: tuple[tuple[float, float, float], ...], vector: tuple[float, float, float]) -> tuple[float, float, float]:
+def _mat_vec(
+    matrix: tuple[tuple[float, float, float], ...], vector: tuple[float, float, float]
+) -> tuple[float, float, float]:
     return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)  # type: ignore[return-value]
 
 
@@ -51,8 +53,7 @@ def _mat_mul(
     right: tuple[tuple[float, float, float], ...],
 ) -> tuple[tuple[float, float, float], ...]:
     return tuple(
-        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3))
-        for r in range(3)
+        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
     )
 
 
@@ -63,7 +64,9 @@ def _det3(matrix: tuple[tuple[float, float, float], ...]) -> float:
     return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
 
 
-def _close_vector(actual: tuple[float, float, float], expected: tuple[float, float, float], tol: float = 1e-9) -> bool:
+def _close_vector(
+    actual: tuple[float, float, float], expected: tuple[float, float, float], tol: float = 1e-9
+) -> bool:
     return all(abs(a - b) <= tol for a, b in zip(actual, expected, strict=True))
 
 
@@ -72,7 +75,9 @@ def _orientation_method(transforms: dict) -> str:
     if override is None:
         return "up"
     if not isinstance(override, str) or not override.strip():
-        raise OrientationContractError("transforms.json orientation_override must be a non-empty string when present")
+        raise OrientationContractError(
+            "transforms.json orientation_override must be a non-empty string when present"
+        )
     return override.strip().lower()
 
 
@@ -165,20 +170,34 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
             f"orientation evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
         )
     if evidence.get("nerfstudio_revision") != PINNED_NERFSTUDIO_REVISION:
-        raise OrientationContractError("orientation evidence Nerfstudio revision is stale or unsupported")
+        raise OrientationContractError(
+            "orientation evidence Nerfstudio revision is stale or unsupported"
+        )
     if evidence.get("algorithm_version") != ALGORITHM_VERSION:
-        raise OrientationContractError("orientation evidence algorithm_version is stale or unsupported")
+        raise OrientationContractError(
+            "orientation evidence algorithm_version is stale or unsupported"
+        )
 
-    canonical = tuple(tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"])
-    consumer = tuple(tuple(float(v) for v in row) for row in evidence["consumer_application"]["matrix3x3"])
+    canonical = tuple(
+        tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"]
+    )
+    consumer = tuple(
+        tuple(float(v) for v in row) for row in evidence["consumer_application"]["matrix3x3"]
+    )
     if abs(_det3(canonical) - 1.0) > 1e-9 or abs(_det3(consumer) - 1.0) > 1e-9:
-        raise OrientationContractError("orientation rotation matrix must be a proper rotation with determinant +1")
+        raise OrientationContractError(
+            "orientation rotation matrix must be a proper rotation with determinant +1"
+        )
     if not _close_vector(_mat_vec(canonical, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
-        raise OrientationContractError("source_to_canonical does not map Nerfstudio +Z up to canonical +Y up")
+        raise OrientationContractError(
+            "source_to_canonical does not map Nerfstudio +Z up to canonical +Y up"
+        )
 
     final_matrix = _mat_mul(VRCHAT_POST_REFLECTION_MATRIX, consumer)
     if not _close_vector(_mat_vec(final_matrix, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
-        raise OrientationContractError("consumer transform plus mandatory Y reflection does not produce final +Y up")
+        raise OrientationContractError(
+            "consumer transform plus mandatory Y reflection does not produce final +Y up"
+        )
 
     quat = [float(v) for v in evidence["consumer_application"]["quaternion_xyzw"]]
     if len(quat) != 4 or abs(sum(v * v for v in quat) - 1.0) > 1e-9:

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from processing.provenance import sha256_file, write_json
+
+PINNED_NERFSTUDIO_REVISION = "50e0e3c70c775e89333256213363badbf074f29d"
+PINNED_VRCHAT_RENDERER_REVISION = "f96c0117cba518ff84d059d36f16909b873e23aa"
+ORIENTATION_SCHEMA_VERSION = 1
+ALGORITHM_VERSION = "nerfstudio-z-up-to-unity-y-up-v1"
+_SQRT_HALF = math.sqrt(0.5)
+
+# Nerfstudio model/world coordinates are +X right, +Y back, +Z up.
+# A pure canonical basis rotation Rx(-90 deg) maps +Z(up) -> +Y(up)
+# and +Y(back) -> -Z(back), i.e. +Z is forward in the target semantic frame.
+SOURCE_TO_CANONICAL_MATRIX = (
+    (1.0, 0.0, 0.0),
+    (0.0, 0.0, 1.0),
+    (0.0, -1.0, 0.0),
+)
+SOURCE_TO_CANONICAL_QUATERNION_XYZW = (-_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
+
+# The pinned VRChat importer always performs a Y reflection AFTER horizon
+# alignment. Therefore the pre-reflection horizon quaternion must map source
+# +Z to -Y so the mandatory reflection produces final +Y.
+VRCHAT_HORIZON_QUATERNION_XYZW = (_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
+VRCHAT_HORIZON_MATRIX = (
+    (1.0, 0.0, 0.0),
+    (0.0, 0.0, -1.0),
+    (0.0, 1.0, 0.0),
+)
+VRCHAT_POST_REFLECTION_MATRIX = (
+    (1.0, 0.0, 0.0),
+    (0.0, -1.0, 0.0),
+    (0.0, 0.0, 1.0),
+)
+
+
+class OrientationContractError(RuntimeError):
+    pass
+
+
+def _mat_vec(matrix: tuple[tuple[float, float, float], ...], vector: tuple[float, float, float]) -> tuple[float, float, float]:
+    return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)  # type: ignore[return-value]
+
+
+def _mat_mul(
+    left: tuple[tuple[float, float, float], ...],
+    right: tuple[tuple[float, float, float], ...],
+) -> tuple[tuple[float, float, float], ...]:
+    return tuple(
+        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3))
+        for r in range(3)
+    )
+
+
+def _det3(matrix: tuple[tuple[float, float, float], ...]) -> float:
+    a, b, c = matrix[0]
+    d, e, f = matrix[1]
+    g, h, i = matrix[2]
+    return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+
+
+def _close_vector(actual: tuple[float, float, float], expected: tuple[float, float, float], tol: float = 1e-9) -> bool:
+    return all(abs(a - b) <= tol for a, b in zip(actual, expected, strict=True))
+
+
+def _orientation_method(transforms: dict) -> str:
+    override = transforms.get("orientation_override")
+    if override is None:
+        return "up"
+    if not isinstance(override, str) or not override.strip():
+        raise OrientationContractError("transforms.json orientation_override must be a non-empty string when present")
+    return override.strip().lower()
+
+
+def build_orientation_evidence(
+    transforms_path: str | Path,
+    ply_path: str | Path,
+    *,
+    nerfstudio_revision: str = PINNED_NERFSTUDIO_REVISION,
+) -> dict:
+    transforms_file = Path(transforms_path).expanduser().resolve()
+    ply_file = Path(ply_path).expanduser().resolve()
+    if not transforms_file.is_file():
+        raise OrientationContractError(f"Nerfstudio transforms.json is missing: {transforms_file}")
+    if not ply_file.is_file() or ply_file.stat().st_size <= 0:
+        raise OrientationContractError(f"Gaussian Splat PLY is missing or empty: {ply_file}")
+    if nerfstudio_revision != PINNED_NERFSTUDIO_REVISION:
+        raise OrientationContractError(
+            "orientation contract is pinned to Nerfstudio revision "
+            f"{PINNED_NERFSTUDIO_REVISION}; got {nerfstudio_revision}"
+        )
+
+    try:
+        transforms = json.loads(transforms_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise OrientationContractError(f"cannot read Nerfstudio transforms.json: {exc}") from exc
+    if not isinstance(transforms, dict):
+        raise OrientationContractError("Nerfstudio transforms.json must contain a JSON object")
+
+    method = _orientation_method(transforms)
+    accepted_methods = {"up", "vertical"}
+    status = "accepted" if method in accepted_methods else "review_required"
+    reason = (
+        "pinned Nerfstudio parser orients the reconstruction to +Z up before training"
+        if status == "accepted"
+        else f"orientation_method={method!r} does not establish the +Z-up gravity contract"
+    )
+
+    evidence = {
+        "schema_version": ORIENTATION_SCHEMA_VERSION,
+        "status": status,
+        "reason": reason,
+        "algorithm_version": ALGORITHM_VERSION,
+        "nerfstudio_revision": nerfstudio_revision,
+        "orientation_method": method,
+        "source_frame": {
+            "name": "nerfstudio-model",
+            "x_axis": "+right",
+            "y_axis": "+back",
+            "z_axis": "+up",
+            "up_vector": [0.0, 0.0, 1.0],
+        },
+        "canonical_frame": {
+            "name": "unity-semantic-y-up",
+            "x_axis": "+right",
+            "y_axis": "+up",
+            "z_axis": "+forward",
+            "up_vector": [0.0, 1.0, 0.0],
+        },
+        "source_to_canonical": {
+            "matrix3x3": [list(row) for row in SOURCE_TO_CANONICAL_MATRIX],
+            "quaternion_xyzw": list(SOURCE_TO_CANONICAL_QUATERNION_XYZW),
+            "pivot": [0.0, 0.0, 0.0],
+        },
+        "consumer_application": {
+            "consumer": "MichaelMoroz/VRChatGaussianSplatting",
+            "revision": PINNED_VRCHAT_RENDERER_REVISION,
+            "mode": "horizon_alignment_pre_y_reflection",
+            "quaternion_xyzw": list(VRCHAT_HORIZON_QUATERNION_XYZW),
+            "matrix3x3": [list(row) for row in VRCHAT_HORIZON_MATRIX],
+            "pivot": [0.0, 0.0, 0.0],
+            "mandatory_post_transform": "reflect-y",
+            "representation_aware": ["position", "gaussian_rotation", "spherical_harmonics"],
+        },
+        "transforms_sha256": sha256_file(transforms_file),
+        "ply_sha256": sha256_file(ply_file),
+        "derivation_method": "pinned Nerfstudio coordinate convention plus explicit consumer import transform",
+    }
+    validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
+    return evidence
+
+
+def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -> None:
+    if evidence.get("schema_version") != ORIENTATION_SCHEMA_VERSION:
+        raise OrientationContractError("unsupported orientation evidence schema_version")
+    if evidence.get("ply_sha256") != expected_ply_sha256:
+        raise OrientationContractError("orientation evidence does not match the exact PLY SHA-256")
+    if evidence.get("status") != "accepted":
+        raise OrientationContractError(
+            f"orientation evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
+        )
+    if evidence.get("nerfstudio_revision") != PINNED_NERFSTUDIO_REVISION:
+        raise OrientationContractError("orientation evidence Nerfstudio revision is stale or unsupported")
+    if evidence.get("algorithm_version") != ALGORITHM_VERSION:
+        raise OrientationContractError("orientation evidence algorithm_version is stale or unsupported")
+
+    canonical = tuple(tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"])
+    consumer = tuple(tuple(float(v) for v in row) for row in evidence["consumer_application"]["matrix3x3"])
+    if abs(_det3(canonical) - 1.0) > 1e-9 or abs(_det3(consumer) - 1.0) > 1e-9:
+        raise OrientationContractError("orientation rotation matrix must be a proper rotation with determinant +1")
+    if not _close_vector(_mat_vec(canonical, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
+        raise OrientationContractError("source_to_canonical does not map Nerfstudio +Z up to canonical +Y up")
+
+    final_matrix = _mat_mul(VRCHAT_POST_REFLECTION_MATRIX, consumer)
+    if not _close_vector(_mat_vec(final_matrix, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
+        raise OrientationContractError("consumer transform plus mandatory Y reflection does not produce final +Y up")
+
+    quat = [float(v) for v in evidence["consumer_application"]["quaternion_xyzw"]]
+    if len(quat) != 4 or abs(sum(v * v for v in quat) - 1.0) > 1e-9:
+        raise OrientationContractError("consumer quaternion must be normalized")
+
+
+def write_orientation_evidence(
+    transforms_path: str | Path,
+    ply_path: str | Path,
+    output_path: str | Path,
+    *,
+    nerfstudio_revision: str = PINNED_NERFSTUDIO_REVISION,
+) -> dict:
+    evidence = build_orientation_evidence(
+        transforms_path,
+        ply_path,
+        nerfstudio_revision=nerfstudio_revision,
+    )
+    output = Path(output_path).expanduser().resolve()
+    write_json(output, evidence)
+    evidence["evidence_path"] = str(output)
+    evidence["evidence_sha256"] = sha256_file(output)
+    return evidence

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -11,11 +11,13 @@ PINNED_VRCHAT_RENDERER_REVISION = "f96c0117cba518ff84d059d36f16909b873e23aa"
 ORIENTATION_SCHEMA_VERSION = 1
 ALGORITHM_VERSION = "nerfstudio-z-up-to-unity-y-up-v1"
 _SQRT_HALF = math.sqrt(0.5)
+Matrix = tuple[tuple[float, ...], ...]
+Vector = tuple[float, ...]
 
 # Nerfstudio model/world coordinates are +X right, +Y back, +Z up.
 # A pure canonical basis rotation Rx(-90 deg) maps +Z(up) -> +Y(up)
 # and +Y(back) -> -Z(back), i.e. +Z is forward in the target semantic frame.
-SOURCE_TO_CANONICAL_MATRIX = (
+SOURCE_TO_CANONICAL_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, 0.0, 1.0),
     (0.0, -1.0, 0.0),
@@ -26,12 +28,12 @@ SOURCE_TO_CANONICAL_QUATERNION_XYZW = (-_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
 # alignment. Therefore the pre-reflection horizon quaternion must map source
 # +Z to -Y so the mandatory reflection produces final +Y.
 VRCHAT_HORIZON_QUATERNION_XYZW = (_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
-VRCHAT_HORIZON_MATRIX = (
+VRCHAT_HORIZON_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, 0.0, -1.0),
     (0.0, 1.0, 0.0),
 )
-VRCHAT_POST_REFLECTION_MATRIX = (
+VRCHAT_POST_REFLECTION_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, -1.0, 0.0),
     (0.0, 0.0, 1.0),
@@ -42,31 +44,24 @@ class OrientationContractError(RuntimeError):
     pass
 
 
-def _mat_vec(
-    matrix: tuple[tuple[float, float, float], ...], vector: tuple[float, float, float]
-) -> tuple[float, float, float]:
-    return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)  # type: ignore[return-value]
+def _mat_vec(matrix: Matrix, vector: Vector) -> Vector:
+    return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)
 
 
-def _mat_mul(
-    left: tuple[tuple[float, float, float], ...],
-    right: tuple[tuple[float, float, float], ...],
-) -> tuple[tuple[float, float, float], ...]:
+def _mat_mul(left: Matrix, right: Matrix) -> Matrix:
     return tuple(
         tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
     )
 
 
-def _det3(matrix: tuple[tuple[float, float, float], ...]) -> float:
+def _det3(matrix: Matrix) -> float:
     a, b, c = matrix[0]
     d, e, f = matrix[1]
     g, h, i = matrix[2]
     return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
 
 
-def _close_vector(
-    actual: tuple[float, float, float], expected: tuple[float, float, float], tol: float = 1e-9
-) -> bool:
+def _close_vector(actual: Vector, expected: Vector, tol: float = 1e-9) -> bool:
     return all(abs(a - b) <= tol for a, b in zip(actual, expected, strict=True))
 
 
@@ -178,10 +173,10 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
             "orientation evidence algorithm_version is stale or unsupported"
         )
 
-    canonical = tuple(
+    canonical: Matrix = tuple(
         tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"]
     )
-    consumer = tuple(
+    consumer: Matrix = tuple(
         tuple(float(v) for v in row) for row in evidence["consumer_application"]["matrix3x3"]
     )
     if abs(_det3(canonical) - 1.0) > 1e-9 or abs(_det3(consumer) - 1.0) > 1e-9:

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -150,7 +150,8 @@ def build_orientation_evidence(
         "ply_sha256": sha256_file(ply_file),
         "derivation_method": "pinned Nerfstudio coordinate convention plus explicit consumer import transform",
     }
-    validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
+    if status == "accepted":
+        validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
     return evidence
 
 

--- a/scripts/measure_ply_orientation.py
+++ b/scripts/measure_ply_orientation.py
@@ -130,6 +130,20 @@ def dominant_plane(pts, seed, iterations=700, distance_ratio=0.006):
     return normal, center, float(len(inliers) / len(pts)), float(np.sqrt(np.mean(residual ** 2))), threshold
 
 
+def _axis_diagnostics(angles):
+    nearest = min(angles, key=angles.get)
+    return {
+        "axis_angles_deg": angles,
+        "nearest_axis": nearest,
+        "nearest_axis_tilt_deg": angles[nearest],
+        # Raw PLY produced by the pinned Nerfstudio path is a +Z-up model frame.
+        "nerfstudio_z_up_angle_deg": angles["z"],
+        # Retained for comparison with the first diagnostic run. This is NOT a correction angle.
+        "raw_unity_y_axis_angle_deg": angles["y"],
+        "y_up_tilt_deg": angles["y"],
+    }
+
+
 def analyze(path: Path, max_points: int):
     pts, total = sample_xyz(path, max_points)
     pts = robust_core(pts)
@@ -138,23 +152,21 @@ def analyze(path: Path, max_points: int):
     normal, center, inlier_ratio, rms, threshold = dominant_plane(pts, seed)
     pa = axis_angles(normal)
     ga = axis_angles(thin)
-    pn = min(pa, key=pa.get)
-    gn = min(ga, key=ga.get)
     parts = path.parts
     scene = parts[parts.index("output") + 1]
+    plane_diag = _axis_diagnostics(pa)
+    global_diag = _axis_diagnostics(ga)
     return {
         "scene": scene,
         "path": path.as_posix(),
         "vertex_count": total,
         "sample_count": int(len(pts)),
         "dominant_plane": {
-            "normal": normal.tolist(), "center": center.tolist(), "axis_angles_deg": pa,
-            "nearest_axis": pn, "nearest_axis_tilt_deg": pa[pn], "y_up_tilt_deg": pa["y"],
+            "normal": normal.tolist(), "center": center.tolist(), **plane_diag,
             "inlier_ratio": inlier_ratio, "rms_residual": rms, "distance_threshold": threshold,
         },
         "global_pca": {
-            "thin_axis": thin.tolist(), "axis_angles_deg": ga, "nearest_axis": gn,
-            "nearest_axis_tilt_deg": ga[gn], "y_up_tilt_deg": ga["y"], "eigenvalues": evals.tolist(),
+            "thin_axis": thin.tolist(), **global_diag, "eigenvalues": evals.tolist(),
         },
         "plane_vs_global_thin_axis_deg": plane_angle(normal, thin),
     }
@@ -175,8 +187,24 @@ def main():
         r = analyze(path, args.max_points)
         results.append(r)
         p, g = r["dominant_plane"], r["global_pca"]
-        print(f'{r["scene"]}: plane={p["nearest_axis"]}+{p["nearest_axis_tilt_deg"]:.3f}deg Y-up={p["y_up_tilt_deg"]:.3f}deg inliers={p["inlier_ratio"]:.3f}; global={g["nearest_axis"]}+{g["nearest_axis_tilt_deg"]:.3f}deg Y-up={g["y_up_tilt_deg"]:.3f}deg consistency={r["plane_vs_global_thin_axis_deg"]:.3f}deg')
-    payload = {"schema_version": 1, "source_commit": args.source_commit, "method": "uniform-sample+robust-core+RANSAC-plane+global-PCA", "count": len(results), "results": results}
+        print(
+            f'{r["scene"]}: plane={p["nearest_axis"]}+{p["nearest_axis_tilt_deg"]:.3f}deg '
+            f'NS-Z-up={p["nerfstudio_z_up_angle_deg"]:.3f}deg raw-Y={p["raw_unity_y_axis_angle_deg"]:.3f}deg '
+            f'inliers={p["inlier_ratio"]:.3f}; global={g["nearest_axis"]}+{g["nearest_axis_tilt_deg"]:.3f}deg '
+            f'NS-Z-up={g["nerfstudio_z_up_angle_deg"]:.3f}deg consistency={r["plane_vs_global_thin_axis_deg"]:.3f}deg'
+        )
+    payload = {
+        "schema_version": 2,
+        "source_commit": args.source_commit,
+        "method": "uniform-sample+robust-core+RANSAC-plane+global-PCA",
+        "coordinate_interpretation": {
+            "raw_ply_frame": "pinned Nerfstudio model/world frame: +X right, +Y back, +Z up",
+            "nerfstudio_z_up_angle_deg": "geometry diagnostic against raw-frame +Z; semantic ground is not inferred",
+            "raw_unity_y_axis_angle_deg": "legacy direct angle against +Y; not a physical tilt or correction angle",
+        },
+        "count": len(results),
+        "results": results,
+    }
     Path(args.output).write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(f"measured={len(results)} output={args.output}")
 

--- a/scripts/measure_ply_orientation.py
+++ b/scripts/measure_ply_orientation.py
@@ -9,10 +9,22 @@ from pathlib import Path
 import numpy as np
 
 PLY_TYPES = {
-    "char": "i1", "int8": "i1", "uchar": "u1", "uint8": "u1",
-    "short": "<i2", "int16": "<i2", "ushort": "<u2", "uint16": "<u2",
-    "int": "<i4", "int32": "<i4", "uint": "<u4", "uint32": "<u4",
-    "float": "<f4", "float32": "<f4", "double": "<f8", "float64": "<f8",
+    "char": "i1",
+    "int8": "i1",
+    "uchar": "u1",
+    "uint8": "u1",
+    "short": "<i2",
+    "int16": "<i2",
+    "ushort": "<u2",
+    "uint16": "<u2",
+    "int": "<i4",
+    "int32": "<i4",
+    "uint": "<u4",
+    "uint32": "<u4",
+    "float": "<f4",
+    "float32": "<f4",
+    "double": "<f8",
+    "float64": "<f8",
 }
 
 
@@ -84,11 +96,15 @@ def axis_angles(v):
     v = unit(v)
     if v is None:
         raise ValueError("zero vector")
-    return {axis: math.degrees(math.acos(float(np.clip(abs(v[i]), 0.0, 1.0)))) for i, axis in enumerate("xyz")}
+    return {
+        axis: math.degrees(math.acos(float(np.clip(abs(v[i]), 0.0, 1.0))))
+        for i, axis in enumerate("xyz")
+    }
 
 
 def plane_angle(a, b):
-    a = unit(a); b = unit(b)
+    a = unit(a)
+    b = unit(b)
     return math.degrees(math.acos(float(np.clip(abs(np.dot(a, b)), 0.0, 1.0))))
 
 
@@ -127,7 +143,13 @@ def dominant_plane(pts, seed, iterations=700, distance_ratio=0.006):
     vals, vecs = np.linalg.eigh(cov)
     normal = vecs[:, int(np.argmin(vals))]
     residual = np.abs(c @ normal)
-    return normal, center, float(len(inliers) / len(pts)), float(np.sqrt(np.mean(residual ** 2))), threshold
+    return (
+        normal,
+        center,
+        float(len(inliers) / len(pts)),
+        float(np.sqrt(np.mean(residual**2))),
+        threshold,
+    )
 
 
 def _axis_diagnostics(angles):
@@ -162,11 +184,17 @@ def analyze(path: Path, max_points: int):
         "vertex_count": total,
         "sample_count": int(len(pts)),
         "dominant_plane": {
-            "normal": normal.tolist(), "center": center.tolist(), **plane_diag,
-            "inlier_ratio": inlier_ratio, "rms_residual": rms, "distance_threshold": threshold,
+            "normal": normal.tolist(),
+            "center": center.tolist(),
+            **plane_diag,
+            "inlier_ratio": inlier_ratio,
+            "rms_residual": rms,
+            "distance_threshold": threshold,
         },
         "global_pca": {
-            "thin_axis": thin.tolist(), **global_diag, "eigenvalues": evals.tolist(),
+            "thin_axis": thin.tolist(),
+            **global_diag,
+            "eigenvalues": evals.tolist(),
         },
         "plane_vs_global_thin_axis_deg": plane_angle(normal, thin),
     }
@@ -188,10 +216,10 @@ def main():
         results.append(r)
         p, g = r["dominant_plane"], r["global_pca"]
         print(
-            f'{r["scene"]}: plane={p["nearest_axis"]}+{p["nearest_axis_tilt_deg"]:.3f}deg '
-            f'NS-Z-up={p["nerfstudio_z_up_angle_deg"]:.3f}deg raw-Y={p["raw_unity_y_axis_angle_deg"]:.3f}deg '
-            f'inliers={p["inlier_ratio"]:.3f}; global={g["nearest_axis"]}+{g["nearest_axis_tilt_deg"]:.3f}deg '
-            f'NS-Z-up={g["nerfstudio_z_up_angle_deg"]:.3f}deg consistency={r["plane_vs_global_thin_axis_deg"]:.3f}deg'
+            f"{r['scene']}: plane={p['nearest_axis']}+{p['nearest_axis_tilt_deg']:.3f}deg "
+            f"NS-Z-up={p['nerfstudio_z_up_angle_deg']:.3f}deg raw-Y={p['raw_unity_y_axis_angle_deg']:.3f}deg "
+            f"inliers={p['inlier_ratio']:.3f}; global={g['nearest_axis']}+{g['nearest_axis_tilt_deg']:.3f}deg "
+            f"NS-Z-up={g['nerfstudio_z_up_angle_deg']:.3f}deg consistency={r['plane_vs_global_thin_axis_deg']:.3f}deg"
         )
     payload = {
         "schema_version": 2,
@@ -205,7 +233,9 @@ def main():
         "count": len(results),
         "results": results,
     }
-    Path(args.output).write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    Path(args.output).write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     print(f"measured={len(results)} output={args.output}")
 
 

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -17,7 +17,14 @@ REVISION = "a" * 40
 
 
 class ArtifactPublishTest(unittest.TestCase):
-    def _fixture(self, root: Path, *, include_revision: bool = True, container_path: bool = False):
+    def _fixture(
+        self,
+        root: Path,
+        *,
+        include_revision: bool = True,
+        container_path: bool = False,
+        orientation_override: str | None = None,
+    ):
         ply = root / "output" / "demo" / "runs" / "r1" / "export" / "splat.ply"
         ply.parent.mkdir(parents=True)
         payload = b"ply\nsynthetic"
@@ -25,6 +32,19 @@ class ArtifactPublishTest(unittest.TestCase):
         sha = hashlib.sha256(payload).hexdigest()
         manifest = root / "output" / "demo" / "manifest.json"
         manifest.parent.mkdir(parents=True, exist_ok=True)
+        transforms = manifest.parent / "nerfstudio-data" / "transforms.json"
+        transforms.parent.mkdir()
+        transforms_payload = {
+            "frames": [
+                {
+                    "file_path": "images/frame-000001.jpg",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+            ]
+        }
+        if orientation_override is not None:
+            transforms_payload["orientation_override"] = orientation_override
+        transforms.write_text(json.dumps(transforms_payload), encoding="utf-8")
         body = {
             "schema_version": 2,
             "dataset": "demo",
@@ -98,6 +118,7 @@ class ArtifactPublishTest(unittest.TestCase):
             self.assertTrue(result["remote_verified"])
             self.assertEqual(sha, result["sha256"])
             self.assertEqual(REVISION, result["source_revision"])
+            self.assertEqual("accepted", result["orientation_status"])
             artifact_manifest = yaml.safe_load(
                 (manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8")
             )
@@ -108,9 +129,18 @@ class ArtifactPublishTest(unittest.TestCase):
             self.assertEqual(REVISION, artifact["provenance"]["revision"])
             self.assertIn("run_id", artifact["provenance"])
             self.assertNotIn("source_path", artifact["provenance"])
+            self.assertEqual("accepted", artifact["orientation"]["status"])
+            self.assertEqual(sha, artifact["orientation"]["ply_sha256"])
+            self.assertEqual("orientation-evidence.json", artifact["orientation"]["evidence_path"])
+            self.assertEqual(
+                [2**-0.5, 0.0, 0.0, 2**-0.5],
+                artifact["orientation"]["consumer_application"]["quaternion_xyzw"],
+            )
             updated = json.loads(manifest.read_text(encoding="utf-8"))
             self.assertEqual("success", updated["status"])
+            self.assertEqual("accepted", updated["orientation"]["status"])
             self.assertEqual("published", updated["artifact_publish"]["status"])
+            self.assertTrue((manifest.parent / "orientation-evidence.json").is_file())
             self.assertTrue(ply.exists())
 
     def test_container_output_path_is_resolved_on_host(self):
@@ -181,6 +211,7 @@ class ArtifactPublishTest(unittest.TestCase):
                 )
             updated = json.loads(manifest.read_text(encoding="utf-8"))
             self.assertEqual("success", updated["status"])
+            self.assertEqual("accepted", updated["orientation"]["status"])
             self.assertEqual("failed", updated["artifact_publish"]["status"])
             self.assertTrue(ply.exists())
 
@@ -194,6 +225,31 @@ class ArtifactPublishTest(unittest.TestCase):
                     manifest,
                     bucket="k4fka/artifacts",
                     hf_cache_hub_root=hf_root,
+                )
+
+    def test_missing_transforms_fails_before_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root)
+            (manifest.parent / "nerfstudio-data" / "transforms.json").unlink()
+            with self.assertRaisesRegex(ArtifactPublishError, "transforms.json"):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    runner=self._successful_runner,
+                )
+
+    def test_non_gravity_orientation_method_fails_before_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root, orientation_override="pca")
+            with self.assertRaisesRegex(ArtifactPublishError, "orientation gate failed"):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    runner=self._successful_runner,
                 )
 
     def test_generated_ply_remains_gitignored(self):

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -34,7 +34,7 @@ class ArtifactPublishTest(unittest.TestCase):
         manifest.parent.mkdir(parents=True, exist_ok=True)
         transforms = manifest.parent / "nerfstudio-data" / "transforms.json"
         transforms.parent.mkdir()
-        transforms_payload = {
+        transforms_payload: dict[str, object] = {
             "frames": [
                 {
                     "file_path": "images/frame-000001.jpg",
@@ -244,7 +244,7 @@ class ArtifactPublishTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             manifest, _, _, hf_root = self._fixture(root, orientation_override="pca")
-            with self.assertRaisesRegex(ArtifactPublishError, "orientation gate failed"):
+            with self.assertRaisesRegex(ArtifactPublishError, "only accepted orientation evidence"):
                 publish_run_splat(
                     manifest,
                     bucket="k4fka/artifacts",

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from processing.orientation import (
+    ALGORITHM_VERSION,
+    OrientationContractError,
+    build_orientation_evidence,
+    validate_orientation_evidence,
+    write_orientation_evidence,
+)
+
+
+class OrientationContractTest(unittest.TestCase):
+    def _fixture(self, root: Path, *, orientation_override: str | None = None):
+        transforms = root / "nerfstudio-data" / "transforms.json"
+        transforms.parent.mkdir(parents=True)
+        payload = {"frames": [{"file_path": "images/frame-000001.jpg", "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}]}
+        if orientation_override is not None:
+            payload["orientation_override"] = orientation_override
+        transforms.write_text(json.dumps(payload), encoding="utf-8")
+        ply = root / "export" / "splat.ply"
+        ply.parent.mkdir()
+        ply.write_bytes(b"ply\nsynthetic-gaussian")
+        return transforms, ply
+
+    def test_default_nerfstudio_up_maps_to_canonical_y_up(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d))
+            evidence = build_orientation_evidence(transforms, ply)
+            self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("up", evidence["orientation_method"])
+            self.assertEqual(ALGORITHM_VERSION, evidence["algorithm_version"])
+            self.assertEqual([0.0, 1.0, 0.0], evidence["canonical_frame"]["up_vector"])
+            self.assertEqual(
+                [-math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
+                evidence["source_to_canonical"]["quaternion_xyzw"],
+            )
+            self.assertEqual(
+                [math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
+                evidence["consumer_application"]["quaternion_xyzw"],
+            )
+            validate_orientation_evidence(evidence, expected_ply_sha256=hashlib.sha256(ply.read_bytes()).hexdigest())
+
+    def test_vertical_is_explicitly_accepted(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d), orientation_override="vertical")
+            evidence = build_orientation_evidence(transforms, ply)
+            self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("vertical", evidence["orientation_method"])
+
+    def test_pca_requires_review_and_cannot_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d), orientation_override="pca")
+            with self.assertRaisesRegex(OrientationContractError, "not accepted"):
+                build_orientation_evidence(transforms, ply)
+
+    def test_none_requires_review_and_cannot_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d), orientation_override="none")
+            with self.assertRaisesRegex(OrientationContractError, "not accepted"):
+                build_orientation_evidence(transforms, ply)
+
+    def test_exact_ply_hash_is_a_gate(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d))
+            evidence = build_orientation_evidence(transforms, ply)
+            with self.assertRaisesRegex(OrientationContractError, "exact PLY"):
+                validate_orientation_evidence(evidence, expected_ply_sha256="0" * 64)
+
+    def test_evidence_is_persisted_and_hashed(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            transforms, ply = self._fixture(root)
+            out = root / "orientation-evidence.json"
+            evidence = write_orientation_evidence(transforms, ply, out)
+            self.assertTrue(out.is_file())
+            self.assertEqual(str(out.resolve()), evidence["evidence_path"])
+            self.assertEqual(hashlib.sha256(out.read_bytes()).hexdigest(), evidence["evidence_sha256"])
+
+    def test_raw_ply_is_not_rewritten(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            transforms, ply = self._fixture(root)
+            before = ply.read_bytes()
+            write_orientation_evidence(transforms, ply, root / "orientation-evidence.json")
+            self.assertEqual(before, ply.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -20,7 +20,7 @@ class OrientationContractTest(unittest.TestCase):
     def _fixture(self, root: Path, *, orientation_override: str | None = None):
         transforms = root / "nerfstudio-data" / "transforms.json"
         transforms.parent.mkdir(parents=True)
-        payload = {
+        payload: dict[str, object] = {
             "frames": [
                 {
                     "file_path": "images/frame-000001.jpg",

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -20,7 +20,14 @@ class OrientationContractTest(unittest.TestCase):
     def _fixture(self, root: Path, *, orientation_override: str | None = None):
         transforms = root / "nerfstudio-data" / "transforms.json"
         transforms.parent.mkdir(parents=True)
-        payload = {"frames": [{"file_path": "images/frame-000001.jpg", "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]}]}
+        payload = {
+            "frames": [
+                {
+                    "file_path": "images/frame-000001.jpg",
+                    "transform_matrix": [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]],
+                }
+            ]
+        }
         if orientation_override is not None:
             payload["orientation_override"] = orientation_override
         transforms.write_text(json.dumps(payload), encoding="utf-8")
@@ -45,7 +52,9 @@ class OrientationContractTest(unittest.TestCase):
                 [math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
                 evidence["consumer_application"]["quaternion_xyzw"],
             )
-            validate_orientation_evidence(evidence, expected_ply_sha256=hashlib.sha256(ply.read_bytes()).hexdigest())
+            validate_orientation_evidence(
+                evidence, expected_ply_sha256=hashlib.sha256(ply.read_bytes()).hexdigest()
+            )
 
     def test_vertical_is_explicitly_accepted(self):
         with tempfile.TemporaryDirectory() as d:
@@ -85,7 +94,9 @@ class OrientationContractTest(unittest.TestCase):
             evidence = write_orientation_evidence(transforms, ply, out)
             self.assertTrue(out.is_file())
             self.assertEqual(str(out.resolve()), evidence["evidence_path"])
-            self.assertEqual(hashlib.sha256(out.read_bytes()).hexdigest(), evidence["evidence_sha256"])
+            self.assertEqual(
+                hashlib.sha256(out.read_bytes()).hexdigest(), evidence["evidence_sha256"]
+            )
 
     def test_raw_ply_is_not_rewritten(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -54,17 +54,21 @@ class OrientationContractTest(unittest.TestCase):
             self.assertEqual("accepted", evidence["status"])
             self.assertEqual("vertical", evidence["orientation_method"])
 
-    def test_pca_requires_review_and_cannot_publish(self):
+    def test_pca_is_preserved_as_review_required_and_cannot_publish(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="pca")
+            evidence = build_orientation_evidence(transforms, ply)
+            self.assertEqual("review_required", evidence["status"])
             with self.assertRaisesRegex(OrientationContractError, "not accepted"):
-                build_orientation_evidence(transforms, ply)
+                validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
 
-    def test_none_requires_review_and_cannot_publish(self):
+    def test_none_is_preserved_as_review_required_and_cannot_publish(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="none")
+            evidence = build_orientation_evidence(transforms, ply)
+            self.assertEqual("review_required", evidence["status"])
             with self.assertRaisesRegex(OrientationContractError, "not accepted"):
-                build_orientation_evidence(transforms, ply)
+                validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
 
     def test_exact_ply_hash_is_a_gate(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Resolves the repository-side implementation for #105 #106 #107 #108.

Key correction: historical direct angle to Unity +Y was not a physical correction angle. The pinned Nerfstudio model/world frame is +X right, +Y back, +Z up. The new diagnostic preserves that old value only as `raw_unity_y_axis_angle_deg` and adds `nerfstudio_z_up_angle_deg`.

Implementation:
- producer orientation evidence from pinned Nerfstudio coordinate convention + `transforms.json` orientation method
- pure source(+Z-up) -> canonical(+Y-up) transform
- separate VRChat importer application transform accounting for the pinned renderer's mandatory post-horizon Y reflection
- raw PLY remains unchanged; no xyz-only Gaussian rewrite
- artifact publish requires exact-hash accepted orientation evidence
- artifact manifest carries coordinate frame, matrices/quaternions, renderer revision, transforms hash, PLY hash, algorithm version and evidence hash
- `pca`/`none` orientation remains `review_required` and cannot publish
- historical PLY diagnostic semantics corrected
- unit tests for known frame conversion, review-required behavior, exact PLY hash, raw-Ply invariance and publish gate

The historical commit `1fa7f35...` contains the 9 PLYs but does not contain their processed `transforms.json`, so scene-specific camera-derived evidence for those old bytes cannot be reconstructed from Git history alone. New production runs retain the necessary contract before publish.