### PR TITLE
Add fail-closed Wikimedia 360 video discovery

### DIFF
--- a/.github/workflows/wikimedia-360-discovery.yml
+++ b/.github/workflows/wikimedia-360-discovery.yml
@@ -1,0 +1,65 @@
+name: Wikimedia 360 Video Discovery
+
+on:
+  schedule:
+    - cron: "41 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: wikimedia-360-video-discovery
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --locked
+      - name: Verify repository before discovery
+        run: bash scripts/check
+      - name: Refresh Wikimedia 360 pool
+        run: uv run python -m processing.wikimedia_360 refresh
+      - name: Validate refreshed snapshot
+        run: |
+          uv run python -m processing.wikimedia_360 validate
+          uv run python -m unittest tests.test_wikimedia_360 tests.test_wikimedia_discovery -v
+      - name: Open a reviewable data pull request when content changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          path="sources/discovery/wikimedia-360.json"
+          if git diff --quiet -- "${path}"; then
+            echo "No 360 discovery content change."
+            exit 0
+          fi
+
+          branch="automation/wikimedia-360-discovery"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "refs/heads/${branch}:refs/remotes/origin/${branch}" || true
+          git switch -c "${branch}"
+          git add "${path}"
+          git commit -m "Data: refresh Wikimedia 360 discovery"
+          git push --force-with-lease origin "HEAD:refs/heads/${branch}"
+
+          existing="$(gh pr list --head "${branch}" --base main --state open --json number --jq '.[0].number // empty')"
+          if [[ -z "${existing}" ]]; then
+            gh pr create \
+              --base main \
+              --head "${branch}" \
+              --title "Data: refresh Wikimedia 360 discovery" \
+              --body "Automated Wikimedia Commons 360-degree video discovery refresh. Review source identity, rights metadata, and projection-review state before merging. Metadata does not rank reconstruction quality and no media blobs are included."
+          fi

--- a/processing/wikimedia_360.py
+++ b/processing/wikimedia_360.py
@@ -214,7 +214,9 @@ def refresh(output_path: str | Path = DEFAULT_POOL) -> dict[str, Any]:
             for candidate in pool["candidates"]
             if candidate["stage_a"].get("eligible_for_projection_review") is True
         ),
-        "eac_count": sum(1 for candidate in pool["candidates"] if candidate["projection_type"] == "eac"),
+        "eac_count": sum(
+            1 for candidate in pool["candidates"] if candidate["projection_type"] == "eac"
+        ),
         "metadata_failure_count": len(pool["metadata_failures"]),
     }
 

--- a/processing/wikimedia_360.py
+++ b/processing/wikimedia_360.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from processing.wikimedia_discovery import normalize_discovery, traverse_category
+
+ROOT_CATEGORY = "Category:360-degree videos"
+DEFAULT_POOL = Path("sources/discovery/wikimedia-360.json")
+FORBIDDEN_QUALITY_FIELDS = {"rank", "score", "expected_success", "quality_score"}
+
+
+def projection_state(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    """Return only projection facts supported by Commons category evidence.
+
+    A 2:1 raster or a '360' title is not enough to assert equirectangular projection.
+    EAC has an explicit Commons category, so it can be identified fail-closed. All
+    other 360 videos remain unknown until the materialized source is reviewed.
+    """
+    categories = {
+        str(value).casefold()
+        for value in [
+            *candidate.get("commons_categories", []),
+            *candidate.get("discovered_categories", []),
+        ]
+    }
+    if "category:eac video" in categories:
+        return {
+            "projection_type": "eac",
+            "projection_authority": "Wikimedia Commons Category:EAC Video",
+            "projection_review_required": False,
+            "equirectangular_processing_ready": False,
+        }
+    return {
+        "projection_type": "unknown",
+        "projection_authority": None,
+        "projection_review_required": True,
+        "equirectangular_processing_ready": False,
+    }
+
+
+def stage_a_gate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    license_record = candidate.get("license")
+    resolution = candidate.get("resolution")
+    checks = {
+        "source_page_present": bool(candidate.get("source_page")),
+        "media_url_present": bool(candidate.get("media_url")),
+        "video_media_confirmed": candidate.get("confirmed_video") is True,
+        "source_sha1_present": isinstance(candidate.get("source_sha1"), str)
+        and len(str(candidate.get("source_sha1"))) == 40,
+        "source_size_present": isinstance(candidate.get("source_size_bytes"), int)
+        and int(candidate["source_size_bytes"]) > 0,
+        "author_present": bool(candidate.get("author")),
+        "license_verified": isinstance(license_record, Mapping)
+        and license_record.get("status") == "verified"
+        and bool(license_record.get("name"))
+        and bool(license_record.get("url")),
+        "duration_present": isinstance(candidate.get("duration_seconds"), (int, float)),
+        "resolution_present": isinstance(resolution, list)
+        and len(resolution) == 2
+        and all(isinstance(value, int) and value > 0 for value in resolution),
+    }
+    failed = sorted(name for name, passed in checks.items() if not passed)
+    return {
+        **checks,
+        "eligible_for_projection_review": not failed,
+        "failed_requirements": failed,
+    }
+
+
+def candidate_record(raw: Mapping[str, Any]) -> dict[str, Any]:
+    width = raw.get("width")
+    height = raw.get("height")
+    resolution = (
+        [width, height]
+        if isinstance(width, int) and width > 0 and isinstance(height, int) and height > 0
+        else None
+    )
+    license_record = raw.get("license")
+    candidate: dict[str, Any] = {
+        "canonical_title": raw.get("canonical_title"),
+        "provider": "Wikimedia Commons",
+        "source_page": raw.get("source_page"),
+        "media_url": raw.get("media_url"),
+        "author": raw.get("author"),
+        "license": dict(license_record) if isinstance(license_record, Mapping) else {},
+        "duration_seconds": raw.get("duration_seconds"),
+        "duration_authority": raw.get("duration_authority"),
+        "resolution": resolution,
+        "source_sha1": raw.get("source_sha1"),
+        "source_size_bytes": raw.get("source_size_bytes"),
+        "mime": raw.get("mime"),
+        "media_type": raw.get("media_type"),
+        "confirmed_video": raw.get("confirmed_video") is True,
+        "commons_categories": sorted(str(value) for value in raw.get("commons_categories", [])),
+        "discovered_categories": sorted(
+            str(value) for value in raw.get("discovered_categories", [])
+        ),
+        "discovery_paths": sorted([list(path) for path in raw.get("discovery_paths", [])]),
+        "metadata_authority": raw.get("metadata_authority"),
+        "evaluation_stage": "metadata",
+        "measurements": {"preflight": None, "colmap": None, "splat": None},
+        "camera_motion": "unknown",
+        "static_scene": "unknown",
+    }
+    candidate.update(projection_state(candidate))
+    candidate["stage_a"] = stage_a_gate(candidate)
+    return candidate
+
+
+def build_pool(
+    *,
+    request_json: Any = None,
+    request_file_json: Any = None,
+) -> dict[str, Any]:
+    traverse_kwargs: dict[str, Any] = {}
+    if request_json is not None:
+        traverse_kwargs["request_json"] = request_json
+    discovered = traverse_category(ROOT_CATEGORY, **traverse_kwargs)
+    discovery = {
+        "schema_version": 1,
+        "authority": "Wikimedia Commons categorymembers",
+        "candidates": [
+            {
+                **candidate,
+                "regions": [],
+            }
+            for candidate in discovered
+        ],
+        "failures": [],
+    }
+
+    normalize_kwargs: dict[str, Any] = {}
+    if request_json is not None:
+        normalize_kwargs["request_json"] = request_json
+    if request_file_json is not None:
+        normalize_kwargs["request_file_json"] = request_file_json
+    normalized = normalize_discovery(discovery, **normalize_kwargs)
+
+    pool = {
+        "schema_version": 1,
+        "snapshot_state": "api",
+        "authority": {
+            "category_discovery": "Wikimedia Commons categorymembers",
+            "video_metadata": "Wikimedia Commons videoinfo/categories",
+            "duration_fallback": "MediaWiki REST API file information",
+        },
+        "root_category": ROOT_CATEGORY,
+        "discovered_file_count": len(discovered),
+        "candidate_count": len(normalized["candidates"]),
+        "candidates": [candidate_record(candidate) for candidate in normalized["candidates"]],
+        "discovery_failures": list(normalized.get("discovery_failures", [])),
+        "metadata_failures": list(normalized.get("metadata_failures", [])),
+        "policy": {
+            "quality_is_not_inferred_from_metadata": True,
+            "aspect_ratio_does_not_prove_equirectangular": True,
+            "title_does_not_prove_equirectangular": True,
+            "production_promotion_requires_stage_c_and_d_evidence": True,
+        },
+    }
+    validate_pool(pool)
+    return pool
+
+
+def validate_pool(pool: Mapping[str, Any]) -> None:
+    if pool.get("schema_version") != 1:
+        raise ValueError("Wikimedia 360 pool schema_version must be 1")
+    if pool.get("root_category") != ROOT_CATEGORY:
+        raise ValueError(f"Wikimedia 360 pool root_category must be {ROOT_CATEGORY}")
+    candidates = pool.get("candidates")
+    if not isinstance(candidates, list):
+        raise ValueError("Wikimedia 360 pool requires candidates")
+
+    titles: set[str] = set()
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            raise ValueError("Wikimedia 360 candidate must be an object")
+        forbidden = FORBIDDEN_QUALITY_FIELDS.intersection(candidate)
+        if forbidden:
+            raise ValueError(f"Metadata quality ranking fields are forbidden: {sorted(forbidden)}")
+        title = candidate.get("canonical_title")
+        if not isinstance(title, str) or not title:
+            raise ValueError("Wikimedia 360 candidate canonical_title is required")
+        if title in titles:
+            raise ValueError(f"Duplicate Wikimedia 360 canonical title: {title}")
+        titles.add(title)
+        if candidate.get("evaluation_stage") != "metadata":
+            raise ValueError(f"{title}: discovery must remain at metadata stage")
+        if not isinstance(candidate.get("stage_a"), Mapping):
+            raise ValueError(f"{title}: stage_a is required")
+        projection_type = candidate.get("projection_type")
+        if projection_type not in {"unknown", "eac"}:
+            raise ValueError(f"{title}: unsupported discovery projection_type={projection_type}")
+        if candidate.get("equirectangular_processing_ready") is not False:
+            raise ValueError(
+                f"{title}: discovery metadata alone must not mark equirectangular processing ready"
+            )
+
+
+def refresh(output_path: str | Path = DEFAULT_POOL) -> dict[str, Any]:
+    pool = build_pool()
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(pool, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {
+        "output": path.as_posix(),
+        "discovered_file_count": pool["discovered_file_count"],
+        "candidate_count": pool["candidate_count"],
+        "stage_a_projection_review_count": sum(
+            1
+            for candidate in pool["candidates"]
+            if candidate["stage_a"].get("eligible_for_projection_review") is True
+        ),
+        "eac_count": sum(1 for candidate in pool["candidates"] if candidate["projection_type"] == "eac"),
+        "metadata_failure_count": len(pool["metadata_failures"]),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Collect Wikimedia Commons 360-degree videos without turning metadata into quality claims."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    refresh_parser = subparsers.add_parser("refresh")
+    refresh_parser.add_argument("--output", default=str(DEFAULT_POOL))
+    validate_parser = subparsers.add_parser("validate")
+    validate_parser.add_argument("--input", default=str(DEFAULT_POOL))
+    args = parser.parse_args()
+
+    if args.command == "refresh":
+        print(json.dumps(refresh(args.output), ensure_ascii=False, indent=2))
+        return
+
+    pool = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    validate_pool(pool)
+    print(json.dumps({"input": args.input, "candidate_count": len(pool["candidates"])}))
+
+
+if __name__ == "__main__":
+    main()

--- a/sources/discovery/wikimedia-360-initial-review.json
+++ b/sources/discovery/wikimedia-360-initial-review.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "authority": "Wikimedia Commons source pages",
+  "purpose": "Initial materialization/projection review queue for issue #140. This is not a reconstruction-quality ranking.",
+  "candidates": [
+    {
+      "canonical_title": "File:Norah Head Insta360 X5 Virtual Tour OHNE TON.webm",
+      "source_page": "https://commons.wikimedia.org/wiki/File:Norah_Head_Insta360_X5_Virtual_Tour_OHNE_TON.webm",
+      "source_evidence": {
+        "capture_device": "Insta360 X5",
+        "camera_motion": "source_description_supported",
+        "description_basis": "Source page describes a virtual tour beginning at Norah Head lighthouse, continuing down stairs and across rocks.",
+        "resolution": [
+          7680,
+          3840
+        ],
+        "license": "CC BY 3.0"
+      },
+      "projection_type": "unknown",
+      "projection_review_required": true,
+      "stage_c_or_d_quality_evaluated": false
+    },
+    {
+      "canonical_title": "File:Test Insta360 Pro2 on DJI Inspire2 8K 59,9 fps - YouTube.webm",
+      "source_page": "https://commons.wikimedia.org/wiki/File:Test_Insta360_Pro2_on_DJI_Inspire2_8K_59,9_fps_-_YouTube.webm",
+      "source_evidence": {
+        "capture_device": "Insta360 Pro 2 + DJI Inspire 2",
+        "camera_motion": "source_description_supported",
+        "description_basis": "Source page describes a 360-degree drone video over an industrial area.",
+        "resolution": [
+          7680,
+          3840
+        ],
+        "license": "CC BY 3.0"
+      },
+      "projection_type": "unknown",
+      "projection_review_required": true,
+      "stage_c_or_d_quality_evaluated": false
+    }
+  ]
+}

--- a/tests/test_wikimedia_360.py
+++ b/tests/test_wikimedia_360.py
@@ -24,7 +24,9 @@ class Wikimedia360Test(unittest.TestCase):
         self.assertTrue(state["projection_review_required"])
         self.assertFalse(state["equirectangular_processing_ready"])
 
-    def test_eac_category_is_explicitly_classified_but_not_sent_to_equirectangular_path(self) -> None:
+    def test_eac_category_is_explicitly_classified_but_not_sent_to_equirectangular_path(
+        self,
+    ) -> None:
         state = projection_state(
             {
                 "commons_categories": ["Category:EAC Video"],
@@ -86,11 +88,7 @@ class Wikimedia360Test(unittest.TestCase):
                     }
                 if category == "Category:EAC Video":
                     return {
-                        "query": {
-                            "categorymembers": [
-                                {"ns": 6, "title": eac_file, "type": "file"}
-                            ]
-                        }
+                        "query": {"categorymembers": [{"ns": 6, "title": eac_file, "type": "file"}]}
                     }
                 raise AssertionError(category)
 

--- a/tests/test_wikimedia_360.py
+++ b/tests/test_wikimedia_360.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import unittest
+
+from processing.wikimedia_360 import (
+    ROOT_CATEGORY,
+    build_pool,
+    candidate_record,
+    projection_state,
+    validate_pool,
+)
+
+
+class Wikimedia360Test(unittest.TestCase):
+    def test_two_to_one_raster_does_not_prove_equirectangular(self) -> None:
+        state = projection_state(
+            {
+                "resolution": [7680, 3840],
+                "commons_categories": [ROOT_CATEGORY],
+                "discovered_categories": [ROOT_CATEGORY],
+            }
+        )
+        self.assertEqual(state["projection_type"], "unknown")
+        self.assertTrue(state["projection_review_required"])
+        self.assertFalse(state["equirectangular_processing_ready"])
+
+    def test_eac_category_is_explicitly_classified_but_not_sent_to_equirectangular_path(self) -> None:
+        state = projection_state(
+            {
+                "commons_categories": ["Category:EAC Video"],
+                "discovered_categories": [ROOT_CATEGORY, "Category:EAC Video"],
+            }
+        )
+        self.assertEqual(state["projection_type"], "eac")
+        self.assertFalse(state["projection_review_required"])
+        self.assertFalse(state["equirectangular_processing_ready"])
+
+    def test_stage_a_is_rights_and_identity_gate_not_quality_score(self) -> None:
+        candidate = candidate_record(
+            {
+                "canonical_title": "File:Moving 360.webm",
+                "source_page": "https://commons.wikimedia.org/wiki/File:Moving_360.webm",
+                "media_url": "https://upload.wikimedia.org/example.webm",
+                "source_sha1": "a" * 40,
+                "source_size_bytes": 1234,
+                "mime": "video/webm",
+                "media_type": "VIDEO",
+                "confirmed_video": True,
+                "width": 7680,
+                "height": 3840,
+                "duration_seconds": 231.0,
+                "duration_authority": "test",
+                "author": "Example Author",
+                "license": {
+                    "name": "CC BY 3.0",
+                    "url": "https://creativecommons.org/licenses/by/3.0/",
+                    "status": "verified",
+                },
+                "commons_categories": [ROOT_CATEGORY],
+                "discovered_categories": [ROOT_CATEGORY],
+                "discovery_paths": [[ROOT_CATEGORY]],
+                "metadata_authority": "test",
+            }
+        )
+        self.assertTrue(candidate["stage_a"]["eligible_for_projection_review"])
+        self.assertEqual(candidate["projection_type"], "unknown")
+        self.assertNotIn("score", candidate)
+        self.assertEqual(candidate["camera_motion"], "unknown")
+        self.assertEqual(candidate["static_scene"], "unknown")
+
+    def test_build_pool_recurses_category_and_normalizes_metadata(self) -> None:
+        root_file = "File:Walkthrough.webm"
+        eac_file = "File:EAC sample.webm"
+
+        def request_json(params):
+            if params.get("list") == "categorymembers":
+                category = params["cmtitle"]
+                if category == ROOT_CATEGORY:
+                    return {
+                        "query": {
+                            "categorymembers": [
+                                {"ns": 6, "title": root_file, "type": "file"},
+                                {"ns": 14, "title": "Category:EAC Video", "type": "subcat"},
+                            ]
+                        }
+                    }
+                if category == "Category:EAC Video":
+                    return {
+                        "query": {
+                            "categorymembers": [
+                                {"ns": 6, "title": eac_file, "type": "file"}
+                            ]
+                        }
+                    }
+                raise AssertionError(category)
+
+            title = params["titles"]
+            categories = [ROOT_CATEGORY]
+            if title == eac_file:
+                categories.append("Category:EAC Video")
+            return {
+                "query": {
+                    "pages": [
+                        {
+                            "title": title,
+                            "categories": [{"title": value} for value in categories],
+                            "videoinfo": [
+                                {
+                                    "url": f"https://upload.wikimedia.org/{title[5:]}",
+                                    "sha1": ("b" if title == root_file else "c") * 40,
+                                    "size": 4096,
+                                    "width": 4096,
+                                    "height": 2048,
+                                    "duration": 60.0,
+                                    "mime": "video/webm",
+                                    "mediatype": "VIDEO",
+                                    "commonmetadata": {},
+                                    "extmetadata": {
+                                        "Artist": {"value": "Example Author"},
+                                        "LicenseShortName": {"value": "CC BY 4.0"},
+                                        "LicenseUrl": {
+                                            "value": "https://creativecommons.org/licenses/by/4.0/"
+                                        },
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+
+        pool = build_pool(request_json=request_json)
+        self.assertEqual(pool["discovered_file_count"], 2)
+        self.assertEqual(pool["candidate_count"], 2)
+        by_title = {item["canonical_title"]: item for item in pool["candidates"]}
+        self.assertEqual(by_title[root_file]["projection_type"], "unknown")
+        self.assertEqual(by_title[eac_file]["projection_type"], "eac")
+        validate_pool(pool)
+
+    def test_validation_rejects_metadata_quality_ranking(self) -> None:
+        pool = {
+            "schema_version": 1,
+            "root_category": ROOT_CATEGORY,
+            "candidates": [
+                {
+                    "canonical_title": "File:Bad.webm",
+                    "evaluation_stage": "metadata",
+                    "stage_a": {},
+                    "projection_type": "unknown",
+                    "equirectangular_processing_ready": False,
+                    "score": 0.99,
+                }
+            ],
+        }
+        with self.assertRaisesRegex(ValueError, "quality ranking"):
+            validate_pool(pool)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the repository-side collection portion of #140.

## What changes
- adds `processing.wikimedia_360` using the existing Wikimedia category traversal and videoinfo normalization
- recursively collects `Category:360-degree videos` and subcategories into a machine-readable pool
- keeps quality judgment out of metadata discovery
- does **not** infer equirectangular projection from a 2:1 raster or a `360` title
- explicitly identifies Commons `Category:EAC Video` and prevents it from entering the equirectangular path
- leaves camera motion/static-scene state unknown until source review
- adds weekly + manual discovery refresh that opens a data-only PR when the Commons pool changes
- seeds two source-page-backed initial materialization/projection-review candidates for #140
- adds deterministic unit tests for the fail-closed projection policy

## Why
The accuracy experiment should reuse the pinned Nerfstudio equirectangular→perspective projection path, but only after source projection is actually verified. This PR creates the collection authority without introducing a second panorama converter or a metadata-derived reconstruction-quality score.

## Not completed by this PR
Actual source materialization, SHA-256, `images-per-equirect=8` vs `14` COLMAP evidence, and Splatfacto Stage D remain runtime evidence gates in #140; they require the large media bytes and GPU execution environment.