### PR TITLE
feat: export reconstructed meshes to GLB OBJ and STL

### DIFF
--- a/.github/workflows/mesh-export-evidence.yml
+++ b/.github/workflows/mesh-export-evidence.yml
@@ -1,0 +1,115 @@
+name: Mesh export evidence
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/mesh-export-evidence.yml'
+      - 'processing/mesh_export.py'
+      - 'processing/mesh_from_points.py'
+      - 'tests/test_mesh_export.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install mesh and glTF validation runtime
+        run: |
+          python -m pip install --disable-pip-version-check numpy open3d==0.19.0
+          npm install --no-save gltf-validator@2.0.0-dev.3.10
+      - name: Materialize real Gaussian PLY and reconstruct canonical alpha mesh
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_commit=1fa7f35b1fc9fce669f97d5ec7c7f46ce4601206
+          scene=puente-san-ignacio-03
+          path="$(git ls-tree -r --name-only "$source_commit" | grep "^output/$scene/.*/export/splat\\.ply$" | head -n1)"
+          test -n "$path"
+          mkdir -p mesh-export-evidence
+          git show "$source_commit:$path" > mesh-export-evidence/source.ply
+          python - <<'PY'
+          from pathlib import Path
+          import numpy as np
+          import open3d as o3d
+
+          from processing.gaussian_ply import _read_vertices
+          from processing.mesh_from_points import _opacity_probabilities, reconstruct_mesh
+
+          source = Path('mesh-export-evidence/source.ply')
+          _, vertices = _read_vertices(source)
+          probabilities = _opacity_probabilities(vertices['opacity'])
+          target = min(50000, len(probabilities))
+          threshold = (
+              float(np.partition(probabilities, len(probabilities) - target)[len(probabilities) - target])
+              if len(probabilities) > target
+              else 0.0
+          )
+          mask = probabilities >= threshold
+          points = np.column_stack(
+              [vertices['x'][mask], vertices['y'][mask], vertices['z'][mask]]
+          ).astype(np.float64)
+          cloud = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(points))
+          distances = np.asarray(cloud.compute_nearest_neighbor_distance())
+          spacing = float(np.median(distances[distances > 0]))
+          reconstruct_mesh(
+              source,
+              'mesh-export-evidence/raw-alpha.ply',
+              method='alpha',
+              alpha=4.0 * spacing,
+              opacity_threshold=threshold,
+              max_faces=1000000,
+          )
+          PY
+      - name: Export GLB OBJ STL and verify readback
+        run: |
+          set -euo pipefail
+          for format in glb obj stl; do
+            python -m processing.mesh_export \
+              mesh-export-evidence/raw-alpha.ply \
+              "mesh-export-evidence/asset.$format" \
+              --manifest "mesh-export-evidence/$format-manifest.json"
+          done
+      - name: Validate GLB with Khronos glTF Validator
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const validator = require('gltf-validator');
+          const path = 'mesh-export-evidence/asset.glb';
+          validator.validateBytes(new Uint8Array(fs.readFileSync(path)), {
+            uri: 'asset.glb',
+            format: 'glb',
+            writeTimestamp: false,
+            maxIssues: 0
+          }).then(report => {
+            fs.writeFileSync(
+              'mesh-export-evidence/gltf-validation.json',
+              JSON.stringify(report, null, 2)
+            );
+            if (report.issues && report.issues.numErrors > 0) {
+              console.error(JSON.stringify(report.issues, null, 2));
+              process.exit(1);
+            }
+          }).catch(error => {
+            console.error(error);
+            process.exit(1);
+          });
+          NODE
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mesh-standard-export-evidence
+          path: mesh-export-evidence/
+          retention-days: 30

--- a/processing/mesh_export.py
+++ b/processing/mesh_export.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+from pathlib import Path
+
+import numpy as np
+
+from processing.provenance import sha256_file, write_json
+
+SUPPORTED_FORMATS = {"glb", "obj", "stl"}
+
+
+def _open3d():
+    try:
+        return importlib.import_module("open3d")
+    except ImportError as exc:
+        raise RuntimeError("Open3D is required for mesh export") from exc
+
+
+def _format_from_output(path: str | Path) -> str:
+    suffix = Path(path).suffix.lower().lstrip(".")
+    if suffix not in SUPPORTED_FORMATS:
+        raise ValueError(f"unsupported mesh export format: {suffix or 'missing'}")
+    return suffix
+
+
+def _legacy_mesh_stats(mesh) -> dict:
+    vertices = np.asarray(mesh.vertices)
+    triangles = np.asarray(mesh.triangles)
+    if len(vertices) == 0 or len(triangles) == 0:
+        raise ValueError("input mesh must contain vertices and triangles")
+    if not np.isfinite(vertices).all():
+        raise ValueError("input mesh contains non-finite vertices")
+    return {
+        "vertex_count": int(len(vertices)),
+        "face_count": int(len(triangles)),
+        "bbox_min": [float(value) for value in vertices.min(axis=0)],
+        "bbox_max": [float(value) for value in vertices.max(axis=0)],
+    }
+
+
+def _artifact_files(output: Path) -> list[dict]:
+    if output.suffix.lower() == ".obj":
+        candidates = sorted(
+            path
+            for path in output.parent.iterdir()
+            if path.is_file() and (path == output or path.name.startswith(f"{output.stem}_") or path.stem == output.stem)
+        )
+    else:
+        candidates = [output]
+    return [
+        {
+            "path": str(path.resolve()),
+            "sha256": sha256_file(path),
+            "size_bytes": path.stat().st_size,
+        }
+        for path in candidates
+    ]
+
+
+def export_mesh(
+    input_mesh: str | Path,
+    output_mesh: str | Path,
+    *,
+    source_manifest: str | Path | None = None,
+) -> dict:
+    o3d = _open3d()
+    input_path = Path(input_mesh).expanduser().resolve()
+    output_path = Path(output_mesh).expanduser().resolve()
+    output_format = _format_from_output(output_path)
+    if not input_path.is_file():
+        raise FileNotFoundError(f"input mesh does not exist: {input_path}")
+
+    legacy = o3d.io.read_triangle_mesh(str(input_path), enable_post_processing=False)
+    source_stats = _legacy_mesh_stats(legacy)
+    if not legacy.has_vertex_normals():
+        legacy.compute_vertex_normals()
+
+    tensor_mesh = o3d.t.geometry.TriangleMesh.from_legacy(legacy)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if not o3d.t.io.write_triangle_mesh(str(output_path), tensor_mesh):
+        raise RuntimeError(f"failed to export mesh: {output_path}")
+    if not output_path.is_file() or output_path.stat().st_size <= 0:
+        raise RuntimeError(f"mesh exporter produced no artifact: {output_path}")
+
+    readback = o3d.io.read_triangle_mesh(str(output_path), enable_post_processing=False)
+    readback_stats = _legacy_mesh_stats(readback)
+
+    lineage = None
+    if source_manifest is not None:
+        manifest_path = Path(source_manifest).expanduser().resolve()
+        lineage = {
+            "manifest_path": str(manifest_path),
+            "manifest_sha256": sha256_file(manifest_path),
+        }
+
+    return {
+        "schema_version": 1,
+        "status": "success",
+        "implementation": {
+            "library": "Open3D",
+            "version": importlib.metadata.version("open3d"),
+        },
+        "input": {
+            "path": str(input_path),
+            "sha256": sha256_file(input_path),
+            "size_bytes": input_path.stat().st_size,
+            **source_stats,
+        },
+        "output": {
+            "format": output_format,
+            "primary_path": str(output_path),
+            "files": _artifact_files(output_path),
+            "readback": readback_stats,
+        },
+        "transform": {
+            "applied": False,
+            "coordinate_frame": "source-mesh-unmodified",
+            "metric_scale": {"status": "unverified", "unit": None},
+        },
+        "source_lineage": lineage,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export a raw triangle mesh to GLB, OBJ, or STL.")
+    parser.add_argument("input_mesh")
+    parser.add_argument("output_mesh")
+    parser.add_argument("--source-manifest")
+    parser.add_argument("--manifest")
+    args = parser.parse_args()
+
+    result = export_mesh(
+        args.input_mesh,
+        args.output_mesh,
+        source_manifest=args.source_manifest,
+    )
+    if args.manifest:
+        write_json(args.manifest, result)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/processing/mesh_export.py
+++ b/processing/mesh_export.py
@@ -42,12 +42,20 @@ def _legacy_mesh_stats(mesh) -> dict:
     }
 
 
+def _belongs_to_obj_group(path: Path, output: Path) -> bool:
+    return (
+        path == output
+        or path.name.startswith(f"{output.stem}_")
+        or path.stem == output.stem
+    )
+
+
 def _artifact_files(output: Path) -> list[dict]:
     if output.suffix.lower() == ".obj":
         candidates = sorted(
             path
             for path in output.parent.iterdir()
-            if path.is_file() and (path == output or path.name.startswith(f"{output.stem}_") or path.stem == output.stem)
+            if path.is_file() and _belongs_to_obj_group(path, output)
         )
     else:
         candidates = [output]

--- a/processing/mesh_export.py
+++ b/processing/mesh_export.py
@@ -43,11 +43,7 @@ def _legacy_mesh_stats(mesh) -> dict:
 
 
 def _belongs_to_obj_group(path: Path, output: Path) -> bool:
-    return (
-        path == output
-        or path.name.startswith(f"{output.stem}_")
-        or path.stem == output.stem
-    )
+    return path == output or path.name.startswith(f"{output.stem}_") or path.stem == output.stem
 
 
 def _artifact_files(output: Path) -> list[dict]:

--- a/tests/test_mesh_export.py
+++ b/tests/test_mesh_export.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from processing.mesh_export import _artifact_files, _format_from_output
+
+
+class MeshExportContractTests(unittest.TestCase):
+    def test_accepts_supported_formats(self) -> None:
+        for extension in ("glb", "obj", "stl"):
+            self.assertEqual(_format_from_output(f"asset.{extension}"), extension)
+
+    def test_rejects_unsupported_format(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported mesh export format"):
+            _format_from_output("asset.ply")
+
+    def test_obj_artifact_group_tracks_sidecars(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            primary = root / "asset.obj"
+            primary.write_text("o mesh\n", encoding="utf-8")
+            (root / "asset.mtl").write_text("newmtl material\n", encoding="utf-8")
+            (root / "asset_albedo.png").write_bytes(b"png")
+            (root / "unrelated.txt").write_text("ignore", encoding="utf-8")
+
+            files = _artifact_files(primary)
+            names = {Path(record["path"]).name for record in files}
+            self.assertEqual(names, {"asset.obj", "asset.mtl", "asset_albedo.png"})
+            self.assertTrue(all(len(record["sha256"]) == 64 for record in files))
+            self.assertTrue(all(record["size_bytes"] > 0 for record in files))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Advance #117 from raw PLY mesh evidence to standard consumer formats using the existing Open3D runtime.

- add `processing/mesh_export.py` for GLB / OBJ / STL export with input/output hashes, readback stats, and explicit unverified metric-scale state
- keep source raw mesh immutable and preserve optional source-manifest lineage
- add focused contract tests without introducing a new project dependency
- add real-Gaussian export evidence on the established Alpha Shapes baseline
- validate GLB with the official Khronos `gltf-validator@2.0.0-dev.3.10`
- persist GLB / OBJ / STL and validation reports as workflow evidence

No new mesh reconstruction library, renderer, or duplicate asset authority is introduced.

Related: #117