### PR TITLE
Accept external physical-up authority without guessing gravity

### DIFF
--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import os
 import subprocess
@@ -89,6 +90,23 @@ def _resolve_transforms_path(run_manifest_path: Path, run_manifest: dict) -> Pat
     return candidate
 
 
+def _resolve_physical_up_path(run_manifest_path: Path, run_manifest: dict) -> Path | None:
+    declared = run_manifest.get("physical_up_evidence_path")
+    if declared is not None:
+        if not isinstance(declared, str) or not declared.strip():
+            raise ArtifactPublishError("physical_up_evidence_path must be a non-empty path when declared")
+        candidate = Path(declared).expanduser()
+        if not candidate.is_absolute():
+            candidate = run_manifest_path.parent / candidate
+        candidate = candidate.resolve()
+        if not candidate.is_file():
+            raise ArtifactPublishError(f"declared physical-up evidence file is missing: {candidate}")
+        return candidate
+
+    candidate = (run_manifest_path.parent / "physical-up-evidence.json").resolve()
+    return candidate if candidate.is_file() else None
+
+
 def _hf_cache_command(hf_cache_hub_root: str | Path | None) -> list[str]:
     root_value = hf_cache_hub_root or os.environ.get("HF_CACHE_HUB_ROOT")
     if not root_value:
@@ -118,7 +136,7 @@ def build_artifact_manifest(
     if orientation.get("ply_sha256") != sha256:
         raise ArtifactPublishError("orientation evidence does not match artifact PLY SHA-256")
     if orientation.get("status") != "accepted":
-        raise ArtifactPublishError("only accepted orientation evidence can be published")
+        raise ArtifactPublishError("only accepted orientation basis evidence can be published")
 
     artifact_id = f"autophotogrammetry/{dataset}/splat"
     remote_path = f"autophotogrammetry/gaussian-splats/{dataset}/{sha256}.ply"
@@ -175,16 +193,27 @@ def publish_run_splat(
         raise ArtifactPublishError("local PLY no longer matches the successful run manifest")
 
     transforms_path = _resolve_transforms_path(run_manifest_path, run_manifest)
+    physical_up_path = _resolve_physical_up_path(run_manifest_path, run_manifest)
     orientation_path = run_manifest_path.parent / "orientation-evidence.json"
     try:
-        orientation = write_orientation_evidence(transforms_path, ply_path, orientation_path)
+        orientation = write_orientation_evidence(
+            transforms_path,
+            ply_path,
+            orientation_path,
+            physical_up_path=physical_up_path,
+        )
     except OrientationContractError as exc:
         raise ArtifactPublishError(f"orientation gate failed: {exc}") from exc
     if orientation["ply_sha256"] != expected_sha:
         raise ArtifactPublishError("orientation evidence was generated for a different PLY SHA-256")
-    # Keep the artifact manifest portable: the hash is authoritative; the path is run-local provenance.
-    orientation_for_manifest = dict(orientation)
+
+    # Keep the artifact manifest portable: hashes are authoritative and local paths
+    # are reduced to sidecar file names inside the run directory.
+    orientation_for_manifest = copy.deepcopy(orientation)
     orientation_for_manifest["evidence_path"] = orientation_path.name
+    physical = orientation_for_manifest.get("physical_up", {})
+    if physical.get("status") == "accepted" and physical.get("evidence_path"):
+        physical["evidence_path"] = Path(str(physical["evidence_path"])).name
     run_manifest["orientation"] = orientation_for_manifest
 
     revision = _recorded_revision(run_manifest, source_revision)
@@ -245,6 +274,7 @@ def publish_run_splat(
         write_json(run_manifest_path, run_manifest)
         raise ArtifactPublishError(f"remote publish verification failed for {artifact_id}")
 
+    physical_up = orientation_for_manifest.get("physical_up", {})
     success = {
         "status": "published",
         "artifact_id": artifact_id,
@@ -255,6 +285,9 @@ def publish_run_splat(
         "source_revision": revision,
         "run_id": run_id,
         "orientation_status": orientation_for_manifest["status"],
+        "orientation_scope": orientation_for_manifest["scope"],
+        "physical_up_status": physical_up.get("status"),
+        "physical_up_authority_type": physical_up.get("authority_type"),
         "orientation_evidence_sha256": orientation_for_manifest["evidence_sha256"],
         "remote_verified": True,
     }

--- a/processing/artifact_publish.py
+++ b/processing/artifact_publish.py
@@ -94,13 +94,17 @@ def _resolve_physical_up_path(run_manifest_path: Path, run_manifest: dict) -> Pa
     declared = run_manifest.get("physical_up_evidence_path")
     if declared is not None:
         if not isinstance(declared, str) or not declared.strip():
-            raise ArtifactPublishError("physical_up_evidence_path must be a non-empty path when declared")
+            raise ArtifactPublishError(
+                "physical_up_evidence_path must be a non-empty path when declared"
+            )
         candidate = Path(declared).expanduser()
         if not candidate.is_absolute():
             candidate = run_manifest_path.parent / candidate
         candidate = candidate.resolve()
         if not candidate.is_file():
-            raise ArtifactPublishError(f"declared physical-up evidence file is missing: {candidate}")
+            raise ArtifactPublishError(
+                f"declared physical-up evidence file is missing: {candidate}"
+            )
         return candidate
 
     candidate = (run_manifest_path.parent / "physical-up-evidence.json").resolve()

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -110,7 +110,9 @@ def _load_external_physical_up(path: str | Path | None) -> dict | None:
     try:
         return load_physical_up_evidence(path)
     except PhysicalUpContractError as exc:
-        raise OrientationContractError(f"external physical-up evidence failed validation: {exc}") from exc
+        raise OrientationContractError(
+            f"external physical-up evidence failed validation: {exc}"
+        ) from exc
 
 
 def _matrix_from_payload(value: object, label: str) -> Matrix:
@@ -278,7 +280,9 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
     if physical_up.get("status") not in {"accepted", "review_required", "unavailable"}:
         raise OrientationContractError("physical_up status is missing or unsupported")
     if scope == "coordinate_basis_plus_physical_up" and physical_up.get("status") != "accepted":
-        raise OrientationContractError("physical-up composition scope requires accepted external authority")
+        raise OrientationContractError(
+            "physical-up composition scope requires accepted external authority"
+        )
 
     canonical = _matrix_from_payload(
         evidence["source_to_canonical"]["matrix3x3"],

--- a/processing/orientation.py
+++ b/processing/orientation.py
@@ -4,31 +4,35 @@ import json
 import math
 from pathlib import Path
 
+from processing.physical_up import (
+    PhysicalUpContractError,
+    load_physical_up_evidence,
+    mat_mul,
+    quaternion_multiply,
+)
 from processing.provenance import sha256_file, write_json
 
 PINNED_NERFSTUDIO_REVISION = "50e0e3c70c775e89333256213363badbf074f29d"
 PINNED_VRCHAT_RENDERER_REVISION = "f96c0117cba518ff84d059d36f16909b873e23aa"
 ORIENTATION_SCHEMA_VERSION = 2
-ALGORITHM_VERSION = "nerfstudio-basis-to-unity-y-up-v2"
+ALGORITHM_VERSION = "nerfstudio-basis-plus-external-physical-up-v3"
 _SQRT_HALF = math.sqrt(0.5)
 Matrix = tuple[tuple[float, ...], ...]
 Vector = tuple[float, ...]
+Quaternion = tuple[float, float, float, float]
 
-# Raw Nerfstudio Gaussian exports use the Nerfstudio model basis. The basis
-# conversion below is deterministic and does not claim that model +Z is true
-# physical gravity. That distinction is carried separately in physical_up.
 SOURCE_TO_CANONICAL_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, 0.0, 1.0),
     (0.0, -1.0, 0.0),
 )
-SOURCE_TO_CANONICAL_QUATERNION_XYZW = (-_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
+SOURCE_TO_CANONICAL_QUATERNION_XYZW: Quaternion = (-_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
 
 # The pinned VRChat importer performs a Y reflection after horizon alignment.
-# This pre-reflection rotation therefore maps source +Z to -Y so the mandatory
-# reflection produces final +Y while rotating Gaussian position, covariance /
-# rotation and spherical harmonics consistently in the importer.
-VRCHAT_HORIZON_QUATERNION_XYZW = (_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
+# This pre-reflection rotation maps model +Z to -Y so the mandatory reflection
+# produces final +Y while rotating position, Gaussian covariance/rotation and
+# spherical harmonics consistently.
+VRCHAT_HORIZON_QUATERNION_XYZW: Quaternion = (_SQRT_HALF, 0.0, 0.0, _SQRT_HALF)
 VRCHAT_HORIZON_MATRIX: Matrix = (
     (1.0, 0.0, 0.0),
     (0.0, 0.0, -1.0),
@@ -49,12 +53,6 @@ def _mat_vec(matrix: Matrix, vector: Vector) -> Vector:
     return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)
 
 
-def _mat_mul(left: Matrix, right: Matrix) -> Matrix:
-    return tuple(
-        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
-    )
-
-
 def _det3(matrix: Matrix) -> float:
     a, b, c = matrix[0]
     d, e, f = matrix[1]
@@ -62,7 +60,7 @@ def _det3(matrix: Matrix) -> float:
     return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
 
 
-def _close_vector(actual: Vector, expected: Vector, tol: float = 1e-9) -> bool:
+def _close_vector(actual: Vector, expected: Vector, tol: float = 1e-8) -> bool:
     return all(abs(a - b) <= tol for a, b in zip(actual, expected, strict=True))
 
 
@@ -106,11 +104,38 @@ def _physical_up_decision(method: str) -> dict:
     }
 
 
+def _load_external_physical_up(path: str | Path | None) -> dict | None:
+    if path is None:
+        return None
+    try:
+        return load_physical_up_evidence(path)
+    except PhysicalUpContractError as exc:
+        raise OrientationContractError(f"external physical-up evidence failed validation: {exc}") from exc
+
+
+def _matrix_from_payload(value: object, label: str) -> Matrix:
+    if not isinstance(value, list) or len(value) != 3:
+        raise OrientationContractError(f"{label} must be a 3x3 matrix")
+    rows: list[tuple[float, ...]] = []
+    for row in value:
+        if not isinstance(row, list) or len(row) != 3:
+            raise OrientationContractError(f"{label} must be a 3x3 matrix")
+        rows.append(tuple(float(component) for component in row))
+    return tuple(rows)
+
+
+def _quaternion_from_payload(value: object, label: str) -> Quaternion:
+    if not isinstance(value, list) or len(value) != 4:
+        raise OrientationContractError(f"{label} must contain four values")
+    return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+
+
 def build_orientation_evidence(
     transforms_path: str | Path,
     ply_path: str | Path,
     *,
     nerfstudio_revision: str = PINNED_NERFSTUDIO_REVISION,
+    physical_up_path: str | Path | None = None,
 ) -> dict:
     transforms_file = Path(transforms_path).expanduser().resolve()
     ply_file = Path(ply_path).expanduser().resolve()
@@ -132,17 +157,56 @@ def build_orientation_evidence(
         raise OrientationContractError("Nerfstudio transforms.json must contain a JSON object")
 
     method = _orientation_method(transforms)
-    basis_status = "accepted" if method in {"up", "vertical"} else "review_required"
-    basis_reason = (
-        "Nerfstudio produced an oriented model frame whose +Z basis can be deterministically mapped to Unity +Y"
-        if basis_status == "accepted"
-        else f"orientation_method={method!r} does not provide the expected oriented +Z model basis"
+    external_physical_up = _load_external_physical_up(physical_up_path)
+    basis_status = (
+        "accepted"
+        if method in {"up", "vertical"} or external_physical_up is not None
+        else "review_required"
     )
+    basis_reason = (
+        "Nerfstudio model basis has a reproducible Unity conversion"
+        if basis_status == "accepted"
+        else f"orientation_method={method!r} lacks a physical-up authority for a usable upright frame"
+    )
+
+    source_to_canonical_matrix = SOURCE_TO_CANONICAL_MATRIX
+    source_to_canonical_quaternion = SOURCE_TO_CANONICAL_QUATERNION_XYZW
+    consumer_matrix = VRCHAT_HORIZON_MATRIX
+    consumer_quaternion = VRCHAT_HORIZON_QUATERNION_XYZW
+    physical_up = _physical_up_decision(method)
+    scope = "coordinate_basis_only"
+    derivation_method = "pinned Nerfstudio basis convention plus explicit consumer import transform"
+
+    if external_physical_up is not None:
+        correction = _matrix_from_payload(
+            external_physical_up["model_to_gravity_aligned"]["matrix3x3"],
+            "physical-up correction",
+        )
+        correction_quaternion = _quaternion_from_payload(
+            external_physical_up["model_to_gravity_aligned"]["quaternion_xyzw"],
+            "physical-up correction quaternion",
+        )
+        source_to_canonical_matrix = mat_mul(SOURCE_TO_CANONICAL_MATRIX, correction)
+        source_to_canonical_quaternion = quaternion_multiply(
+            SOURCE_TO_CANONICAL_QUATERNION_XYZW,
+            correction_quaternion,
+        )
+        consumer_matrix = mat_mul(VRCHAT_HORIZON_MATRIX, correction)
+        consumer_quaternion = quaternion_multiply(
+            VRCHAT_HORIZON_QUATERNION_XYZW,
+            correction_quaternion,
+        )
+        physical_up = external_physical_up
+        scope = "coordinate_basis_plus_physical_up"
+        derivation_method = (
+            "pinned Nerfstudio basis convention plus validated external physical-up authority "
+            "plus explicit consumer import transform"
+        )
 
     evidence = {
         "schema_version": ORIENTATION_SCHEMA_VERSION,
         "status": basis_status,
-        "scope": "coordinate_basis_only",
+        "scope": scope,
         "reason": basis_reason,
         "algorithm_version": ALGORITHM_VERSION,
         "nerfstudio_revision": nerfstudio_revision,
@@ -153,7 +217,7 @@ def build_orientation_evidence(
             "y_axis": "+model-y",
             "z_axis": "+model-z",
             "basis_up_vector": [0.0, 0.0, 1.0],
-            "physical_gravity_claimed": False,
+            "physical_gravity_claimed": external_physical_up is not None,
         },
         "canonical_frame": {
             "name": "unity-basis-y-up",
@@ -161,27 +225,27 @@ def build_orientation_evidence(
             "y_axis": "+basis-up",
             "z_axis": "+forward",
             "basis_up_vector": [0.0, 1.0, 0.0],
-            "physical_gravity_claimed": False,
+            "physical_gravity_claimed": external_physical_up is not None,
         },
         "source_to_canonical": {
-            "matrix3x3": [list(row) for row in SOURCE_TO_CANONICAL_MATRIX],
-            "quaternion_xyzw": list(SOURCE_TO_CANONICAL_QUATERNION_XYZW),
+            "matrix3x3": [list(row) for row in source_to_canonical_matrix],
+            "quaternion_xyzw": list(source_to_canonical_quaternion),
             "pivot": [0.0, 0.0, 0.0],
         },
         "consumer_application": {
             "consumer": "MichaelMoroz/VRChatGaussianSplatting",
             "revision": PINNED_VRCHAT_RENDERER_REVISION,
             "mode": "horizon_alignment_pre_y_reflection",
-            "quaternion_xyzw": list(VRCHAT_HORIZON_QUATERNION_XYZW),
-            "matrix3x3": [list(row) for row in VRCHAT_HORIZON_MATRIX],
+            "quaternion_xyzw": list(consumer_quaternion),
+            "matrix3x3": [list(row) for row in consumer_matrix],
             "pivot": [0.0, 0.0, 0.0],
             "mandatory_post_transform": "reflect-y",
             "representation_aware": ["position", "gaussian_rotation", "spherical_harmonics"],
         },
-        "physical_up": _physical_up_decision(method),
+        "physical_up": physical_up,
         "transforms_sha256": sha256_file(transforms_file),
         "ply_sha256": sha256_file(ply_file),
-        "derivation_method": "pinned Nerfstudio basis convention plus explicit consumer import transform",
+        "derivation_method": derivation_method,
     }
     if basis_status == "accepted":
         validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
@@ -197,10 +261,9 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
         raise OrientationContractError(
             f"orientation basis evidence is not accepted: {evidence.get('status')} ({evidence.get('reason')})"
         )
-    if evidence.get("scope") != "coordinate_basis_only":
-        raise OrientationContractError(
-            "orientation evidence must explicitly declare coordinate_basis_only scope"
-        )
+    scope = evidence.get("scope")
+    if scope not in {"coordinate_basis_only", "coordinate_basis_plus_physical_up"}:
+        raise OrientationContractError("orientation evidence scope is unsupported")
     if evidence.get("nerfstudio_revision") != PINNED_NERFSTUDIO_REVISION:
         raise OrientationContractError(
             "orientation evidence Nerfstudio revision is stale or unsupported"
@@ -211,36 +274,45 @@ def validate_orientation_evidence(evidence: dict, *, expected_ply_sha256: str) -
         )
     if evidence.get("canonical_frame", {}).get("name") != "unity-basis-y-up":
         raise OrientationContractError("orientation evidence canonical frame is unsupported")
-    if evidence.get("physical_up", {}).get("status") not in {
-        "accepted",
-        "review_required",
-        "unavailable",
-    }:
+    physical_up = evidence.get("physical_up", {})
+    if physical_up.get("status") not in {"accepted", "review_required", "unavailable"}:
         raise OrientationContractError("physical_up status is missing or unsupported")
+    if scope == "coordinate_basis_plus_physical_up" and physical_up.get("status") != "accepted":
+        raise OrientationContractError("physical-up composition scope requires accepted external authority")
 
-    canonical: Matrix = tuple(
-        tuple(float(v) for v in row) for row in evidence["source_to_canonical"]["matrix3x3"]
+    canonical = _matrix_from_payload(
+        evidence["source_to_canonical"]["matrix3x3"],
+        "source_to_canonical",
     )
-    consumer: Matrix = tuple(
-        tuple(float(v) for v in row) for row in evidence["consumer_application"]["matrix3x3"]
+    consumer = _matrix_from_payload(
+        evidence["consumer_application"]["matrix3x3"],
+        "consumer_application",
     )
-    if abs(_det3(canonical) - 1.0) > 1e-9 or abs(_det3(consumer) - 1.0) > 1e-9:
+    if abs(_det3(canonical) - 1.0) > 1e-7 or abs(_det3(consumer) - 1.0) > 1e-7:
         raise OrientationContractError(
             "orientation rotation matrix must be a proper rotation with determinant +1"
         )
-    if not _close_vector(_mat_vec(canonical, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
+
+    model_up: Vector = (0.0, 0.0, 1.0)
+    if physical_up.get("status") == "accepted":
+        value = physical_up.get("model_up_vector")
+        if not isinstance(value, list) or len(value) != 3:
+            raise OrientationContractError("accepted physical_up requires model_up_vector")
+        model_up = (float(value[0]), float(value[1]), float(value[2]))
+
+    if not _close_vector(_mat_vec(canonical, model_up), (0.0, 1.0, 0.0)):
         raise OrientationContractError(
-            "source_to_canonical does not map Nerfstudio model +Z basis to Unity +Y basis"
+            "source_to_canonical does not map the authoritative model up to Unity +Y"
         )
 
-    final_matrix = _mat_mul(VRCHAT_POST_REFLECTION_MATRIX, consumer)
-    if not _close_vector(_mat_vec(final_matrix, (0.0, 0.0, 1.0)), (0.0, 1.0, 0.0)):
+    final_matrix = mat_mul(VRCHAT_POST_REFLECTION_MATRIX, consumer)
+    if not _close_vector(_mat_vec(final_matrix, model_up), (0.0, 1.0, 0.0)):
         raise OrientationContractError(
-            "consumer transform plus mandatory Y reflection does not produce final +Y basis"
+            "consumer transform plus mandatory Y reflection does not produce final authoritative +Y"
         )
 
     quat = [float(v) for v in evidence["consumer_application"]["quaternion_xyzw"]]
-    if len(quat) != 4 or abs(sum(v * v for v in quat) - 1.0) > 1e-9:
+    if len(quat) != 4 or abs(sum(v * v for v in quat) - 1.0) > 1e-7:
         raise OrientationContractError("consumer quaternion must be normalized")
 
 
@@ -250,11 +322,13 @@ def write_orientation_evidence(
     output_path: str | Path,
     *,
     nerfstudio_revision: str = PINNED_NERFSTUDIO_REVISION,
+    physical_up_path: str | Path | None = None,
 ) -> dict:
     evidence = build_orientation_evidence(
         transforms_path,
         ply_path,
         nerfstudio_revision=nerfstudio_revision,
+        physical_up_path=physical_up_path,
     )
     output = Path(output_path).expanduser().resolve()
     write_json(output, evidence)

--- a/processing/physical_up.py
+++ b/processing/physical_up.py
@@ -24,7 +24,11 @@ class PhysicalUpContractError(RuntimeError):
 
 
 def _finite(value: object) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
 
 
 def _vector3(value: object, label: str) -> Vector:
@@ -186,7 +190,9 @@ def load_physical_up_evidence(path: str | Path) -> dict:
         or len(authority_sha) != 64
         or any(character not in "0123456789abcdef" for character in authority_sha)
     ):
-        raise PhysicalUpContractError("authority_source_sha256 must be a lowercase SHA-256 hex digest")
+        raise PhysicalUpContractError(
+            "authority_source_sha256 must be a lowercase SHA-256 hex digest"
+        )
 
     semantics = payload.get("vector_semantics")
     if semantics not in ALLOWED_VECTOR_SEMANTICS:
@@ -194,13 +200,17 @@ def load_physical_up_evidence(path: str | Path) -> dict:
     source_frame = payload.get("source_frame")
     if not isinstance(source_frame, str) or not source_frame.strip():
         raise PhysicalUpContractError("source_frame must be a non-empty string")
-    source_vector = _normalize(_vector3(payload.get("source_vector"), "source_vector"), "source_vector")
+    source_vector = _normalize(
+        _vector3(payload.get("source_vector"), "source_vector"), "source_vector"
+    )
     if semantics == "gravity_down":
         source_up = tuple(-component for component in source_vector)
     else:
         source_up = source_vector
 
-    source_to_model = _matrix3(payload.get("source_to_model_matrix3x3"), "source_to_model_matrix3x3")
+    source_to_model = _matrix3(
+        payload.get("source_to_model_matrix3x3"), "source_to_model_matrix3x3"
+    )
     _validate_rotation_matrix(source_to_model, "source_to_model_matrix3x3")
     model_up = _normalize(_mat_vec(source_to_model, source_up), "model up vector")
     correction_matrix, correction_quaternion = rotation_from_to(model_up, (0.0, 0.0, 1.0))

--- a/processing/physical_up.py
+++ b/processing/physical_up.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from processing.provenance import sha256_file
+
+PHYSICAL_UP_SCHEMA_VERSION = 1
+ALLOWED_AUTHORITY_TYPES = {
+    "imu_gravity",
+    "surveyed_up_vector",
+    "surveyed_ground_plane",
+    "independent_gravity_reference",
+}
+ALLOWED_VECTOR_SEMANTICS = {"up", "gravity_down"}
+Matrix = tuple[tuple[float, ...], ...]
+Vector = tuple[float, ...]
+Quaternion = tuple[float, float, float, float]
+
+
+class PhysicalUpContractError(RuntimeError):
+    pass
+
+
+def _finite(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def _vector3(value: object, label: str) -> Vector:
+    if not isinstance(value, list) or len(value) != 3 or not all(_finite(v) for v in value):
+        raise PhysicalUpContractError(f"{label} must contain exactly three finite numbers")
+    return tuple(float(v) for v in value)
+
+
+def _matrix3(value: object, label: str) -> Matrix:
+    if not isinstance(value, list) or len(value) != 3:
+        raise PhysicalUpContractError(f"{label} must be a 3x3 matrix")
+    rows = tuple(_vector3(row, f"{label} row") for row in value)
+    return rows
+
+
+def _dot(left: Vector, right: Vector) -> float:
+    return sum(a * b for a, b in zip(left, right, strict=True))
+
+
+def _cross(left: Vector, right: Vector) -> Vector:
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def _norm(value: Vector) -> float:
+    return math.sqrt(_dot(value, value))
+
+
+def _normalize(value: Vector, label: str) -> Vector:
+    magnitude = _norm(value)
+    if not math.isfinite(magnitude) or magnitude <= 1e-12:
+        raise PhysicalUpContractError(f"{label} must have non-zero finite norm")
+    return tuple(component / magnitude for component in value)
+
+
+def _mat_vec(matrix: Matrix, vector: Vector) -> Vector:
+    return tuple(sum(row[i] * vector[i] for i in range(3)) for row in matrix)
+
+
+def mat_mul(left: Matrix, right: Matrix) -> Matrix:
+    return tuple(
+        tuple(sum(left[r][k] * right[k][c] for k in range(3)) for c in range(3)) for r in range(3)
+    )
+
+
+def _det3(matrix: Matrix) -> float:
+    a, b, c = matrix[0]
+    d, e, f = matrix[1]
+    g, h, i = matrix[2]
+    return a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+
+
+def _validate_rotation_matrix(matrix: Matrix, label: str) -> None:
+    if abs(_det3(matrix) - 1.0) > 1e-6:
+        raise PhysicalUpContractError(f"{label} must be a proper rotation with determinant +1")
+    for row in matrix:
+        if abs(_dot(row, row) - 1.0) > 1e-6:
+            raise PhysicalUpContractError(f"{label} rows must be unit length")
+    for i in range(3):
+        for j in range(i + 1, 3):
+            if abs(_dot(matrix[i], matrix[j])) > 1e-6:
+                raise PhysicalUpContractError(f"{label} rows must be orthogonal")
+
+
+def rotation_from_to(source: Vector, target: Vector) -> tuple[Matrix, Quaternion]:
+    source_n = _normalize(source, "source direction")
+    target_n = _normalize(target, "target direction")
+    cosine = max(-1.0, min(1.0, _dot(source_n, target_n)))
+    if cosine > 1.0 - 1e-12:
+        return (
+            ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+            (0.0, 0.0, 0.0, 1.0),
+        )
+    if cosine < -1.0 + 1e-12:
+        candidates = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+        basis = min(candidates, key=lambda axis: abs(_dot(source_n, axis)))
+        axis = _normalize(_cross(source_n, basis), "180-degree rotation axis")
+        x, y, z = axis
+        matrix: Matrix = (
+            (2.0 * x * x - 1.0, 2.0 * x * y, 2.0 * x * z),
+            (2.0 * y * x, 2.0 * y * y - 1.0, 2.0 * y * z),
+            (2.0 * z * x, 2.0 * z * y, 2.0 * z * z - 1.0),
+        )
+        return matrix, (x, y, z, 0.0)
+
+    cross = _cross(source_n, target_n)
+    sine = _norm(cross)
+    axis = tuple(component / sine for component in cross)
+    x, y, z = axis
+    one_minus_cosine = 1.0 - cosine
+    matrix = (
+        (
+            cosine + x * x * one_minus_cosine,
+            x * y * one_minus_cosine - z * sine,
+            x * z * one_minus_cosine + y * sine,
+        ),
+        (
+            y * x * one_minus_cosine + z * sine,
+            cosine + y * y * one_minus_cosine,
+            y * z * one_minus_cosine - x * sine,
+        ),
+        (
+            z * x * one_minus_cosine - y * sine,
+            z * y * one_minus_cosine + x * sine,
+            cosine + z * z * one_minus_cosine,
+        ),
+    )
+    half_angle = math.acos(cosine) * 0.5
+    half_sine = math.sin(half_angle)
+    quaternion = (
+        x * half_sine,
+        y * half_sine,
+        z * half_sine,
+        math.cos(half_angle),
+    )
+    return matrix, quaternion
+
+
+def quaternion_multiply(left: Quaternion, right: Quaternion) -> Quaternion:
+    lx, ly, lz, lw = left
+    rx, ry, rz, rw = right
+    value = (
+        lw * rx + lx * rw + ly * rz - lz * ry,
+        lw * ry - lx * rz + ly * rw + lz * rx,
+        lw * rz + lx * ry - ly * rx + lz * rw,
+        lw * rw - lx * rx - ly * ry - lz * rz,
+    )
+    magnitude = math.sqrt(sum(component * component for component in value))
+    if magnitude <= 1e-12 or not math.isfinite(magnitude):
+        raise PhysicalUpContractError("composed quaternion is invalid")
+    return tuple(component / magnitude for component in value)  # type: ignore[return-value]
+
+
+def load_physical_up_evidence(path: str | Path) -> dict:
+    evidence_path = Path(path).expanduser().resolve()
+    if not evidence_path.is_file():
+        raise PhysicalUpContractError(f"physical-up evidence file is missing: {evidence_path}")
+    try:
+        payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PhysicalUpContractError(f"cannot read physical-up evidence: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PhysicalUpContractError("physical-up evidence must contain a JSON object")
+    if payload.get("schema_version") != PHYSICAL_UP_SCHEMA_VERSION:
+        raise PhysicalUpContractError("unsupported physical-up evidence schema_version")
+
+    authority_type = payload.get("authority_type")
+    if authority_type not in ALLOWED_AUTHORITY_TYPES:
+        raise PhysicalUpContractError(f"unsupported physical-up authority_type: {authority_type!r}")
+    authority_source = payload.get("authority_source")
+    if not isinstance(authority_source, str) or not authority_source.strip():
+        raise PhysicalUpContractError("physical-up authority_source must be a non-empty string")
+    authority_sha = payload.get("authority_source_sha256")
+    if (
+        not isinstance(authority_sha, str)
+        or len(authority_sha) != 64
+        or any(character not in "0123456789abcdef" for character in authority_sha)
+    ):
+        raise PhysicalUpContractError("authority_source_sha256 must be a lowercase SHA-256 hex digest")
+
+    semantics = payload.get("vector_semantics")
+    if semantics not in ALLOWED_VECTOR_SEMANTICS:
+        raise PhysicalUpContractError(f"unsupported vector_semantics: {semantics!r}")
+    source_frame = payload.get("source_frame")
+    if not isinstance(source_frame, str) or not source_frame.strip():
+        raise PhysicalUpContractError("source_frame must be a non-empty string")
+    source_vector = _normalize(_vector3(payload.get("source_vector"), "source_vector"), "source_vector")
+    if semantics == "gravity_down":
+        source_up = tuple(-component for component in source_vector)
+    else:
+        source_up = source_vector
+
+    source_to_model = _matrix3(payload.get("source_to_model_matrix3x3"), "source_to_model_matrix3x3")
+    _validate_rotation_matrix(source_to_model, "source_to_model_matrix3x3")
+    model_up = _normalize(_mat_vec(source_to_model, source_up), "model up vector")
+    correction_matrix, correction_quaternion = rotation_from_to(model_up, (0.0, 0.0, 1.0))
+    _validate_rotation_matrix(correction_matrix, "model physical-up correction")
+    corrected = _mat_vec(correction_matrix, model_up)
+    if any(abs(a - b) > 1e-6 for a, b in zip(corrected, (0.0, 0.0, 1.0), strict=True)):
+        raise PhysicalUpContractError("physical-up correction does not map model up to +Z")
+
+    uncertainty = payload.get("angular_uncertainty_deg")
+    if uncertainty is not None and (not _finite(uncertainty) or float(uncertainty) < 0.0):
+        raise PhysicalUpContractError("angular_uncertainty_deg must be finite and non-negative")
+
+    resolved = {
+        "status": "accepted",
+        "observable_from_sfm_alone": False,
+        "authority_type": authority_type,
+        "authority_source": authority_source.strip(),
+        "authority_source_sha256": authority_sha,
+        "source_frame": source_frame.strip(),
+        "vector_semantics": semantics,
+        "source_vector": list(source_vector),
+        "source_to_model_matrix3x3": [list(row) for row in source_to_model],
+        "model_up_vector": list(model_up),
+        "model_to_gravity_aligned": {
+            "matrix3x3": [list(row) for row in correction_matrix],
+            "quaternion_xyzw": list(correction_quaternion),
+        },
+        "evidence_path": str(evidence_path),
+        "evidence_sha256": sha256_file(evidence_path),
+    }
+    if uncertainty is not None:
+        resolved["angular_uncertainty_deg"] = float(uncertainty)
+    return resolved

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -24,6 +24,7 @@ class ArtifactPublishTest(unittest.TestCase):
         include_revision: bool = True,
         container_path: bool = False,
         orientation_override: str | None = None,
+        with_physical_up: bool = False,
     ):
         ply = root / "output" / "demo" / "runs" / "r1" / "export" / "splat.ply"
         ply.parent.mkdir(parents=True)
@@ -45,7 +46,7 @@ class ArtifactPublishTest(unittest.TestCase):
         if orientation_override is not None:
             transforms_payload["orientation_override"] = orientation_override
         transforms.write_text(json.dumps(transforms_payload), encoding="utf-8")
-        body = {
+        body: dict[str, object] = {
             "schema_version": 2,
             "dataset": "demo",
             "status": "success",
@@ -66,6 +67,29 @@ class ArtifactPublishTest(unittest.TestCase):
         }
         if include_revision:
             body["source_revision"] = REVISION
+        if with_physical_up:
+            physical_path = manifest.parent / "physical-up-evidence.json"
+            physical_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "authority_type": "imu_gravity",
+                        "authority_source": "fixture://imu.json",
+                        "authority_source_sha256": "c" * 64,
+                        "source_frame": "imu-frame",
+                        "vector_semantics": "gravity_down",
+                        "source_vector": [0.0, 0.5, -0.8660254037844386],
+                        "source_to_model_matrix3x3": [
+                            [1.0, 0.0, 0.0],
+                            [0.0, 1.0, 0.0],
+                            [0.0, 0.0, 1.0],
+                        ],
+                        "angular_uncertainty_deg": 0.2,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            body["physical_up_evidence_path"] = physical_path.name
         manifest.write_text(json.dumps(body), encoding="utf-8")
         hf_root = root / "hf-cache-hub"
         (hf_root / "scripts").mkdir(parents=True)
@@ -119,6 +143,9 @@ class ArtifactPublishTest(unittest.TestCase):
             self.assertEqual(sha, result["sha256"])
             self.assertEqual(REVISION, result["source_revision"])
             self.assertEqual("accepted", result["orientation_status"])
+            self.assertEqual("coordinate_basis_only", result["orientation_scope"])
+            self.assertEqual("review_required", result["physical_up_status"])
+            self.assertIsNone(result["physical_up_authority_type"])
             artifact_manifest = yaml.safe_load(
                 (manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8")
             )
@@ -130,6 +157,7 @@ class ArtifactPublishTest(unittest.TestCase):
             self.assertIn("run_id", artifact["provenance"])
             self.assertNotIn("source_path", artifact["provenance"])
             self.assertEqual("accepted", artifact["orientation"]["status"])
+            self.assertEqual("review_required", artifact["orientation"]["physical_up"]["status"])
             self.assertEqual(sha, artifact["orientation"]["ply_sha256"])
             self.assertEqual("orientation-evidence.json", artifact["orientation"]["evidence_path"])
             self.assertEqual(
@@ -142,6 +170,27 @@ class ArtifactPublishTest(unittest.TestCase):
             self.assertEqual("published", updated["artifact_publish"]["status"])
             self.assertTrue((manifest.parent / "orientation-evidence.json").is_file())
             self.assertTrue(ply.exists())
+
+    def test_external_physical_up_is_published_with_portable_evidence_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root, with_physical_up=True)
+            result = publish_run_splat(
+                manifest,
+                bucket="k4fka/artifacts",
+                hf_cache_hub_root=hf_root,
+                runner=self._successful_runner,
+            )
+            self.assertEqual("coordinate_basis_plus_physical_up", result["orientation_scope"])
+            self.assertEqual("accepted", result["physical_up_status"])
+            self.assertEqual("imu_gravity", result["physical_up_authority_type"])
+            artifact = yaml.safe_load(
+                (manifest.parent / "artifact-manifest.yaml").read_text(encoding="utf-8")
+            )["artifacts"][0]
+            physical = artifact["orientation"]["physical_up"]
+            self.assertEqual("accepted", physical["status"])
+            self.assertEqual("physical-up-evidence.json", physical["evidence_path"])
+            self.assertEqual("c" * 64, physical["authority_source_sha256"])
 
     def test_container_output_path_is_resolved_on_host(self):
         with tempfile.TemporaryDirectory() as d:
@@ -240,11 +289,26 @@ class ArtifactPublishTest(unittest.TestCase):
                     runner=self._successful_runner,
                 )
 
+    def test_declared_missing_physical_up_fails_before_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, _, hf_root = self._fixture(root)
+            body = json.loads(manifest.read_text(encoding="utf-8"))
+            body["physical_up_evidence_path"] = "missing-physical-up.json"
+            manifest.write_text(json.dumps(body), encoding="utf-8")
+            with self.assertRaisesRegex(ArtifactPublishError, "physical-up evidence file is missing"):
+                publish_run_splat(
+                    manifest,
+                    bucket="k4fka/artifacts",
+                    hf_cache_hub_root=hf_root,
+                    runner=self._successful_runner,
+                )
+
     def test_non_gravity_orientation_method_fails_before_publish(self):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             manifest, _, _, hf_root = self._fixture(root, orientation_override="pca")
-            with self.assertRaisesRegex(ArtifactPublishError, "only accepted orientation evidence"):
+            with self.assertRaisesRegex(ArtifactPublishError, "only accepted orientation basis evidence"):
                 publish_run_splat(
                     manifest,
                     bucket="k4fka/artifacts",

--- a/tests/test_artifact_publish.py
+++ b/tests/test_artifact_publish.py
@@ -296,7 +296,9 @@ class ArtifactPublishTest(unittest.TestCase):
             body = json.loads(manifest.read_text(encoding="utf-8"))
             body["physical_up_evidence_path"] = "missing-physical-up.json"
             manifest.write_text(json.dumps(body), encoding="utf-8")
-            with self.assertRaisesRegex(ArtifactPublishError, "physical-up evidence file is missing"):
+            with self.assertRaisesRegex(
+                ArtifactPublishError, "physical-up evidence file is missing"
+            ):
                 publish_run_splat(
                     manifest,
                     bucket="k4fka/artifacts",
@@ -308,7 +310,9 @@ class ArtifactPublishTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
             manifest, _, _, hf_root = self._fixture(root, orientation_override="pca")
-            with self.assertRaisesRegex(ArtifactPublishError, "only accepted orientation basis evidence"):
+            with self.assertRaisesRegex(
+                ArtifactPublishError, "only accepted orientation basis evidence"
+            ):
                 publish_run_splat(
                     manifest,
                     bucket="k4fka/artifacts",

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -37,6 +37,31 @@ class OrientationContractTest(unittest.TestCase):
         ply.write_bytes(b"ply\nsynthetic-gaussian")
         return transforms, ply
 
+    def _physical_up(self, root: Path, *, angle_deg: float = 30.0) -> Path:
+        angle = math.radians(angle_deg)
+        path = root / "physical-up-evidence.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "authority_type": "surveyed_up_vector",
+                    "authority_source": "fixture://survey.json",
+                    "authority_source_sha256": "b" * 64,
+                    "source_frame": "survey-frame",
+                    "vector_semantics": "up",
+                    "source_vector": [0.0, math.sin(angle), math.cos(angle)],
+                    "source_to_model_matrix3x3": [
+                        [1.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0],
+                        [0.0, 0.0, 1.0],
+                    ],
+                    "angular_uncertainty_deg": 0.1,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
     def test_default_up_accepts_basis_but_not_physical_gravity(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d))
@@ -70,7 +95,54 @@ class OrientationContractTest(unittest.TestCase):
             self.assertEqual("vertical", evidence["orientation_method"])
             self.assertEqual("review_required", evidence["physical_up"]["status"])
 
-    def test_pca_is_review_required(self):
+    def test_external_authority_is_composed_and_maps_real_up_to_unity_y(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            transforms, ply = self._fixture(root)
+            physical_up = self._physical_up(root, angle_deg=30.0)
+            evidence = build_orientation_evidence(
+                transforms,
+                ply,
+                physical_up_path=physical_up,
+            )
+            self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("coordinate_basis_plus_physical_up", evidence["scope"])
+            self.assertEqual("accepted", evidence["physical_up"]["status"])
+            self.assertEqual("surveyed_up_vector", evidence["physical_up"]["authority_type"])
+            self.assertTrue(evidence["canonical_frame"]["physical_gravity_claimed"])
+            model_up = evidence["physical_up"]["model_up_vector"]
+            matrix = evidence["source_to_canonical"]["matrix3x3"]
+            final_up = [sum(matrix[r][c] * model_up[c] for c in range(3)) for r in range(3)]
+            self.assertAlmostEqual(0.0, final_up[0], places=7)
+            self.assertAlmostEqual(1.0, final_up[1], places=7)
+            self.assertAlmostEqual(0.0, final_up[2], places=7)
+            validate_orientation_evidence(evidence, expected_ply_sha256=evidence["ply_sha256"])
+
+    def test_external_authority_can_resolve_pca_model_frame(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            transforms, ply = self._fixture(root, orientation_override="pca")
+            physical_up = self._physical_up(root, angle_deg=15.0)
+            evidence = build_orientation_evidence(
+                transforms,
+                ply,
+                physical_up_path=physical_up,
+            )
+            self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("accepted", evidence["physical_up"]["status"])
+
+    def test_invalid_external_authority_fails_closed(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            transforms, ply = self._fixture(root)
+            physical_up = self._physical_up(root)
+            payload = json.loads(physical_up.read_text(encoding="utf-8"))
+            payload["authority_type"] = "dominant_plane_pca"
+            physical_up.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(OrientationContractError, "external physical-up evidence"):
+                build_orientation_evidence(transforms, ply, physical_up_path=physical_up)
+
+    def test_pca_is_review_required_without_external_authority(self):
         with tempfile.TemporaryDirectory() as d:
             transforms, ply = self._fixture(Path(d), orientation_override="pca")
             evidence = build_orientation_evidence(transforms, ply)

--- a/tests/test_physical_up.py
+++ b/tests/test_physical_up.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from processing.physical_up import PhysicalUpContractError, load_physical_up_evidence
+
+
+class PhysicalUpContractTest(unittest.TestCase):
+    def _write(
+        self,
+        root: Path,
+        *,
+        authority_type: str = "imu_gravity",
+        semantics: str = "up",
+        source_vector: list[float] | None = None,
+        matrix: list[list[float]] | None = None,
+    ) -> Path:
+        path = root / "physical-up-evidence.json"
+        payload = {
+            "schema_version": 1,
+            "authority_type": authority_type,
+            "authority_source": "fixture://telemetry.json",
+            "authority_source_sha256": "a" * 64,
+            "source_frame": "fixture-imu",
+            "vector_semantics": semantics,
+            "source_vector": source_vector or [0.0, 0.0, 1.0],
+            "source_to_model_matrix3x3": matrix
+            or [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            "angular_uncertainty_deg": 0.25,
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def test_known_tilt_is_rotated_to_model_z(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            angle = math.radians(30.0)
+            path = self._write(
+                root,
+                source_vector=[0.0, math.sin(angle), math.cos(angle)],
+            )
+            evidence = load_physical_up_evidence(path)
+            self.assertEqual("accepted", evidence["status"])
+            self.assertEqual("imu_gravity", evidence["authority_type"])
+            self.assertEqual(
+                hashlib.sha256(path.read_bytes()).hexdigest(), evidence["evidence_sha256"]
+            )
+            matrix = evidence["model_to_gravity_aligned"]["matrix3x3"]
+            up = evidence["model_up_vector"]
+            corrected = [sum(matrix[r][c] * up[c] for c in range(3)) for r in range(3)]
+            self.assertAlmostEqual(0.0, corrected[0], places=7)
+            self.assertAlmostEqual(0.0, corrected[1], places=7)
+            self.assertAlmostEqual(1.0, corrected[2], places=7)
+
+    def test_gravity_down_semantics_are_inverted(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write(Path(d), semantics="gravity_down", source_vector=[0.0, 0.0, -2.0])
+            evidence = load_physical_up_evidence(path)
+            self.assertEqual([0.0, 0.0, 1.0], evidence["model_up_vector"])
+
+    def test_unknown_authority_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write(Path(d), authority_type="dominant_plane_pca")
+            with self.assertRaisesRegex(PhysicalUpContractError, "authority_type"):
+                load_physical_up_evidence(path)
+
+    def test_zero_vector_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write(Path(d), source_vector=[0.0, 0.0, 0.0])
+            with self.assertRaisesRegex(PhysicalUpContractError, "non-zero"):
+                load_physical_up_evidence(path)
+
+    def test_non_rotation_frame_transform_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write(
+                Path(d),
+                matrix=[[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            )
+            with self.assertRaisesRegex(PhysicalUpContractError, "proper rotation"):
+                load_physical_up_evidence(path)
+
+    def test_malformed_source_hash_is_rejected(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = self._write(Path(d))
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            payload["authority_source_sha256"] = "not-a-sha"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(PhysicalUpContractError, "SHA-256"):
+                load_physical_up_evidence(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the producer side of #121.

- new `processing/physical_up.py` fail-closed contract for `imu_gravity`, `surveyed_up_vector`, `surveyed_ground_plane`, and independently auditable gravity references
- rejects geometry/PCA as authority
- requires explicit source frame, vector semantics, source-to-model proper rotation, authority provenance SHA-256
- normalizes up/gravity vectors and computes a deterministic model-up -> +Z correction
- `processing/orientation.py` composes physical correction before the existing Nerfstudio-basis -> Unity conversion and before the renderer-aware horizon transform
- without external authority, behavior remains `coordinate_basis_only` + `physical_up=review_required`
- with accepted authority, scope becomes `coordinate_basis_plus_physical_up` and the final transform is verified to map the authoritative model up to Unity +Y
- pca/none can only become upright-ready when an external authority supplies the missing absolute orientation
- artifact publish auto-discovers/accepts `physical_up_evidence_path`, embeds evidence hashes and exposes `physical_up_status` / authority type
- synthetic 30° survey/IMU fixtures, gravity-down semantics, malformed authority/hash/vector/matrix and portable artifact-manifest tests included

No current legacy artifact is promoted to accepted physical up by this PR; real authority data is still required per source.