### PR TITLE
Use shallow checkout for 360 discovery

### DIFF
--- a/.github/workflows/wikimedia-360-discovery.yml
+++ b/.github/workflows/wikimedia-360-discovery.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: main
-          fetch-depth: 0
+          fetch-depth: 1
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"


### PR DESCRIPTION
Follow-up to #140/#143.

The discovery workflow only needs the current `main` tree. Full-history checkout (`fetch-depth: 0`) fetches every branch and materially delays the live collector; the data branch is fetched explicitly later only when needed. Use `fetch-depth: 1` to reduce runtime and failure surface without changing source discovery, validation, or persistence semantics.