### PR TITLE
Add fail-closed Gaussian PLY input inspection

### DIFF
--- a/processing/gaussian_ply.py
+++ b/processing/gaussian_ply.py
@@ -28,6 +28,22 @@ _PLY_TYPES = {
     "float64": "<f8",
 }
 
+_BACKEND_REQUIREMENTS = {
+    "point-cloud-poisson": {"x", "y", "z"},
+    "gaussian-covariance-normal": {
+        "x",
+        "y",
+        "z",
+        "scale_0",
+        "scale_1",
+        "scale_2",
+        "rot_0",
+        "rot_1",
+        "rot_2",
+        "rot_3",
+    },
+}
+
 
 def _read_vertex_layout(handle) -> tuple[int, np.dtype]:
     first = handle.readline().decode("ascii", errors="strict").strip()
@@ -71,22 +87,13 @@ def _read_vertex_layout(handle) -> tuple[int, np.dtype]:
     return vertex_count, np.dtype(properties)
 
 
-def gaussian_ply_metrics(path: str | Path) -> dict:
-    """Measure primitive, opacity and scale-anisotropy statistics from a standard 3DGS PLY.
-
-    The exporter representation stores opacity as logits and scale components as log-scales.
-    Unsupported PLY layouts fail closed instead of producing guessed metrics.
-    """
+def _read_vertices(path: str | Path) -> tuple[Path, np.ndarray]:
     ply = Path(path).expanduser().resolve()
     if not ply.is_file():
         raise ValueError(f"PLY does not exist: {ply}")
 
     with ply.open("rb") as handle:
         vertex_count, dtype = _read_vertex_layout(handle)
-        required = {"opacity", "scale_0", "scale_1", "scale_2"}
-        missing = required - set(dtype.names or ())
-        if missing:
-            raise ValueError(f"PLY is missing Gaussian properties: {sorted(missing)}")
         vertices = np.fromfile(handle, dtype=dtype, count=vertex_count)
 
     if len(vertices) != vertex_count:
@@ -95,8 +102,129 @@ def gaussian_ply_metrics(path: str | Path) -> dict:
         )
     if vertex_count == 0:
         raise ValueError("PLY has zero Gaussian primitives")
+    return ply, vertices
+
+
+def _infer_sh_degree(names: set[str]) -> int | None:
+    rest_count = sum(name.startswith("f_rest_") for name in names)
+    if rest_count == 0:
+        return 0 if {"f_dc_0", "f_dc_1", "f_dc_2"}.issubset(names) else None
+    if rest_count % 3 != 0:
+        return None
+    coefficients_per_channel = rest_count // 3 + 1
+    root = int(math.isqrt(coefficients_per_channel))
+    if root * root != coefficients_per_channel:
+        return None
+    return root - 1
+
+
+def gaussian_ply_inspection(path: str | Path) -> dict:
+    """Inspect a Gaussian PLY without modifying it.
+
+    Unknown field layouts remain unknown. The function validates payload completeness and
+    finite numeric values instead of guessing missing Gaussian attributes or provenance.
+    """
+    ply, vertices = _read_vertices(path)
+    names = set(vertices.dtype.names or ())
+    required_xyz = {"x", "y", "z"}
+    missing_xyz = required_xyz - names
+    if missing_xyz:
+        raise ValueError(f"PLY is missing position properties: {sorted(missing_xyz)}")
+
+    floating_names = [
+        name
+        for name in vertices.dtype.names or ()
+        if np.issubdtype(vertices.dtype[name], np.floating)
+    ]
+    nonfinite_by_property = {
+        name: int(np.count_nonzero(~np.isfinite(vertices[name]))) for name in floating_names
+    }
+    nonfinite_by_property = {
+        name: count for name, count in nonfinite_by_property.items() if count > 0
+    }
+    if nonfinite_by_property:
+        raise ValueError(f"PLY contains non-finite values: {nonfinite_by_property}")
+
+    xyz = np.column_stack(
+        [
+            np.asarray(vertices["x"], dtype=np.float64),
+            np.asarray(vertices["y"], dtype=np.float64),
+            np.asarray(vertices["z"], dtype=np.float64),
+        ]
+    )
+    minimum = np.min(xyz, axis=0)
+    maximum = np.max(xyz, axis=0)
+    centroid = np.mean(xyz, axis=0)
+
+    rotation_fields = [f"rot_{index}" for index in range(4)]
+    scale_fields = [f"scale_{index}" for index in range(3)]
+    dc_fields = sorted(name for name in names if name.startswith("f_dc_"))
+    rest_fields = sorted(name for name in names if name.startswith("f_rest_"))
+
+    return {
+        "schema_version": 1,
+        "path": str(ply),
+        "encoding": "binary_little_endian",
+        "size_bytes": ply.stat().st_size,
+        "sha256": sha256_file(ply),
+        "vertex_count": int(len(vertices)),
+        "properties": list(vertices.dtype.names or ()),
+        "dialect": "unknown",
+        "position": {
+            "fields": ["x", "y", "z"],
+            "bbox_min": [float(value) for value in minimum],
+            "bbox_max": [float(value) for value in maximum],
+            "centroid": [float(value) for value in centroid],
+        },
+        "gaussian_fields": {
+            "opacity": "opacity" in names,
+            "scale": all(field in names for field in scale_fields),
+            "rotation": all(field in names for field in rotation_fields),
+            "dc_fields": dc_fields,
+            "rest_field_count": len(rest_fields),
+            "inferred_sh_degree": _infer_sh_degree(names),
+        },
+        "finite_values": True,
+    }
+
+
+def validate_gaussian_ply_backend(inspection: dict, backend: str) -> dict:
+    """Validate whether an inspected PLY satisfies a mesh backend's PLY-side inputs."""
+    if backend == "render-depth-tsdf":
+        return {
+            "backend": backend,
+            "supported": False,
+            "missing_fields": [],
+            "reason": "requires training config/checkpoint/cameras; PLY alone is insufficient",
+        }
+    if backend not in _BACKEND_REQUIREMENTS:
+        raise ValueError(f"unsupported Gaussian PLY backend: {backend}")
+
+    names = set(inspection.get("properties", []))
+    missing = sorted(_BACKEND_REQUIREMENTS[backend] - names)
+    return {
+        "backend": backend,
+        "supported": not missing,
+        "missing_fields": missing,
+        "reason": None if not missing else "required PLY properties are missing",
+    }
+
+
+def gaussian_ply_metrics(path: str | Path) -> dict:
+    """Measure primitive, opacity and scale-anisotropy statistics from a standard 3DGS PLY.
+
+    The exporter representation stores opacity as logits and scale components as log-scales.
+    Unsupported PLY layouts fail closed instead of producing guessed metrics.
+    """
+    ply, vertices = _read_vertices(path)
+    required = {"opacity", "scale_0", "scale_1", "scale_2"}
+    missing = required - set(vertices.dtype.names or ())
+    if missing:
+        raise ValueError(f"PLY is missing Gaussian properties: {sorted(missing)}")
 
     opacity_logits = np.asarray(vertices["opacity"], dtype=np.float64)
+    if not np.all(np.isfinite(opacity_logits)):
+        raise ValueError("PLY opacity contains non-finite values")
     opacity = np.empty_like(opacity_logits)
     positive = opacity_logits >= 0
     opacity[positive] = 1.0 / (1.0 + np.exp(-opacity_logits[positive]))
@@ -110,6 +238,8 @@ def gaussian_ply_metrics(path: str | Path) -> dict:
             np.asarray(vertices["scale_2"], dtype=np.float64),
         ]
     )
+    if not np.all(np.isfinite(log_scales)):
+        raise ValueError("PLY scales contain non-finite values")
     log_ratio = np.max(log_scales, axis=1) - np.min(log_scales, axis=1)
     ratio = np.exp(np.minimum(log_ratio, math.log(np.finfo(np.float64).max)))
 
@@ -129,7 +259,7 @@ def gaussian_ply_metrics(path: str | Path) -> dict:
         "path": str(ply),
         "size_bytes": ply.stat().st_size,
         "sha256": sha256_file(ply),
-        "primitive_count": int(vertex_count),
+        "primitive_count": int(len(vertices)),
         "opacity": {
             "quantiles": quantiles(opacity),
             "below_0_1_count": int(np.count_nonzero(low_opacity)),
@@ -144,13 +274,23 @@ def gaussian_ply_metrics(path: str | Path) -> dict:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Measure Gaussian PLY primitive/opacity/scale statistics."
-    )
+    parser = argparse.ArgumentParser(description="Inspect or measure a Gaussian PLY.")
     parser.add_argument("ply")
     parser.add_argument("--output")
+    parser.add_argument("--inspect", action="store_true")
+    parser.add_argument(
+        "--backend",
+        choices=[*sorted(_BACKEND_REQUIREMENTS), "render-depth-tsdf"],
+        help="Validate PLY-side requirements for a mesh backend; implies --inspect.",
+    )
     args = parser.parse_args()
-    result = gaussian_ply_metrics(args.ply)
+
+    if args.inspect or args.backend:
+        result = gaussian_ply_inspection(args.ply)
+        if args.backend:
+            result["backend_validation"] = validate_gaussian_ply_backend(result, args.backend)
+    else:
+        result = gaussian_ply_metrics(args.ply)
     if args.output:
         write_json(args.output, result)
     print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/tests/test_gaussian_ply.py
+++ b/tests/test_gaussian_ply.py
@@ -111,9 +111,7 @@ class GaussianPlyMetricsTests(unittest.TestCase):
             self._write_ply(path)
             inspection = gaussian_ply_inspection(path)
             poisson = validate_gaussian_ply_backend(inspection, "point-cloud-poisson")
-            covariance = validate_gaussian_ply_backend(
-                inspection, "gaussian-covariance-normal"
-            )
+            covariance = validate_gaussian_ply_backend(inspection, "gaussian-covariance-normal")
             tsdf = validate_gaussian_ply_backend(inspection, "render-depth-tsdf")
             self.assertTrue(poisson["supported"])
             self.assertFalse(covariance["supported"])

--- a/tests/test_gaussian_ply.py
+++ b/tests/test_gaussian_ply.py
@@ -4,23 +4,45 @@ from pathlib import Path
 
 import numpy as np
 
-from processing.gaussian_ply import gaussian_ply_metrics
+from processing.gaussian_ply import (
+    gaussian_ply_inspection,
+    gaussian_ply_metrics,
+    validate_gaussian_ply_backend,
+)
 
 
 class GaussianPlyMetricsTests(unittest.TestCase):
-    def _write_ply(self, path: Path) -> None:
-        dtype = np.dtype(
+    def _write_ply(
+        self,
+        path: Path,
+        *,
+        include_rotation: bool = False,
+        include_xyz: bool = True,
+        nonfinite_x: bool = False,
+    ) -> None:
+        fields = []
+        if include_xyz:
+            fields.extend([("x", "<f4"), ("y", "<f4"), ("z", "<f4")])
+        fields.extend(
             [
-                ("x", "<f4"),
-                ("y", "<f4"),
-                ("z", "<f4"),
+                ("f_dc_0", "<f4"),
+                ("f_dc_1", "<f4"),
+                ("f_dc_2", "<f4"),
                 ("opacity", "<f4"),
                 ("scale_0", "<f4"),
                 ("scale_1", "<f4"),
                 ("scale_2", "<f4"),
             ]
         )
+        if include_rotation:
+            fields.extend((f"rot_{index}", "<f4") for index in range(4))
+        dtype = np.dtype(fields)
         vertices = np.zeros(2, dtype=dtype)
+        if include_xyz:
+            vertices[0]["x"] = np.float32(np.nan if nonfinite_x else -1.0)
+            vertices[1]["x"] = np.float32(3.0)
+            vertices[1]["y"] = np.float32(2.0)
+            vertices[1]["z"] = np.float32(1.0)
         vertices[0]["opacity"] = np.float32(-3.0)
         vertices[1]["opacity"] = np.float32(3.0)
         vertices[0]["scale_0"] = np.float32(0.0)
@@ -29,19 +51,15 @@ class GaussianPlyMetricsTests(unittest.TestCase):
         vertices[1]["scale_0"] = np.float32(0.0)
         vertices[1]["scale_1"] = np.float32(0.0)
         vertices[1]["scale_2"] = np.float32(3.0)
-        header = (
-            "ply\n"
-            "format binary_little_endian 1.0\n"
-            "element vertex 2\n"
-            "property float x\n"
-            "property float y\n"
-            "property float z\n"
-            "property float opacity\n"
-            "property float scale_0\n"
-            "property float scale_1\n"
-            "property float scale_2\n"
-            "end_header\n"
-        ).encode("ascii")
+        header_lines = [
+            "ply",
+            "format binary_little_endian 1.0",
+            "element vertex 2",
+        ]
+        for name in dtype.names or ():
+            header_lines.append(f"property float {name}")
+        header_lines.append("end_header")
+        header = ("\n".join(header_lines) + "\n").encode("ascii")
         with path.open("wb") as handle:
             handle.write(header)
             handle.write(vertices.tobytes())
@@ -57,6 +75,54 @@ class GaussianPlyMetricsTests(unittest.TestCase):
             self.assertEqual(result["scale_anisotropy_ratio"]["above_10_count"], 1)
             self.assertAlmostEqual(result["scale_anisotropy_ratio"]["above_10_ratio"], 0.5)
             self.assertEqual(len(result["sha256"]), 64)
+
+    def test_inspection_records_fields_bounds_hash_and_unknown_dialect(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "splat.ply"
+            self._write_ply(path, include_rotation=True)
+            result = gaussian_ply_inspection(path)
+            self.assertEqual(result["encoding"], "binary_little_endian")
+            self.assertEqual(result["vertex_count"], 2)
+            self.assertEqual(result["dialect"], "unknown")
+            self.assertEqual(result["position"]["bbox_min"], [-1.0, 0.0, 0.0])
+            self.assertEqual(result["position"]["bbox_max"], [3.0, 2.0, 1.0])
+            self.assertEqual(result["position"]["centroid"], [1.0, 1.0, 0.5])
+            self.assertTrue(result["gaussian_fields"]["rotation"])
+            self.assertEqual(result["gaussian_fields"]["inferred_sh_degree"], 0)
+            self.assertEqual(len(result["sha256"]), 64)
+
+    def test_inspection_rejects_missing_xyz(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "missing-xyz.ply"
+            self._write_ply(path, include_xyz=False)
+            with self.assertRaisesRegex(ValueError, "position properties"):
+                gaussian_ply_inspection(path)
+
+    def test_inspection_rejects_nonfinite_values(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "nan.ply"
+            self._write_ply(path, nonfinite_x=True)
+            with self.assertRaisesRegex(ValueError, "non-finite"):
+                gaussian_ply_inspection(path)
+
+    def test_backend_validator_reports_missing_fields_without_guessing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "splat.ply"
+            self._write_ply(path)
+            inspection = gaussian_ply_inspection(path)
+            poisson = validate_gaussian_ply_backend(inspection, "point-cloud-poisson")
+            covariance = validate_gaussian_ply_backend(
+                inspection, "gaussian-covariance-normal"
+            )
+            tsdf = validate_gaussian_ply_backend(inspection, "render-depth-tsdf")
+            self.assertTrue(poisson["supported"])
+            self.assertFalse(covariance["supported"])
+            self.assertEqual(
+                covariance["missing_fields"],
+                ["rot_0", "rot_1", "rot_2", "rot_3"],
+            )
+            self.assertFalse(tsdf["supported"])
+            self.assertIn("checkpoint", tsdf["reason"])
 
     def test_metrics_fail_closed_for_ascii_ply(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Implements the smallest coherent part of #111 without adding a second PLY parser or mesh framework.

Changes:
- extend existing `processing/gaussian_ply.py` with non-destructive PLY inspection
- record encoding, vertex count, property inventory, SHA-256/size, xyz bounds/centroid, Gaussian rotation/scale/color-field presence, and conservative SH-degree inference
- reject missing xyz, truncated payloads, and non-finite floating-point values
- keep dialect as `unknown` rather than guessing Splatfacto provenance from field names
- add backend-side input validation for point-cloud Poisson and Gaussian-covariance-normal paths
- explicitly reject `render-depth-tsdf` as PLY-only because it needs training config/checkpoint/cameras
- preserve the existing Gaussian quality metrics API
- add focused unit tests for valid inspection, missing xyz, NaN, backend requirements, and existing ASCII fail-closed behavior

This does not claim mesh generation, Blender/Unity import, GPU execution, or runtime validation.

Refs #111