### PR TITLE
fix: make Open3D mesh runtime reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG CUDA_ARCH_LIST=12.0
 ARG NERFSTUDIO_REVISION=50e0e3c70c775e89333256213363badbf074f29d
 ARG GSPLAT_REVISION=v1.4.0
+ARG OPEN3D_VERSION=0.19.0
 ARG AUTOPHOTOGRAMMETRY_REVISION
 ENV CUDA_HOME=/usr/local/cuda \
     TORCH_CUDA_ARCH_LIST=${CUDA_ARCH_LIST} \
@@ -45,6 +46,8 @@ RUN git init /opt/nerfstudio \
     && git -C /opt/nerfstudio checkout --detach FETCH_HEAD \
     && test "$(git -C /opt/nerfstudio rev-parse HEAD)" = "${NERFSTUDIO_REVISION}" \
     && python -m pip install --no-cache-dir /opt/nerfstudio
+
+RUN python -m pip install --no-cache-dir "open3d==${OPEN3D_VERSION}"
 
 COPY requirements.txt /tmp/requirements.txt
 RUN python -m pip install --no-cache-dir -r /tmp/requirements.txt \


### PR DESCRIPTION
## Outcome

Make the merged PLY-only mesh baseline runnable in the canonical production image.

- pin Open3D `0.19.0` in `Dockerfile`
- keep Open3D out of the lightweight project dependency set
- use the existing production image rather than introducing a second mesh environment

## Why

`processing/mesh_from_points.py` is now on `main`, but the canonical image did not explicitly install Open3D. The mesh path therefore could not claim reproducible runtime availability even though repository CI passed.

Open3D 0.19.0 is the current PyPI release and publishes Linux wheels for the Python versions supported by this repository. Open3D's official surface-reconstruction API provides the Alpha Shapes, Ball Pivoting, and Poisson methods consumed by the implementation.

## Verification boundary

Normal PR CI can verify repository contracts. Actual Docker image build/publish is triggered after merge by the existing `GPU Image` workflow; real Gaussian PLY benchmark evidence remains Issue #112.