### PR TITLE
Remove winding-independent duplicate triangles before export

### DIFF
--- a/processing/mesh_postprocess.py
+++ b/processing/mesh_postprocess.py
@@ -32,6 +32,30 @@ def _duplicate_count(rows: np.ndarray) -> int:
     return int(len(rows) - len(np.unique(rows, axis=0)))
 
 
+def _canonical_triangles(triangles: np.ndarray) -> np.ndarray:
+    if len(triangles) == 0:
+        return triangles.copy()
+    return np.sort(triangles, axis=1)
+
+
+def _duplicate_triangle_count(triangles: np.ndarray) -> int:
+    return _duplicate_count(_canonical_triangles(triangles))
+
+
+def _remove_topological_duplicate_triangles(mesh) -> int:
+    triangles = np.asarray(mesh.triangles)
+    if len(triangles) == 0:
+        return 0
+    canonical = _canonical_triangles(triangles)
+    _, first_indices = np.unique(canonical, axis=0, return_index=True)
+    keep = np.zeros(len(triangles), dtype=bool)
+    keep[first_indices] = True
+    removed = int(np.count_nonzero(~keep))
+    if removed:
+        mesh.remove_triangles_by_mask((~keep).tolist())
+    return removed
+
+
 def _mesh_stats(mesh) -> dict:
     vertices = np.asarray(mesh.vertices)
     triangles = np.asarray(mesh.triangles)
@@ -66,7 +90,7 @@ def _mesh_stats(mesh) -> dict:
         "largest_component_face_count": int(max(component_sizes, default=0)),
         "largest_component_area": float(max(component_areas, default=0.0)),
         "duplicate_vertex_count": _duplicate_count(vertices),
-        "duplicate_face_count": _duplicate_count(triangles),
+        "duplicate_face_count": _duplicate_triangle_count(triangles),
         "degenerate_face_count": int(np.count_nonzero(degenerate)),
         "boundary_edge_count": int(np.count_nonzero(edge_counts == 1)),
         "non_manifold_edge_count": int(np.count_nonzero(edge_counts > 2)),
@@ -158,6 +182,13 @@ def repair_mesh(
     mesh.remove_duplicated_triangles()
     operations.append(
         {"operation": "remove_duplicated_triangles", "removed": initial_faces - len(mesh.triangles)}
+    )
+    removed_topological_duplicates = _remove_topological_duplicate_triangles(mesh)
+    operations.append(
+        {
+            "operation": "remove_topological_duplicate_triangles",
+            "removed": removed_topological_duplicates,
+        }
     )
     initial_faces = len(mesh.triangles)
     mesh.remove_degenerate_triangles()
@@ -260,6 +291,7 @@ def decimate_mesh(
     )
     decimated.remove_degenerate_triangles()
     decimated.remove_duplicated_triangles()
+    removed_topological_duplicates = _remove_topological_duplicate_triangles(decimated)
     decimated.remove_unreferenced_vertices()
     decimated.compute_triangle_normals()
     decimated.compute_vertex_normals()
@@ -285,6 +317,7 @@ def decimate_mesh(
             "target_faces": target_faces,
             "maximum_error": None if np.isinf(maximum_error) else maximum_error,
             "boundary_weight": boundary_weight,
+            "removed_topological_duplicate_faces": removed_topological_duplicates,
         },
         "geometry_deviation": deviation,
     }

--- a/tests/test_mesh_postprocess.py
+++ b/tests/test_mesh_postprocess.py
@@ -31,7 +31,13 @@ class MeshPostprocessContractTests(unittest.TestCase):
 
     def test_duplicate_triangle_count_is_winding_independent(self) -> None:
         triangles = np.array(
-            [[0, 1, 2], [2, 0, 1], [2, 1, 0], [0, 2, 3]], dtype=np.int64
+            [
+                [0, 1, 2],
+                [2, 0, 1],
+                [2, 1, 0],
+                [0, 2, 3],
+            ],
+            dtype=np.int64,
         )
         self.assertEqual(_duplicate_triangle_count(triangles), 2)
 

--- a/tests/test_mesh_postprocess.py
+++ b/tests/test_mesh_postprocess.py
@@ -4,7 +4,12 @@ import unittest
 
 import numpy as np
 
-from processing.mesh_postprocess import _duplicate_count, _triangle_edges
+from processing.mesh_postprocess import (
+    _canonical_triangles,
+    _duplicate_count,
+    _duplicate_triangle_count,
+    _triangle_edges,
+)
 
 
 class MeshPostprocessContractTests(unittest.TestCase):
@@ -17,8 +22,22 @@ class MeshPostprocessContractTests(unittest.TestCase):
         rows = np.array([[0, 1, 2], [0, 1, 2], [2, 1, 0]], dtype=np.int64)
         self.assertEqual(_duplicate_count(rows), 1)
 
+    def test_canonical_triangles_ignore_vertex_order(self) -> None:
+        triangles = np.array([[0, 1, 2], [2, 0, 1], [2, 1, 0]], dtype=np.int64)
+        self.assertEqual(
+            _canonical_triangles(triangles).tolist(),
+            [[0, 1, 2], [0, 1, 2], [0, 1, 2]],
+        )
+
+    def test_duplicate_triangle_count_is_winding_independent(self) -> None:
+        triangles = np.array(
+            [[0, 1, 2], [2, 0, 1], [2, 1, 0], [0, 2, 3]], dtype=np.int64
+        )
+        self.assertEqual(_duplicate_triangle_count(triangles), 2)
+
     def test_duplicate_count_handles_empty_rows(self) -> None:
         self.assertEqual(_duplicate_count(np.empty((0, 3), dtype=np.int64)), 0)
+        self.assertEqual(_duplicate_triangle_count(np.empty((0, 3), dtype=np.int64)), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal
Make post-processed mesh topology explicit before GLB export so the exported asset does not silently normalize duplicate triangles in Blender.

## Evidence
The current real-asset evidence has `decimated.ply` at 16,726 faces while the generated GLB/Khronos/Blender consumer reports 16,705 triangles. Direct inspection of the persisted `decimated.ply` found exactly 21 duplicate triangles when vertex order/winding is ignored, with 0 zero-area faces, 0 repeated-index faces, and 0 non-finite vertices.

## Change
- Canonicalize triangle identity by sorting the three vertex indices.
- Report duplicate faces using winding-independent triangle identity.
- Remove topological duplicate triangles after repair and decimation.
- Keep existing Open3D algorithms and dependencies unchanged.
- Record the number removed by decimation in the manifest.

## Acceptance
- Unit tests cover permutations/reversed winding as duplicate topology.
- Existing Test workflow passes.
- Real mesh export evidence produces a decimated mesh with `duplicate_face_count=0` and no unexplained face-count drift into GLB/Blender.
