### PR TITLE
Add photogrammetry reconstruction agent guidance

### DIFF
--- a/.agents/skills/photogrammetry-reconstruction/SKILL.md
+++ b/.agents/skills/photogrammetry-reconstruction/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: photogrammetry-reconstruction
+description: Use when running, reviewing, or planning photogrammetry or 3DGS reconstruction experiments involving source-shot selection, temporal sampling, perspective-view selection, COLMAP registration/connectivity, dataset freezing, camera optimization, or reconstruction-quality A/B tests. Do not use raw image count or registered ratio alone to select a winner.
+---
+
+# Photogrammetry Reconstruction
+
+Use this workflow to turn reconstruction experiments into controlled, reviewable evidence rather than parameter search driven by proxy metrics.
+
+## Core rule
+
+More observations are not automatically more useful geometric constraints.
+
+Do not select a dataset or training configuration from image count, COLMAP registered count, or registered ratio alone. Compare pose evidence and downstream reconstruction quality separately.
+
+## Workflow
+
+### 1. Fix the experimental responsibility
+
+State exactly what changes in the current experiment and what remains fixed.
+
+Prefer one responsibility per comparison, for example:
+
+- shot / time interval
+- temporal sampling density
+- perspective direction set
+- crop
+- COLMAP camera or matching configuration
+- connected-component choice
+- camera optimizer
+- iteration budget
+- regularization or artifact-control parameter
+
+Do not mix input-selection experiments with training-parameter experiments when the effects cannot be separated.
+
+### 2. Fix source identity
+
+Before comparing variants, record enough information to reproduce the source:
+
+- source URL or local identity
+- checksum when materialized
+- shot or time range
+- source-frame timestamps or identities
+- projection settings and crop
+
+For a controlled A/B, keep these fixed unless one of them is the explicit variable under test.
+
+### 3. Evaluate input geometry before training tuning
+
+For each input candidate, inspect at least:
+
+- generated image identities/count
+- registered image identities/count
+- COLMAP connected components / pose connectivity
+- reprojection evidence when available
+- whether registered views cover the target structure rather than only easy background regions
+
+Treat weakly textured, sky/sea-dominated, redundant, or poorly connected views as candidates for removal. Do not assume adding directions or timestamps is beneficial.
+
+### 4. Use a fixed downstream evaluator
+
+When comparing input candidates, keep the reconstruction/training baseline fixed and render the same hold-out viewpoints.
+
+Compare against ground truth or the source frame and inspect at least:
+
+- major-structure retention
+- geometry or silhouette consistency
+- floaters
+- smear / streaking / duplicated surfaces
+- obvious transparency or banding artifacts
+- NaN/Inf or other numerical failures
+
+Do not promote a candidate solely because its COLMAP registration ratio improved.
+
+### 5. Select and freeze the dataset
+
+Select the dataset only when the combined pose evidence and fixed-view reconstruction evidence justify it.
+
+A valid outcome is `winner: none` when no candidate produces stable reconstruction.
+
+Once selected, freeze and record the dataset identity before changing:
+
+- camera optimizer
+- iteration budget
+- Scale Regularization / MCMC
+- antialiasing, anisotropy, culling, densification, or related training controls
+
+Do not silently change the input dataset during downstream training A/B tests.
+
+### 6. Run training-side A/B tests only on the frozen dataset
+
+Change one training responsibility at a time where practical. Keep the dataset identity and evaluation views fixed.
+
+Training longer is not evidence of improvement by itself. Compare the same reconstruction-quality evidence after the run.
+
+### 7. Preserve evidence
+
+Keep experiment-specific numbers and outputs out of this skill. Store them in the repository's Issues or artifacts so later agents can audit the actual run.
+
+For each comparison, preserve when available:
+
+- changed variable
+- fixed variables
+- source/dataset identity or hash
+- generated and registered image identities/counts
+- pose/component evidence
+- evaluation-view identities
+- render/GT evidence
+- NaN/Inf or numerical-failure counts
+- decision: PASS / PARTIAL PASS / FAIL, with the reason
+
+Prefer an existing machine-readable evidence format in the repository. Do not create a parallel schema when an established artifact already represents the same information.
+
+## Decision rules
+
+Use these rules when conclusions conflict:
+
+1. Actual hold-out reconstruction evidence outranks registration ratio alone.
+2. Major target-structure retention outranks a higher count of easy/background registered views.
+3. A controlled comparison outranks an uncontrolled run with more images or more iterations.
+4. Input quality and pose connectivity are resolved before attributing failure to training parameters.
+5. If the evidence does not distinguish candidates, record that result instead of manufacturing a winner.
+
+## Repository evidence
+
+The current rules were motivated by controlled evidence in:
+
+- https://github.com/KAFKA2306/AutoPhotogrammetry/issues/146
+- https://github.com/KAFKA2306/AutoPhotogrammetry/issues/148
+
+Treat those Issues as evidence for the workflow, not as universal numeric thresholds or a requirement to reuse a specific number of views.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+## Photogrammetry / 3D reconstruction
+
+- Do not optimize image count or COLMAP registered count/ratio as a proxy for reconstruction quality.
+- Before tuning training parameters, validate the input shot, timestamps, perspective directions, crop, COLMAP pose connectivity, and registered image identities.
+- Prefer controlled A/B comparisons. Change one experimental responsibility at a time and keep source identity, evaluation views, and unrelated settings fixed.
+- Treat additional images as useful only when they add usable geometric constraints. Explicitly test whether removing weak, sky/sea-dominated, redundant, or poorly connected views improves reconstruction.
+- Evaluate registration evidence and downstream reconstruction quality separately. At minimum inspect pose/component connectivity, major-structure retention on fixed hold-out views, floaters/smear, and NaN/Inf.
+- Freeze the selected dataset identity before camera-optimizer, iteration-budget, regularization, or other training-side A/B experiments.
+- Preserve experiment-specific numbers, renders, hashes, and conclusions in Issues or machine-readable artifacts. Keep this file limited to reusable decision rules.
+
+Use `.agents/skills/photogrammetry-reconstruction/SKILL.md` for the repeatable experiment workflow.


### PR DESCRIPTION
## Summary

- add a root `AGENTS.md` with reusable photogrammetry/3D reconstruction decision principles
- add `.agents/skills/photogrammetry-reconstruction/SKILL.md` with the repeatable controlled-experiment workflow
- keep #146/#148 run-specific numbers as evidence rather than universal thresholds

## Key behavior

- do not optimize image count or COLMAP registered ratio as reconstruction-quality proxies
- resolve source/shot/view/pose-connectivity quality before training-side tuning
- evaluate fixed hold-out reconstruction quality separately from registration metrics
- freeze dataset identity before camera optimizer / iteration / regularization A/B tests
- preserve machine-readable evidence without creating a duplicate schema

Evidence: #146, #148