### PR TITLE
feat: publish verified mesh artifacts

### DIFF
--- a/processing/mesh_artifact_publish.py
+++ b/processing/mesh_artifact_publish.py
@@ -17,7 +17,9 @@ SUPPORTED_SINGLE_FILE_FORMATS = {"glb", "stl"}
 def _revision(value: str) -> str:
     value = value.strip()
     if len(value) != 40 or any(c not in "0123456789abcdef" for c in value):
-        raise ArtifactPublishError("source_revision must be a full lowercase 40-character Git commit SHA")
+        raise ArtifactPublishError(
+            "source_revision must be a full lowercase 40-character Git commit SHA"
+        )
     return value
 
 
@@ -138,7 +140,9 @@ def publish_mesh_export(
         license_url=license_url,
     )
     artifact = manifest["artifacts"][0]
-    artifact_manifest_path = export_manifest_path.parent / f"{artifact['format']}-artifact-manifest.yaml"
+    artifact_manifest_path = (
+        export_manifest_path.parent / f"{artifact['format']}-artifact-manifest.yaml"
+    )
     artifact_manifest_path.write_text(
         yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True), encoding="utf-8"
     )

--- a/processing/mesh_artifact_publish.py
+++ b/processing/mesh_artifact_publish.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+import yaml
+
+from processing.artifact_publish import ArtifactPublishError, _hf_cache_command
+from processing.provenance import sha256_file
+
+SUPPORTED_SINGLE_FILE_FORMATS = {"glb", "stl"}
+
+
+def _revision(value: str) -> str:
+    value = value.strip()
+    if len(value) != 40 or any(c not in "0123456789abcdef" for c in value):
+        raise ArtifactPublishError("source_revision must be a full lowercase 40-character Git commit SHA")
+    return value
+
+
+def _sha256(value: str, label: str) -> str:
+    value = value.strip()
+    if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+        raise ArtifactPublishError(f"{label} must be a lowercase SHA-256")
+    return value
+
+
+def _verified_export(export_manifest_path: Path) -> tuple[dict, Path, str, int]:
+    manifest = json.loads(export_manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("status") != "success":
+        raise ArtifactPublishError("mesh export manifest is not successful")
+    output = manifest.get("output") or {}
+    output_format = str(output.get("format") or "").lower()
+    if output_format not in SUPPORTED_SINGLE_FILE_FORMATS:
+        raise ArtifactPublishError(
+            "mesh artifact publish currently requires a single-file GLB or STL export"
+        )
+    files = output.get("files")
+    if not isinstance(files, list) or len(files) != 1:
+        raise ArtifactPublishError("single-file mesh export must declare exactly one output file")
+    declared = files[0]
+    path = Path(str(declared.get("path") or "")).expanduser().resolve()
+    if not path.is_file() or path.stat().st_size <= 0:
+        raise ArtifactPublishError(f"mesh artifact is missing or empty: {path}")
+    actual_sha = sha256_file(path)
+    actual_size = path.stat().st_size
+    if actual_sha != declared.get("sha256") or actual_size != declared.get("size_bytes"):
+        raise ArtifactPublishError("local mesh no longer matches its export manifest")
+    return manifest, path, actual_sha, actual_size
+
+
+def build_mesh_artifact_manifest(
+    export_manifest_path: str | Path,
+    *,
+    dataset: str,
+    bucket: str,
+    source_revision: str,
+    source_gaussian_sha256: str,
+    raw_mesh_sha256: str,
+    source_url: str | None = None,
+    license_url: str | None = None,
+) -> tuple[dict, str, Path]:
+    export_manifest_path = Path(export_manifest_path).expanduser().resolve()
+    if not export_manifest_path.is_file():
+        raise ArtifactPublishError(f"mesh export manifest is missing: {export_manifest_path}")
+    export_manifest, mesh_path, mesh_sha, mesh_size = _verified_export(export_manifest_path)
+    source_revision = _revision(source_revision)
+    source_gaussian_sha256 = _sha256(source_gaussian_sha256, "source_gaussian_sha256")
+    raw_mesh_sha256 = _sha256(raw_mesh_sha256, "raw_mesh_sha256")
+
+    output_format = export_manifest["output"]["format"]
+    parent_mesh_sha = _sha256(str(export_manifest["input"]["sha256"]), "parent mesh SHA-256")
+    transform = export_manifest.get("transform") or {}
+    metric_scale = transform.get("metric_scale") or {"status": "unverified", "unit": None}
+    if metric_scale.get("status") not in {"accepted", "unverified", "unavailable"}:
+        raise ArtifactPublishError("mesh export metric scale status is unsupported")
+
+    artifact_id = f"autophotogrammetry/{dataset}/mesh/{output_format}"
+    remote_path = f"autophotogrammetry/meshes/{dataset}/{mesh_sha}.{output_format}"
+    artifact = {
+        "id": artifact_id,
+        "kind": "mesh",
+        "format": output_format,
+        "generated": False,
+        "storage": {
+            "type": "huggingface-bucket",
+            "bucket": bucket,
+            "path": remote_path,
+        },
+        "size_bytes": mesh_size,
+        "sha256": mesh_sha,
+        "provenance": {
+            "repository": "KAFKA2306/AutoPhotogrammetry",
+            "revision": source_revision,
+            "source_gaussian_sha256": source_gaussian_sha256,
+            "raw_mesh_sha256": raw_mesh_sha256,
+            "parent_mesh_sha256": parent_mesh_sha,
+            "export_manifest_sha256": sha256_file(export_manifest_path),
+        },
+        "geometry": {
+            "coordinate_frame": transform.get("coordinate_frame", "unknown"),
+            "metric_scale": metric_scale,
+            "readback": export_manifest["output"].get("readback"),
+        },
+    }
+    if source_url:
+        artifact["source_url"] = source_url
+    if license_url:
+        artifact["license_url"] = license_url
+    return {"schema_version": 1, "artifacts": [artifact]}, artifact_id, mesh_path
+
+
+def publish_mesh_export(
+    export_manifest_path: str | Path,
+    *,
+    dataset: str,
+    bucket: str,
+    source_revision: str,
+    source_gaussian_sha256: str,
+    raw_mesh_sha256: str,
+    source_url: str | None = None,
+    license_url: str | None = None,
+    hf_cache_hub_root: str | Path | None = None,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> dict:
+    export_manifest_path = Path(export_manifest_path).expanduser().resolve()
+    manifest, artifact_id, mesh_path = build_mesh_artifact_manifest(
+        export_manifest_path,
+        dataset=dataset,
+        bucket=bucket,
+        source_revision=source_revision,
+        source_gaussian_sha256=source_gaussian_sha256,
+        raw_mesh_sha256=raw_mesh_sha256,
+        source_url=source_url,
+        license_url=license_url,
+    )
+    artifact = manifest["artifacts"][0]
+    artifact_manifest_path = export_manifest_path.parent / f"{artifact['format']}-artifact-manifest.yaml"
+    artifact_manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+    command: Sequence[str] = [
+        *_hf_cache_command(hf_cache_hub_root),
+        "--manifest",
+        str(artifact_manifest_path),
+        "publish",
+        str(mesh_path),
+        "--id",
+        artifact_id,
+    ]
+    completed = runner(command, check=False, capture_output=True, text=True)
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ArtifactPublishError("hf-cache-hub returned non-JSON output") from exc
+    if (
+        completed.returncode != 0
+        or result.get("status") != "PUBLISHED"
+        or result.get("remote_verified") is not True
+        or result.get("sha256") != artifact["sha256"]
+        or result.get("size_bytes") != artifact["size_bytes"]
+    ):
+        raise ArtifactPublishError(f"remote publish verification failed for {artifact_id}")
+    return {
+        "status": "published",
+        "artifact_id": artifact_id,
+        "manifest_path": str(artifact_manifest_path),
+        "remote_uri": result["remote_uri"],
+        "sha256": artifact["sha256"],
+        "size_bytes": artifact["size_bytes"],
+        "source_gaussian_sha256": source_gaussian_sha256,
+        "raw_mesh_sha256": raw_mesh_sha256,
+        "remote_verified": True,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish a verified single-file mesh export.")
+    parser.add_argument("export_manifest")
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--source-gaussian-sha256", required=True)
+    parser.add_argument("--raw-mesh-sha256", required=True)
+    parser.add_argument("--source-url")
+    parser.add_argument("--license-url")
+    parser.add_argument("--hf-cache-hub-root")
+    args = parser.parse_args()
+    result = publish_mesh_export(
+        args.export_manifest,
+        dataset=args.dataset,
+        bucket=args.bucket,
+        source_revision=args.source_revision,
+        source_gaussian_sha256=args.source_gaussian_sha256,
+        raw_mesh_sha256=args.raw_mesh_sha256,
+        source_url=args.source_url,
+        license_url=args.license_url,
+        hf_cache_hub_root=args.hf_cache_hub_root,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mesh_artifact_publish.py
+++ b/tests/test_mesh_artifact_publish.py
@@ -95,7 +95,9 @@ class MeshArtifactPublishTest(unittest.TestCase):
             self.assertEqual(RAW_MESH_SHA, artifact["provenance"]["raw_mesh_sha256"])
             self.assertEqual("d" * 64, artifact["provenance"]["parent_mesh_sha256"])
             self.assertEqual("unverified", artifact["geometry"]["metric_scale"]["status"])
-            self.assertEqual("https://creativecommons.org/licenses/by/4.0/", artifact["license_url"])
+            self.assertEqual(
+                "https://creativecommons.org/licenses/by/4.0/", artifact["license_url"]
+            )
 
     def test_publish_requires_remote_hash_and_size_readback(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_mesh_artifact_publish.py
+++ b/tests/test_mesh_artifact_publish.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from processing.artifact_publish import ArtifactPublishError
+from processing.mesh_artifact_publish import (
+    build_mesh_artifact_manifest,
+    publish_mesh_export,
+)
+
+REVISION = "a" * 40
+SOURCE_GAUSSIAN_SHA = "b" * 64
+RAW_MESH_SHA = "c" * 64
+
+
+class MeshArtifactPublishTest(unittest.TestCase):
+    def _fixture(self, root: Path, *, output_format: str = "glb"):
+        mesh = root / f"asset.{output_format}"
+        payload = b"mesh-artifact"
+        mesh.write_bytes(payload)
+        mesh_sha = hashlib.sha256(payload).hexdigest()
+        manifest = root / f"{output_format}-manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "success",
+                    "input": {"sha256": "d" * 64},
+                    "output": {
+                        "format": output_format,
+                        "files": [
+                            {
+                                "path": str(mesh),
+                                "sha256": mesh_sha,
+                                "size_bytes": len(payload),
+                            }
+                        ],
+                        "readback": {"vertex_count": 10, "face_count": 12},
+                    },
+                    "transform": {
+                        "coordinate_frame": "source-mesh-unmodified",
+                        "metric_scale": {"status": "unverified", "unit": None},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        hf_root = root / "hf-cache-hub"
+        (hf_root / "scripts").mkdir(parents=True)
+        (hf_root / "scripts" / "artifact_manager.py").write_text("# cli", encoding="utf-8")
+        return manifest, mesh, mesh_sha, len(payload), hf_root
+
+    @staticmethod
+    def _runner(command, **kwargs):
+        artifact_manifest = Path(command[command.index("--manifest") + 1])
+        artifact = yaml.safe_load(artifact_manifest.read_text(encoding="utf-8"))["artifacts"][0]
+        result = {
+            "status": "PUBLISHED",
+            "remote_verified": True,
+            "remote_uri": f"hf://buckets/{artifact['storage']['bucket']}/{artifact['storage']['path']}",
+            "sha256": artifact["sha256"],
+            "size_bytes": artifact["size_bytes"],
+        }
+        return subprocess.CompletedProcess(command, 0, stdout=json.dumps(result), stderr="")
+
+    def test_glb_manifest_preserves_mesh_lineage_and_license(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, mesh_sha, mesh_size, _ = self._fixture(root)
+            artifact_manifest, artifact_id, _ = build_mesh_artifact_manifest(
+                manifest,
+                dataset="demo",
+                bucket="k4fka/kafka-data-lake",
+                source_revision=REVISION,
+                source_gaussian_sha256=SOURCE_GAUSSIAN_SHA,
+                raw_mesh_sha256=RAW_MESH_SHA,
+                source_url="https://commons.wikimedia.org/wiki/File:Demo.webm",
+                license_url="https://creativecommons.org/licenses/by/4.0/",
+            )
+            artifact = artifact_manifest["artifacts"][0]
+            self.assertEqual("autophotogrammetry/demo/mesh/glb", artifact_id)
+            self.assertEqual("mesh", artifact["kind"])
+            self.assertEqual("glb", artifact["format"])
+            self.assertFalse(artifact["generated"])
+            self.assertEqual(mesh_sha, artifact["sha256"])
+            self.assertEqual(mesh_size, artifact["size_bytes"])
+            self.assertEqual(SOURCE_GAUSSIAN_SHA, artifact["provenance"]["source_gaussian_sha256"])
+            self.assertEqual(RAW_MESH_SHA, artifact["provenance"]["raw_mesh_sha256"])
+            self.assertEqual("d" * 64, artifact["provenance"]["parent_mesh_sha256"])
+            self.assertEqual("unverified", artifact["geometry"]["metric_scale"]["status"])
+            self.assertEqual("https://creativecommons.org/licenses/by/4.0/", artifact["license_url"])
+
+    def test_publish_requires_remote_hash_and_size_readback(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, _, mesh_sha, mesh_size, hf_root = self._fixture(root)
+            result = publish_mesh_export(
+                manifest,
+                dataset="demo",
+                bucket="k4fka/kafka-data-lake",
+                source_revision=REVISION,
+                source_gaussian_sha256=SOURCE_GAUSSIAN_SHA,
+                raw_mesh_sha256=RAW_MESH_SHA,
+                hf_cache_hub_root=hf_root,
+                runner=self._runner,
+            )
+            self.assertEqual("published", result["status"])
+            self.assertEqual(mesh_sha, result["sha256"])
+            self.assertEqual(mesh_size, result["size_bytes"])
+            self.assertTrue(result["remote_verified"])
+            published_manifest = yaml.safe_load(
+                (root / "glb-artifact-manifest.yaml").read_text(encoding="utf-8")
+            )
+            self.assertEqual("mesh", published_manifest["artifacts"][0]["kind"])
+
+    def test_local_mesh_drift_fails_before_publish(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            manifest, mesh, _, _, hf_root = self._fixture(root)
+            mesh.write_bytes(b"changed")
+            with self.assertRaisesRegex(ArtifactPublishError, "no longer matches"):
+                publish_mesh_export(
+                    manifest,
+                    dataset="demo",
+                    bucket="k4fka/kafka-data-lake",
+                    source_revision=REVISION,
+                    source_gaussian_sha256=SOURCE_GAUSSIAN_SHA,
+                    raw_mesh_sha256=RAW_MESH_SHA,
+                    hf_cache_hub_root=hf_root,
+                    runner=self._runner,
+                )
+
+    def test_obj_group_is_rejected_until_group_publish_is_supported(self):
+        with tempfile.TemporaryDirectory() as d:
+            manifest, _, _, _, _ = self._fixture(Path(d), output_format="obj")
+            with self.assertRaisesRegex(ArtifactPublishError, "single-file GLB or STL"):
+                build_mesh_artifact_manifest(
+                    manifest,
+                    dataset="demo",
+                    bucket="k4fka/kafka-data-lake",
+                    source_revision=REVISION,
+                    source_gaussian_sha256=SOURCE_GAUSSIAN_SHA,
+                    raw_mesh_sha256=RAW_MESH_SHA,
+                )
+
+    def test_invalid_source_hash_fails_closed(self):
+        with tempfile.TemporaryDirectory() as d:
+            manifest, _, _, _, _ = self._fixture(Path(d))
+            with self.assertRaisesRegex(ArtifactPublishError, "source_gaussian_sha256"):
+                build_mesh_artifact_manifest(
+                    manifest,
+                    dataset="demo",
+                    bucket="k4fka/kafka-data-lake",
+                    source_revision=REVISION,
+                    source_gaussian_sha256="bad",
+                    raw_mesh_sha256=RAW_MESH_SHA,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Add a first production mesh-artifact publish path for #119 using the existing hf-cache-hub authority.

- publish verified single-file GLB/STL exports as `kind: mesh`
- preserve source Gaussian SHA-256, raw mesh SHA-256, parent mesh SHA-256, source revision, coordinate frame, metric-scale status, source URL and license URL
- require local export hash/size to still match before publish
- require remote hf-cache-hub readback hash/size and `remote_verified=true`
- keep OBJ group publishing fail-closed until multi-file artifact groups are implemented

This does not add a second artifact store or renderer. It reuses the current `processing.artifact_publish` hf-cache-hub command path.

Related: #117 #119