### PR TITLE
Persist newly generated 360 discovery snapshots

### DIFF
--- a/.github/workflows/wikimedia-360-discovery.yml
+++ b/.github/workflows/wikimedia-360-discovery.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -euo pipefail
           path="sources/discovery/wikimedia-360.json"
-          if git diff --quiet -- "${path}"; then
+          if [[ -z "$(git status --porcelain -- "${path}")" ]]; then
             echo "No 360 discovery content change."
             exit 0
           fi


### PR DESCRIPTION
Fixes the first live #140 discovery run.

The collector generated `sources/discovery/wikimedia-360.json`, but because that file is new/untracked, `git diff --quiet -- <path>` returned clean and skipped the data PR. Use `git status --porcelain -- <path>` so both new snapshots and later modifications are detected.

Observed live run before this fix: 70 discovered files, 8 normalized candidates, 62 explicit metadata failures, 1 EAC candidate. This PR changes only persistence detection; it does not weaken fail-closed metadata handling.