### PR TITLE
Refresh 360 discovery when collector changes

### DIFF
--- a/.github/workflows/wikimedia-360-discovery.yml
+++ b/.github/workflows/wikimedia-360-discovery.yml
@@ -1,6 +1,12 @@
 name: Wikimedia 360 Video Discovery
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "processing/wikimedia_360.py"
+      - "processing/wikimedia_discovery.py"
+      - ".github/workflows/wikimedia-360-discovery.yml"
   schedule:
     - cron: "41 4 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
Follow-up to #141 / #140.

Adds a narrow `push` trigger for changes to the 360 collector, shared Wikimedia discovery implementation, or this workflow itself. This lets the first merged collector immediately materialize the current Commons discovery snapshot and keeps future collector changes self-validating, while ordinary `main` pushes do not run this workflow.