### PR TITLE
feat: add opacity ablation to PLY-only mesh baseline

### DIFF
--- a/processing/mesh_from_points.py
+++ b/processing/mesh_from_points.py
@@ -35,7 +35,9 @@ def _opacity_probabilities(logits: np.ndarray) -> np.ndarray:
     return probabilities
 
 
-def _point_samples(vertices: np.ndarray, opacity_threshold: float | None) -> tuple[np.ndarray, dict]:
+def _point_samples(
+    vertices: np.ndarray, opacity_threshold: float | None
+) -> tuple[np.ndarray, dict]:
     names = set(vertices.dtype.names or ())
     mask = np.ones(len(vertices), dtype=bool)
     if opacity_threshold is not None:

--- a/processing/mesh_from_points.py
+++ b/processing/mesh_from_points.py
@@ -25,12 +25,45 @@ def _open3d():
         raise RuntimeError("Open3D is required for PLY-only mesh reconstruction") from exc
 
 
-def _point_cloud(path: str | Path):
+def _opacity_probabilities(logits: np.ndarray) -> np.ndarray:
+    values = np.asarray(logits, dtype=np.float64)
+    probabilities = np.empty_like(values)
+    positive = values >= 0
+    probabilities[positive] = 1.0 / (1.0 + np.exp(-values[positive]))
+    exp_logits = np.exp(values[~positive])
+    probabilities[~positive] = exp_logits / (1.0 + exp_logits)
+    return probabilities
+
+
+def _point_samples(vertices: np.ndarray, opacity_threshold: float | None) -> tuple[np.ndarray, dict]:
+    names = set(vertices.dtype.names or ())
+    mask = np.ones(len(vertices), dtype=bool)
+    if opacity_threshold is not None:
+        if not 0.0 <= opacity_threshold <= 1.0:
+            raise ValueError("opacity_threshold must be between 0 and 1")
+        if "opacity" not in names:
+            raise ValueError("opacity_threshold requires an opacity property")
+        mask = _opacity_probabilities(vertices["opacity"]) >= opacity_threshold
+    kept = int(np.count_nonzero(mask))
+    if kept < 4:
+        raise ValueError(f"opacity filtering left too few point samples: {kept}")
+    points = np.column_stack(
+        [vertices["x"][mask], vertices["y"][mask], vertices["z"][mask]]
+    ).astype(np.float64)
+    return points, {
+        "input_point_count": int(len(vertices)),
+        "kept_point_count": kept,
+        "filtered_point_count": int(len(vertices) - kept),
+        "opacity_threshold": opacity_threshold,
+    }
+
+
+def _point_cloud(path: str | Path, opacity_threshold: float | None):
     o3d = _open3d()
     _, vertices = _read_vertices(path)
-    points = np.column_stack([vertices["x"], vertices["y"], vertices["z"]]).astype(np.float64)
+    points, filtering = _point_samples(vertices, opacity_threshold)
     cloud = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(points))
-    return o3d, cloud
+    return o3d, cloud, filtering
 
 
 def _mesh_stats(mesh) -> dict:
@@ -59,6 +92,7 @@ def reconstruct_mesh(
     depth: int | None = None,
     normal_radius: float | None = None,
     normal_max_nn: int = 30,
+    opacity_threshold: float | None = None,
     max_faces: int | None = None,
 ) -> dict:
     inspection = gaussian_ply_inspection(input_ply)
@@ -66,8 +100,8 @@ def reconstruct_mesh(
     if not backend["supported"]:
         raise ValueError(f"input PLY is not usable as a point cloud: {backend['missing_fields']}")
 
-    o3d, cloud = _point_cloud(input_ply)
-    parameters: dict[str, object] = {}
+    o3d, cloud, filtering = _point_cloud(input_ply, opacity_threshold)
+    parameters: dict[str, object] = {"opacity_threshold": opacity_threshold}
     started = time.perf_counter()
 
     if method == "alpha":
@@ -128,6 +162,7 @@ def reconstruct_mesh(
             "sha256": inspection["sha256"],
             "size_bytes": inspection["size_bytes"],
             "point_count": inspection["vertex_count"],
+            "filtering": filtering,
         },
         "output": {
             "path": str(output),
@@ -154,6 +189,7 @@ def main() -> None:
     parser.add_argument("--depth", type=int)
     parser.add_argument("--normal-radius", type=float)
     parser.add_argument("--normal-max-nn", type=int, default=30)
+    parser.add_argument("--opacity-threshold", type=float)
     parser.add_argument("--max-faces", type=int)
     parser.add_argument("--manifest")
     args = parser.parse_args()
@@ -166,6 +202,7 @@ def main() -> None:
         depth=args.depth,
         normal_radius=args.normal_radius,
         normal_max_nn=args.normal_max_nn,
+        opacity_threshold=args.opacity_threshold,
         max_faces=args.max_faces,
     )
     if args.manifest:

--- a/tests/test_mesh_from_points.py
+++ b/tests/test_mesh_from_points.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import unittest
+
 import numpy as np
-import pytest
 
 from processing.mesh_from_points import _point_samples
 
@@ -19,32 +20,37 @@ def _vertices(opacity: list[float] | None = None) -> np.ndarray:
     return values
 
 
-def test_point_samples_without_opacity_filter_keeps_all_points() -> None:
-    points, filtering = _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), None)
-    assert len(points) == 4
-    assert filtering == {
-        "input_point_count": 4,
-        "kept_point_count": 4,
-        "filtered_point_count": 0,
-        "opacity_threshold": None,
-    }
+class MeshPointSamplesTests(unittest.TestCase):
+    def test_without_opacity_filter_keeps_all_points(self) -> None:
+        points, filtering = _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), None)
+        self.assertEqual(len(points), 4)
+        self.assertEqual(
+            filtering,
+            {
+                "input_point_count": 4,
+                "kept_point_count": 4,
+                "filtered_point_count": 0,
+                "opacity_threshold": None,
+            },
+        )
+
+    def test_filters_using_sigmoid_opacity(self) -> None:
+        points, filtering = _point_samples(_vertices([-3.0, 0.0, 1.0, 2.0, 3.0]), 0.5)
+        self.assertEqual(len(points), 4)
+        self.assertEqual(points[:, 0].tolist(), [1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(filtering["filtered_point_count"], 1)
+        self.assertEqual(filtering["opacity_threshold"], 0.5)
+
+    def test_rejects_invalid_or_unsupported_filter(self) -> None:
+        with self.assertRaisesRegex(ValueError, "between 0 and 1"):
+            _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), 1.1)
+        with self.assertRaisesRegex(ValueError, "requires an opacity property"):
+            _point_samples(_vertices(), 0.5)
+
+    def test_rejects_too_few_remaining_points(self) -> None:
+        with self.assertRaisesRegex(ValueError, "too few point samples"):
+            _point_samples(_vertices([-10.0, -10.0, -10.0, 10.0]), 0.5)
 
 
-def test_point_samples_filters_using_sigmoid_opacity() -> None:
-    points, filtering = _point_samples(_vertices([-3.0, 0.0, 1.0, 2.0, 3.0]), 0.5)
-    assert len(points) == 4
-    assert points[:, 0].tolist() == [1.0, 2.0, 3.0, 4.0]
-    assert filtering["filtered_point_count"] == 1
-    assert filtering["opacity_threshold"] == 0.5
-
-
-def test_point_samples_rejects_invalid_or_unsupported_filter() -> None:
-    with pytest.raises(ValueError, match="between 0 and 1"):
-        _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), 1.1)
-    with pytest.raises(ValueError, match="requires an opacity property"):
-        _point_samples(_vertices(), 0.5)
-
-
-def test_point_samples_rejects_too_few_remaining_points() -> None:
-    with pytest.raises(ValueError, match="too few point samples"):
-        _point_samples(_vertices([-10.0, -10.0, -10.0, 10.0]), 0.5)
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mesh_from_points.py
+++ b/tests/test_mesh_from_points.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from processing.mesh_from_points import _point_samples
+
+
+def _vertices(opacity: list[float] | None = None) -> np.ndarray:
+    fields = [("x", "f4"), ("y", "f4"), ("z", "f4")]
+    if opacity is not None:
+        fields.append(("opacity", "f4"))
+    values = np.zeros(len(opacity or [0, 0, 0, 0]), dtype=np.dtype(fields))
+    values["x"] = np.arange(len(values), dtype=np.float32)
+    values["y"] = 1
+    values["z"] = 2
+    if opacity is not None:
+        values["opacity"] = opacity
+    return values
+
+
+def test_point_samples_without_opacity_filter_keeps_all_points() -> None:
+    points, filtering = _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), None)
+    assert len(points) == 4
+    assert filtering == {
+        "input_point_count": 4,
+        "kept_point_count": 4,
+        "filtered_point_count": 0,
+        "opacity_threshold": None,
+    }
+
+
+def test_point_samples_filters_using_sigmoid_opacity() -> None:
+    points, filtering = _point_samples(_vertices([-3.0, 0.0, 1.0, 2.0, 3.0]), 0.5)
+    assert len(points) == 4
+    assert points[:, 0].tolist() == [1.0, 2.0, 3.0, 4.0]
+    assert filtering["filtered_point_count"] == 1
+    assert filtering["opacity_threshold"] == 0.5
+
+
+def test_point_samples_rejects_invalid_or_unsupported_filter() -> None:
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        _point_samples(_vertices([0.0, 0.0, 0.0, 0.0]), 1.1)
+    with pytest.raises(ValueError, match="requires an opacity property"):
+        _point_samples(_vertices(), 0.5)
+
+
+def test_point_samples_rejects_too_few_remaining_points() -> None:
+    with pytest.raises(ValueError, match="too few point samples"):
+        _point_samples(_vertices([-10.0, -10.0, -10.0, 10.0]), 0.5)


### PR DESCRIPTION
## Outcome

Complete the missing opacity-threshold input needed by #112's real Gaussian PLY benchmark.

- add `--opacity-threshold` to the existing `processing/mesh_from_points.py`
- interpret the standard Gaussian `opacity` field as logits and filter by sigmoid probability
- preserve the original PLY; filtering is in-memory only
- record input/kept/filtered point counts and threshold in the result manifest
- fail closed when opacity is unavailable, threshold is invalid, or too few samples remain
- add focused tests without requiring Open3D in normal CI

No new mesh framework, dependency, workflow, or data authority is added.

Related: #112