### PR TITLE
Business: make paid PoC inquiries structured and canonical

### DIFF
--- a/.github/ISSUE_TEMPLATE/photogrammetry-service.yml
+++ b/.github/ISSUE_TEMPLATE/photogrammetry-service.yml
@@ -1,0 +1,104 @@
+name: Photogrammetry service inquiry
+description: Request a free input audit, paid one-object PoC, or batch/private deployment discussion.
+title: "[Photogrammetry inquiry] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this public form only for non-confidential qualification information.
+        Do not attach customer images, personal data, credentials, unpublished contract terms, or other confidential material. A private transfer method must be agreed before any customer image bytes are transferred.
+
+  - type: dropdown
+    id: engagement
+    attributes:
+      label: Engagement
+      description: Choose the smallest engagement that matches the current decision you need to make.
+      options:
+        - Free input-audit sample
+        - Paid one-object PoC
+        - Batch or private deployment discussion
+    validations:
+      required: true
+
+  - type: dropdown
+    id: organization_type
+    attributes:
+      label: Organization type
+      options:
+        - Museum, archive, or research collection
+        - EC, manufacturer, or product team
+        - 3D production or photogrammetry provider
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: asset_type
+    attributes:
+      label: Object or asset type
+      description: Describe the kind of physical object or collection, without confidential identifiers.
+      placeholder: e.g. ceramic artifact, furniture product, architectural detail
+    validations:
+      required: true
+
+  - type: input
+    id: object_count
+    attributes:
+      label: Approximate object count
+      placeholder: e.g. 1, 25, 100+
+    validations:
+      required: true
+
+  - type: input
+    id: image_count
+    attributes:
+      label: Approximate images per object
+      placeholder: e.g. 80-150
+    validations:
+      required: true
+
+  - type: dropdown
+    id: rights
+    attributes:
+      label: Rights to process the submitted images
+      description: Processing can proceed only when the customer controls the images or has a confirmed permission/license basis for the intended use.
+      options:
+        - Confirmed
+        - Needs review
+        - Not confirmed
+    validations:
+      required: true
+
+  - type: dropdown
+    id: intended_use
+    attributes:
+      label: Intended 3D use
+      options:
+        - Web or EC visualization
+        - Museum, archive, or research visualization
+        - Game, VR, or spatial experience
+        - Editing or downstream 3D production
+        - 3D printing
+        - Reconstruction-readiness decision only
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision this engagement should support
+      description: State the concrete decision or deliverable you need from the audit or PoC. Do not include confidential information.
+      placeholder: e.g. Decide whether the current 120-image capture is ready for reconstruction or needs recapture.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: public_data_acknowledgement
+    attributes:
+      label: Public issue acknowledgement
+      options:
+        - label: I will not attach private customer images, personal data, credentials, or confidential information to this public issue.
+          required: true
+        - label: I understand that reconstruction quality is not guaranteed when registration, reprojection, geometry completeness, or texture quality have not been measured.
+          required: true

--- a/docs/business/photogrammetry-readiness-service.md
+++ b/docs/business/photogrammetry-readiness-service.md
@@ -64,19 +64,13 @@ For 10+ objects, the discussion can cover repeatable batch processing, capture g
 
 ## Calls to action
 
-These public issue links collect **non-confidential qualification information only**.
+All three service paths use one structured GitHub Issue Form so the qualification contract has one canonical implementation. The form collects only non-confidential scope information and requires an acknowledgement not to attach customer image bytes, personal data, credentials, or confidential information.
 
-### 撮影セットを監査する
+- [撮影セットを監査する](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?template=photogrammetry-service.yml&title=%5BPhotogrammetry+inquiry%5D+Input+audit)
+- [1対象物のPoCを相談する](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?template=photogrammetry-service.yml&title=%5BPhotogrammetry+inquiry%5D+One-object+PoC)
+- [大量3D化を相談する](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?template=photogrammetry-service.yml&title=%5BPhotogrammetry+inquiry%5D+Batch+or+private+deployment)
 
-[Open an input-audit inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+input+audit+inquiry&body=Organization+type+%28museum%2Farchive%2FEC%2Fmanufacturer%2F3D+production%2Fother%29%3A%0AObject+or+asset+type%3A%0AApproximate+image+count%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0AWhat+would+you+like+the+audit+to+check%3F%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
-
-### 1対象物のPoCを相談する
-
-[Open a one-object PoC inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+one-object+PoC+inquiry&body=Organization+type%3A%0AObject+or+asset+type%3A%0AApproximate+image+count%3A%0AIntended+3D+use%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0ADesired+timing%3A%0AWhat+decision+should+the+PoC+support%3F%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
-
-### 大量3D化を相談する
-
-[Open a batch/deployment inquiry](https://github.com/KAFKA2306/AutoPhotogrammetry/issues/new?title=Photogrammetry+batch+or+deployment+inquiry&body=Organization+type%3A%0AApproximate+object+count%3A%0AApproximate+images+per+object%3A%0ACapture+workflow%3A%0AIntended+3D+use%3A%0APreferred+operation+%28managed+batch%2Fprivate+CLI%2Fprivate+deployment%2Funsure%29%3A%0ADo+you+control+the+rights+to+use+the+images%3F+%28yes%2Fno%2Funsure%29%3A%0A%0ADo+not+attach+private+images%2C+personal+data%2C+credentials%2C+or+confidential+information.)
+The form asks for engagement type, organization type, object/asset type, approximate object and image counts, rights state, intended 3D use, and the concrete decision the engagement should support. It does not request customer names, contact details, or confidential transfer data.
 
 ## Measurement contract
 


### PR DESCRIPTION
Refs #3

## Before → After
- inquiry implementation: three long hand-maintained prefilled issue URLs → one canonical GitHub Issue Form
- qualification fields: free-form body text → required engagement / organization / asset / scale / rights / intended-use / decision fields
- public-data safety: warning text only → warning + required acknowledgement before submission
- contact/PII fields requested by the repository: 0 → 0
- runtime dependencies/workflows/backends: unchanged

## Why
The readiness report, sample, backend lineage, service contract and three CTAs are already on current `main`. The remaining repository-side conversion friction was duplicated URL-encoded inquiry bodies. GitHub Issue Forms are the upstream GitHub mechanism for structured required issue input, so this removes custom URL-body maintenance instead of adding another application or service.

## Evidence boundary
This improves the public qualification path only. It does not claim a qualified inquiry, booked pilot, paid pilot, or revenue. Customer image bytes and confidential data remain prohibited in public issues.

## Verification
Exact-head repository CI is required before merge. The form is stored at `.github/ISSUE_TEMPLATE/photogrammetry-service.yml`, the location required by GitHub Issue Forms, and all three documented CTAs route through that single template.