### PR TITLE
Separate Gaussian coordinate basis from physical gravity

### DIFF
--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -8,15 +8,15 @@ from processing.provenance import sha256_file, write_json
 
 PINNED_NERFSTUDIO_REVISION = "50e0e3c70c775e89333256213363badbf074f29d"
 PINNED_VRCHAT_RENDERER_REVISION = "f96c0117cba518ff84d059d36f16909b873e23aa"
-ORIENTATION_SCHEMA_VERSION = 1
-ALGORITHM_VERSION = "nerfstudio-z-up-to-unity-y-up-v1"
+ORIENTATION_SCHEMA_VERSION = 2
+ALGORITHM_VERSION = "nerfstudio-basis-to-unity-y-up-v2"
 _SQRT_HALF = math.sqrt(0.5)
 Matrix = tuple[tuple[float, ...], ...]
 Vector = tuple[float, ...]
 
-# Nerfstudio model/world coordinates are +X right, +Y back, +Z up.
-# A pure canonical basis rotation Rx(-90 deg) maps +Z(up) -> +Y(up)
-# and +Y(back) -> -Z(back), i.e. +Z is forward in the target semantic frame.
+# Raw Nerfstudio Gaussian exports use the Nerfstudio model basis. The basis
+# conversion below is deterministic and does not claim that model +Z is true
+# physical gravity. That distinction is carried separately in physical_up.
 SOURCE_TO_CANONICAL_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, 0.0, 1.0),
@@ -24,9 +24,10 @@ SOURCE_TO_CANONICAL_MATRIX: Matrix = (
 )
 SOURCE_TO_CANONICAL_QUATERNION_XYZW = (-_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
 
-# The pinned VRChat importer always performs a Y reflection AFTER horizon
-# alignment. Therefore the pre-reflection horizon quaternion must map source
-# +Z to -Y so the mandatory reflection produces final +Y.
+# The pinned VRChat importer performs a Y reflection after horizon alignment.
+# This pre-reflection rotation therefore maps source +Z to -Y so the mandatory
+# reflection produces final +Y while rotating Gaussian position, covariance /
+# rotation and spherical harmonics consistently in the importer.
 VRCHAT_HORIZON_QUATERNION_XYZW = (_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
 VRCHAT_HORIZON_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
@@ -50,7 +51,8 @@ def _mat_vec(matrix: Matrix, vector: Vector) -> Vector:
 
 def _mat_mul(left: Matrix, right: Matrix) -> Matrix:
     return tuple(
-        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
+        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3))
+        for r in range(3)
     )
 
 
@@ -74,6 +76,35 @@ def _orientation_method(transforms: dict) -> str:
             "transforms.json orientation_override must be a non-empty string when present"
         )
     return override.strip().lower()
+
+
+def _physical_up_decision(method: str) -> dict:
+    if method == "up":
+        reason = (
+            "Nerfstudio `up` aligns the mean camera-up vector to model +Z. "
+            "SfM has a global rotation gauge, so this is a camera-orientation heuristic, "
+            "not an independently observed gravity vector."
+        )
+    elif method == "vertical":
+        reason = (
+            "Nerfstudio `vertical` estimates an image-vertical 3D direction and uses camera-up "
+            "for sign disambiguation. It is a geometric/camera heuristic, not an external gravity observation."
+        )
+    elif method == "pca":
+        reason = "Nerfstudio `pca` aligns camera-center principal axes and does not establish physical gravity."
+    else:
+        reason = "Nerfstudio orientation is disabled; physical gravity is not established."
+    return {
+        "status": "review_required",
+        "observable_from_sfm_alone": False,
+        "authority": None,
+        "reason": reason,
+        "required_external_authority": [
+            "IMU/gravity telemetry",
+            "surveyed control points or known ground plane",
+            "another independently auditable gravity reference",
+        ],
+    }
 
 
 def build_orientation_evidence(
@@ -102,34 +133,36 @@ def build_orientation_evidence(
         raise OrientationContractError("Nerfstudio transforms.json must contain a JSON object")
 
     method = _orientation_method(transforms)
-    accepted_methods = {"up", "vertical"}
-    status = "accepted" if method in accepted_methods else "review_required"
-    reason = (
-        "pinned Nerfstudio parser orients the reconstruction to +Z up before training"
-        if status == "accepted"
-        else f"orientation_method={method!r} does not establish the +Z-up gravity contract"
+    basis_status = "accepted" if method in {"up", "vertical"} else "review_required"
+    basis_reason = (
+        "Nerfstudio produced an oriented model frame whose +Z basis can be deterministically mapped to Unity +Y"
+        if basis_status == "accepted"
+        else f"orientation_method={method!r} does not provide the expected oriented +Z model basis"
     )
 
     evidence = {
         "schema_version": ORIENTATION_SCHEMA_VERSION,
-        "status": status,
-        "reason": reason,
+        "status": basis_status,
+        "scope": "coordinate_basis_only",
+        "reason": basis_reason,
         "algorithm_version": ALGORITHM_VERSION,
         "nerfstudio_revision": nerfstudio_revision,
         "orientation_method": method,
         "source_frame": {
-            "name": "nerfstudio-model",
-            "x_axis": "+right",
-            "y_axis": "+back",
-            "z_axis": "+up",
-            "up_vector": [0.0, 0.0, 1.0],
+            "name": "nerfstudio-model-basis",
+            "x_axis": "+model-x",
+            "y_axis": "+model-y",
+            "z_axis": "+model-z",
+            "basis_up_vector": [0.0, 0.0, 1.0],
+            "physical_gravity_claimed": False,
         },
         "canonical_frame": {
-            "name": "unity-semantic-y-up",
+            "name": "unity-basis-y-up",
             "x_axis": "+right",
-            "y_axis": "+up",
+            "y_axis": "+basis-up",
             "z_axis": "+forward",
-            "up_vector": [0.0, 1.0, 0.0],
+            "basis_up_vector": [0.0, 1.0, 0.0],
+            "physical_gravity_claimed": False,
         },
         "source_to_canonical": {
             "matrix3x3": [list(row) for row in SOURCE_TO_CANONICAL_MATRIX],
@@ -146,11 +179,12 @@ def build_orientation_evidence(
             "mandatory_post_transform": "reflect-y",
             "representation_aware": ["position", "gaussian_rotation", "spherical_harmonics"],
         },
+        "physical_up": _physical_up_decision(method),
         "transforms_sha256": sha256_file(transforms_file),
         "ply_sha256": sha256_file(ply_file),
-        "derivation_method": "pinned Nerfstudio coordinate convention plus explicit consumer import transform",
+        "derivation_method": "pinned Nerfstudio basis convention plus explicit consumer import transform",
     }
-    if status == "accepted":
+    if basis_status == "accepted":
         validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
     return evidence
 
@@ -162,16 +196,22 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
         raise OrientationContractError("orientation evidence does not match the exact PLY SHA-256")
     if evidence.get("status") != "accepted":
         raise OrientationContractError(
-            f"orientation evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
+            f"orientation basis evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
         )
+    if evidence.get("scope") != "coordinate_basis_only":
+        raise OrientationContractError("orientation evidence must explicitly declare coordinate_basis_only scope")
     if evidence.get("nerfstudio_revision") != PINNED_NERFSTUDIO_REVISION:
-        raise OrientationContractError(
-            "orientation evidence Nerfstudio revision is stale or unsupported"
-        )
+        raise OrientationContractError("orientation evidence Nerfstudio revision is stale or unsupported")
     if evidence.get("algorithm_version") != ALGORITHM_VERSION:
-        raise OrientationContractError(
-            "orientation evidence algorithm_version is stale or unsupported"
-        )
+        raise OrientationContractError("orientation evidence algorithm_version is stale or unsupported")
+    if evidence.get("canonical_frame", {}).get("name") != "unity-basis-y-up":
+        raise OrientationContractError("orientation evidence canonical frame is unsupported")
+    if evidence.get("physical_up", {}).get("status") not in {
+        "accepted",
+        "review_required",
+        "unavailable",
+    }:
+        raise OrientationContractError("physical_up status is missing or unsupported")
 
     canonical: Matrix = tuple(
         tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"]
@@ -185,13 +225,13 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
         )
     if not _close_vector(_mat_vec(canonical, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
         raise OrientationContractError(
-            "source_to_canonical does not map Nerfstudio +Z up to canonical +Y up"
+            "source_to_canonical does not map Nerfstudio model +Z basis to Unity +Y basis"
         )
 
     final_matrix = _mat_mul(VRCHAT_POST_REFLECTION_MATRIX, consumer)
     if not _close_vector(_mat_vec(final_matrix, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
         raise OrientationContractError(
-            "consumer transform plus mandatory Y reflection does not produce final +Y up"
+            "consumer transform plus mandatory Y reflection does not produce final +Y basis"
         )
 
     quat = [float(v) for v in evidence["consumer_application"]["quaternion_xyzw"]]

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -51,8 +51,7 @@ def _mat_vec(matrix: Matrix, vector: Vector) -> Vector:
 
 def _mat_mul(left: Matrix, right: Matrix) -> Matrix:
     return tuple(
-        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3))
-        for r in range(3)
+        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
     )
 
 
@@ -199,11 +198,17 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
             f"orientation basis evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
         )
     if evidence.get("scope") != "coordinate_basis_only":
-        raise OrientationContractError("orientation evidence must explicitly declare coordinate_basis_only scope")
+        raise OrientationContractError(
+            "orientation evidence must explicitly declare coordinate_basis_only scope"
+        )
     if evidence.get("nerfstudio_revision") != PINNED_NERFSTUDIO_REVISION:
-        raise OrientationContractError("orientation evidence Nerfstudio revision is stale or unsupported")
+        raise OrientationContractError(
+            "orientation evidence Nerfstudio revision is stale or unsupported"
+        )
     if evidence.get("algorithm_version") != ALGORITHM_VERSION:
-        raise OrientationContractError("orientation evidence algorithm_version is stale or unsupported")
+        raise OrientationContractError(
+            "orientation evidence algorithm_version is stale or unsupported"
+        )
     if evidence.get("canonical_frame", {}).get("name") != "unity-basis-y-up":
         raise OrientationContractError("orientation evidence canonical frame is unsupported")
     if evidence.get("physical_up", {}).get("status") not in {

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from processing.orientation import (
     ALGORITHM_VERSION,
+    ORIENTATION_SCHEMA_VERSION,
     OrientationContractError,
     build_orientation_evidence,
     validate_orientation_evidence,
@@ -36,14 +37,19 @@ class OrientationContractTest(unittest.TestCase):
         ply.write_bytes(b"ply\nsynthetic-gaussian")
         return transforms, ply
 
-    def test_default_nerfstudio_up_maps_to_canonical_y_up(self):
+    def test_default_up_accepts_basis_but_not_physical_gravity(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d))
             evidence = build_orientation_evidence(transforms, ply)
+            self.assertEqual(ORIENTATION_SCHEMA_VERSION, evidence["schema_version"])
             self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("coordinate_basis_only", evidence["scope"])
             self.assertEqual("up", evidence["orientation_method"])
             self.assertEqual(ALGORITHM_VERSION, evidence["algorithm_version"])
-            self.assertEqual([0.0, 1.0, 0.0], evidence["canonical_frame"]["up_vector"])
+            self.assertEqual("unity-basis-y-up", evidence["canonical_frame"]["name"])
+            self.assertFalse(evidence["canonical_frame"]["physical_gravity_claimed"])
+            self.assertEqual("review_required", evidence["physical_up"]["status"])
+            self.assertFalse(evidence["physical_up"]["observable_from_sfm_alone"])
             self.assertEqual(
                 [-math.sqrt(0.5), 0.0, 0.0, math.sqrt(0.5)],
                 evidence["source_to_canonical"]["quaternion_xyzw"],
@@ -56,27 +62,29 @@ class OrientationContractTest(unittest.TestCase):
                 evidence, expected_ply_sha256=hashlib.sha256(ply.read_bytes()).hexdigest()
             )
 
-    def test_vertical_is_explicitly_accepted(self):
+    def test_vertical_accepts_basis_but_not_physical_gravity(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="vertical")
             evidence = build_orientation_evidence(transforms, ply)
             self.assertEqual("accepted", evidence["status"])
             self.assertEqual("vertical", evidence["orientation_method"])
+            self.assertEqual("review_required", evidence["physical_up"]["status"])
 
-    def test_pca_is_preserved_as_review_required_and_cannot_publish(self):
+    def test_pca_is_review_required(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="pca")
             evidence = build_orientation_evidence(transforms, ply)
             self.assertEqual("review_required", evidence["status"])
-            with self.assertRaisesRegex(OrientationContractError, "not accepted"):
+            self.assertEqual("review_required", evidence["physical_up"]["status"])
+            with self.assertRaisesRegex(OrientationContractError, "basis evidence is not accepted"):
                 validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
 
-    def test_none_is_preserved_as_review_required_and_cannot_publish(self):
+    def test_none_is_review_required(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="none")
             evidence = build_orientation_evidence(transforms, ply)
             self.assertEqual("review_required", evidence["status"])
-            with self.assertRaisesRegex(OrientationContractError, "not accepted"):
+            with self.assertRaisesRegex(OrientationContractError, "basis evidence is not accepted"):
                 validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
 
     def test_exact_ply_hash_is_a_gate(self):
@@ -85,6 +93,14 @@ class OrientationContractTest(unittest.TestCase):
             evidence = build_orientation_evidence(transforms, ply)
             with self.assertRaisesRegex(OrientationContractError, "exact PLY"):
                 validate_orientation_evidence(evidence, expected_ply_sha256="0" * 64)
+
+    def test_schema_rejects_semantic_y_up_v1_claim(self):
+        with tempfile.TemporaryDirectory() as d:
+            transforms, ply = self._fixture(Path(d))
+            evidence = build_orientation_evidence(transforms, ply)
+            evidence["canonical_frame"]["name"] = "unity-semantic-y-up"
+            with self.assertRaisesRegex(OrientationContractError, "canonical frame"):
+                validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
 
     def test_evidence_is_persisted_and_hashed(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Corrects the observability boundary in the producer-owned orientation contract.

Pinned Nerfstudio `up` aligns the **mean camera-up vector** to model +Z; `vertical` is also a camera/geometric estimator. SfM has a global rotation gauge, so neither is independent physical-gravity evidence.

Changes:
- schema v2 / algorithm `nerfstudio-basis-to-unity-y-up-v2`
- accepted basis conversion remains deterministic (+Z model basis -> Unity +Y basis)
- canonical frame renamed to `unity-basis-y-up`; it explicitly does not claim physical gravity
- `physical_up.status=review_required` with `observable_from_sfm_alone=false` for default `up`/`vertical`
- pca/none remain review-required for the basis contract
- exact PLY hash, proper-rotation, renderer reflection and representation-aware transform gates remain intact
- tests prevent the previous `unity-semantic-y-up` overclaim

This is required before migrating the existing 20 vrmine artifacts: basis correction can be automatic, residual physical horizon must remain separately evidenced.