### PR TITLE
Adopt canonical KAFKA2306/design authority

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --locked
-      - name: Verify canonical design contract
-        run: |
-          git init /tmp/kafka-design
-          git -C /tmp/kafka-design fetch --depth=1 https://github.com/KAFKA2306/design.git f39a0865cf0342f495bf49f547c7fdf112145d77
-          git -C /tmp/kafka-design checkout --detach FETCH_HEAD
-          node /tmp/kafka-design/scripts/design-conformance.mjs --consumer "$GITHUB_WORKSPACE"
       - run: bash scripts/check
+      - name: Verify canonical design contract
+        run: node assets/.kafka-design/portable-conformance.mjs --consumer "$GITHUB_WORKSPACE"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,10 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --locked
+      - name: Verify canonical design contract
+        run: |
+          git init /tmp/kafka-design
+          git -C /tmp/kafka-design fetch --depth=1 https://github.com/KAFKA2306/design.git f39a0865cf0342f495bf49f547c7fdf112145d77
+          git -C /tmp/kafka-design checkout --detach FETCH_HEAD
+          node /tmp/kafka-design/scripts/design-conformance.mjs --consumer "$GITHUB_WORKSPACE"
       - run: bash scripts/check

--- a/assets/.kafka-design/conformance-policy.mjs
+++ b/assets/.kafka-design/conformance-policy.mjs
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const CONFIG_NAME = 'design.config.json'
+const LOCK_NAME = 'design.lock.json'
+const SKIP_DIRS = new Set(['.git', '.docusaurus', 'node_modules', 'dist', 'build', 'site', 'coverage'])
+const SOURCE_EXTENSIONS = new Set(['.css', '.scss', '.sass', '.less', '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs', '.yml', '.yaml'])
+const CORE_COMPONENTS = new Set(['button.tsx', 'input.tsx', 'dialog.tsx', 'tabs.tsx', 'product-ui.tsx'])
+
+function toPosix(relativePath) {
+  return relativePath.split(path.sep).join('/')
+}
+
+function walk(root, relativeDir = '') {
+  const dir = path.join(root, relativeDir)
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = path.join(relativeDir, entry.name)
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) return []
+      return walk(root, relativePath)
+    }
+    if (!entry.isFile() || !SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())) return []
+    return [relativePath]
+  })
+}
+
+function stripCssComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+function push(errors, rule, filePath, message) {
+  errors.push({ rule, path: toPosix(filePath), message })
+}
+
+function scanCss(errors, consumerRoot, relativePath) {
+  const source = stripCssComments(fs.readFileSync(path.join(consumerRoot, relativePath), 'utf8'))
+
+  const rawColor = /#[0-9a-f]{3,8}\b|\brgba?\s*\(|\bhsla?\s*\(/i
+  if (rawColor.test(source)) push(errors, 'duplicate-visual-authority', relativePath, 'raw color literal found; use canonical --k-color-* tokens')
+
+  const visualVariable = /(--[\w-]*(?:color|background|surface|foreground|muted|accent|primary|border|radius|shadow)[\w-]*)\s*:\s*([^;]+);/gi
+  for (const match of source.matchAll(visualVariable)) {
+    const value = match[2].trim()
+    if (/^var\(--k-[\w-]+\)$/.test(value) || /^(?:inherit|initial|unset|none|transparent|currentColor)$/.test(value)) continue
+    push(errors, 'duplicate-visual-authority', relativePath, `${match[1]} defines visual authority outside canonical --k-* tokens`)
+  }
+
+  const forbidden = [
+    ['gradient', /\b(?:linear|radial|conic)-gradient\s*\(/i],
+    ['glass', /\bbackdrop-filter\s*:/i],
+    ['glow/shadow', /\bbox-shadow\s*:\s*(?!none\b)(?!var\(--k-)/i],
+    ['blur', /\bfilter\s*:\s*[^;]*\bblur\s*\(/i],
+  ]
+  for (const [name, pattern] of forbidden) {
+    if (pattern.test(source)) push(errors, 'forbidden-visual-effect', relativePath, `${name} effect is consumer-owned; use canonical design styles instead`)
+  }
+
+  const chartOverride = /(?:^|[;{])\s*(?:stroke|fill)\s*:\s*(?!var\(--k-|none\b|currentColor\b)[^;}]+/gim
+  if (chartOverride.test(source)) push(errors, 'chart-override', relativePath, 'chart stroke/fill styling is outside canonical chart grammar')
+}
+
+function scanCode(errors, consumerRoot, relativePath) {
+  const source = fs.readFileSync(path.join(consumerRoot, relativePath), 'utf8')
+  if (/\bfrom\s+['"]recharts['"]|\brequire\(\s*['"]recharts['"]\s*\)/.test(source)) {
+    const normalized = toPosix(relativePath)
+    if (!normalized.endsWith('/components/ui/product/chart.tsx')) {
+      push(errors, 'chart-override', relativePath, 'Recharts may only be used by the canonical Product UI chart adapter')
+    }
+  }
+}
+
+function scanWorkflow(errors, consumerRoot, relativePath) {
+  const source = fs.readFileSync(path.join(consumerRoot, relativePath), 'utf8')
+  if (/KAFKA2306\/design\/.+@(main|master|beta|develop|dev|latest)\b/i.test(source)) {
+    push(errors, 'mutable-design-ref', relativePath, 'design workflow/action reference must use a full immutable SHA')
+  }
+}
+
+function scanComponentDuplicates(errors, files) {
+  const byName = new Map()
+  for (const relativePath of files) {
+    const base = path.basename(relativePath).toLowerCase()
+    if (!CORE_COMPONENTS.has(base)) continue
+    if (!byName.has(base)) byName.set(base, [])
+    byName.get(base).push(relativePath)
+  }
+  for (const [name, matches] of byName) {
+    if (matches.length <= 1) continue
+    for (const relativePath of matches) push(errors, 'design-owned-component-duplication', relativePath, `${name} exists in multiple source locations: ${matches.map(toPosix).join(', ')}`)
+  }
+}
+
+export function scanConformancePolicy(consumerPath, config) {
+  const consumerRoot = path.resolve(consumerPath)
+  const errors = []
+  const managedPrefix = `${toPosix(config.managedDir).replace(/\/$/, '')}/`
+  const files = walk(consumerRoot).filter((relativePath) => {
+    const normalized = toPosix(relativePath)
+    return normalized !== CONFIG_NAME && normalized !== LOCK_NAME && !normalized.startsWith(managedPrefix)
+  })
+
+  scanComponentDuplicates(errors, files)
+
+  for (const relativePath of files) {
+    const extension = path.extname(relativePath).toLowerCase()
+    if (['.css', '.scss', '.sass', '.less'].includes(extension)) scanCss(errors, consumerRoot, relativePath)
+    if (['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'].includes(extension)) scanCode(errors, consumerRoot, relativePath)
+    if (['.yml', '.yaml'].includes(extension)) scanWorkflow(errors, consumerRoot, relativePath)
+  }
+
+  return errors
+}

--- a/assets/.kafka-design/kafka-components.css
+++ b/assets/.kafka-design/kafka-components.css
@@ -1,0 +1,802 @@
+.k-button {
+  display: inline-flex;
+  min-height: var(--k-dimension-control-height);
+  align-items: center;
+  justify-content: center;
+  gap: var(--k-dimension-space2);
+  border: 1px solid var(--k-color-primary);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-primary);
+  color: var(--k-color-surface);
+  padding-inline: var(--k-dimension-space3);
+  font: inherit;
+  cursor: pointer;
+}
+
+.k-button-secondary {
+  border-color: var(--k-color-border);
+  background: var(--k-color-surface);
+  color: var(--k-color-foreground);
+}
+
+.k-button:disabled,
+.k-button[data-loading] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.k-field {
+  display: grid;
+  gap: var(--k-dimension-space1);
+}
+
+.k-field-label {
+  color: var(--k-color-foreground);
+  font-size: var(--k-font-size-small);
+  font-weight: 600;
+}
+
+.k-input {
+  width: 100%;
+  min-width: 0;
+  min-height: var(--k-dimension-control-height);
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  color: var(--k-color-foreground);
+  padding-inline: var(--k-dimension-space2);
+  font: inherit;
+}
+
+.k-input::placeholder {
+  color: var(--k-color-muted-foreground);
+}
+
+.k-input[aria-invalid="true"] {
+  border-color: var(--k-color-danger);
+}
+
+.k-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.k-field-error {
+  color: var(--k-color-danger);
+  font-size: var(--k-font-size-small);
+}
+
+.k-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: color-mix(in srgb, var(--k-color-foreground) 24%, transparent);
+}
+
+.k-dialog-popup {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: 50;
+  display: grid;
+  width: min(calc(100vw - (var(--k-dimension-space4) * 2)), 32rem);
+  max-height: calc(100vh - (var(--k-dimension-space4) * 2));
+  overflow: auto;
+  transform: translate(-50%, -50%);
+  gap: var(--k-dimension-space3);
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  color: var(--k-color-foreground);
+  padding: var(--k-dimension-space4);
+}
+
+.k-dialog-header,
+.k-dialog-body {
+  display: grid;
+  gap: var(--k-dimension-space1);
+}
+
+.k-dialog-title {
+  margin: 0;
+  font-size: var(--k-font-size-title);
+  line-height: 1.2;
+}
+
+.k-dialog-description {
+  margin: 0;
+  color: var(--k-color-muted-foreground);
+}
+
+.k-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--k-dimension-space2);
+}
+
+.k-tabs {
+  min-width: 0;
+}
+
+.k-tabs-list {
+  display: flex;
+  max-width: 100%;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--k-color-border);
+}
+
+.k-tabs-tab {
+  min-height: var(--k-dimension-control-height);
+  flex: 0 0 auto;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--k-color-muted-foreground);
+  padding-inline: var(--k-dimension-space3);
+  font: inherit;
+  cursor: pointer;
+}
+
+.k-tabs-tab[data-active] {
+  border-bottom-color: var(--k-color-primary);
+  color: var(--k-color-foreground);
+}
+
+.k-tabs-tab:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.k-tabs-panel {
+  padding-top: var(--k-dimension-space3);
+}
+
+.k-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.k-metric {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--k-dimension-space1) var(--k-dimension-space2);
+  align-items: end;
+  border-bottom: 1px solid var(--k-color-border);
+  padding-block: var(--k-dimension-space2);
+}
+
+.k-metric-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--k-dimension-space1) var(--k-dimension-space2);
+}
+
+.k-metric-label,
+.k-metric-kind,
+.k-metric-unit {
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-metric-value {
+  font-family: var(--k-font-family-mono);
+  font-size: var(--k-font-size-title);
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  line-height: 1;
+  text-align: right;
+}
+
+.k-metric-unit {
+  font-family: var(--k-font-family-sans);
+  font-weight: 400;
+}
+
+.k-metric-kind {
+  text-transform: capitalize;
+}
+
+.k-source-line {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: var(--k-dimension-space1) var(--k-dimension-space2);
+  margin: 0;
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-source-line > span:not(:last-child)::after,
+.k-source-line > time:not(:last-child)::after {
+  content: "·";
+  margin-left: var(--k-dimension-space2);
+}
+
+.k-filter-toolbar {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--k-dimension-space2);
+}
+
+.k-filter-search {
+  min-width: min(100%, 15rem);
+  flex: 1 1 15rem;
+}
+
+.k-filter-slot {
+  display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  gap: var(--k-dimension-space2);
+}
+
+.k-filter-count {
+  margin-left: auto;
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+  font-variant-numeric: tabular-nums;
+}
+
+.k-table-region {
+  width: 100%;
+  max-width: 100%;
+  overflow: auto;
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+}
+
+.k-data-table {
+  width: 100%;
+  min-width: max-content;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.k-data-table th,
+.k-data-table td {
+  height: var(--k-dimension-table-row);
+  border-bottom: 1px solid var(--k-color-border);
+  padding: 0 var(--k-dimension-space2);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.k-data-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--k-color-surface);
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+  font-weight: 600;
+}
+
+.k-data-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.k-data-table [data-align="numeric"] {
+  font-family: var(--k-font-family-mono);
+  text-align: right;
+}
+
+.k-table-state,
+.k-table-partial {
+  margin: 0;
+  padding: var(--k-dimension-space3);
+  color: var(--k-color-muted-foreground);
+}
+
+.k-table-partial {
+  border-bottom: 1px solid var(--k-color-border);
+  font-size: var(--k-font-size-small);
+}
+
+.k-chart-frame {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  gap: var(--k-dimension-space2);
+  border-top: 1px solid var(--k-color-border);
+  padding-block: var(--k-dimension-space2);
+}
+
+.k-chart-header {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--k-dimension-space2);
+}
+
+.k-chart-header > span {
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--k-dimension-space3);
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-chart-legend span::before {
+  display: inline-block;
+  width: var(--k-dimension-space4);
+  margin-right: var(--k-dimension-space1);
+  border-top: 2px solid var(--k-color-primary);
+  content: "";
+  vertical-align: middle;
+}
+
+.k-chart-legend [data-series="forecast"]::before,
+.k-chart-legend [data-series="target"]::before {
+  border-top-color: var(--k-color-accent);
+  border-top-style: dashed;
+}
+
+.k-chart-legend [data-series="frontier"]::before {
+  border-top-color: var(--k-color-muted-foreground);
+}
+
+.k-chart-legend [data-series="contribution"]::before,
+.k-chart-legend [data-series="portfolio"]::before {
+  border-top-color: var(--k-color-primary);
+}
+
+.k-chart-plot {
+  width: 100%;
+  height: 220px;
+  min-width: 0;
+}
+
+.k-chart-tooltip {
+  display: grid;
+  gap: var(--k-dimension-space1);
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  color: var(--k-color-foreground);
+  padding: var(--k-dimension-space2);
+  font-size: var(--k-font-size-small);
+  font-variant-numeric: tabular-nums;
+}
+
+.k-chart-data-link {
+  width: fit-content;
+  font-size: var(--k-font-size-small);
+}
+
+.k-chart-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--k-dimension-space3) var(--k-dimension-space4);
+}
+
+.k-artifact-viewer {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  gap: var(--k-dimension-space2);
+}
+
+.k-artifact-stage {
+  display: grid;
+  width: 100%;
+  min-height: 20rem;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  color: var(--k-color-muted-foreground);
+}
+
+.k-artifact-stage img {
+  width: 100%;
+  height: 100%;
+  max-height: 70vh;
+}
+
+.k-artifact-viewer[data-fit="contain"] .k-artifact-stage img {
+  object-fit: contain;
+}
+
+.k-artifact-viewer[data-fit="cover"] .k-artifact-stage img {
+  object-fit: cover;
+}
+
+.k-artifact-viewer figcaption {
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-artifact-gallery {
+  display: grid;
+  min-width: 0;
+  gap: var(--k-dimension-space2);
+}
+
+.k-artifact-thumbnails {
+  display: flex;
+  max-width: 100%;
+  gap: var(--k-dimension-space2);
+  overflow-x: auto;
+}
+
+.k-artifact-thumbnail {
+  width: 4rem;
+  height: 4rem;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  padding: 0;
+  cursor: pointer;
+}
+
+.k-artifact-thumbnail[aria-pressed="true"] {
+  border-color: var(--k-color-primary);
+  outline: 1px solid var(--k-color-primary);
+  outline-offset: -2px;
+}
+
+.k-artifact-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.k-artifact-metadata {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+  gap: var(--k-dimension-space1);
+  font-size: var(--k-font-size-small);
+}
+
+.k-artifact-metadata > div {
+  display: grid;
+  grid-template-columns: minmax(5rem, 0.35fr) minmax(0, 1fr);
+  gap: var(--k-dimension-space2);
+  border-bottom: 1px solid var(--k-color-border);
+  padding-block: var(--k-dimension-space1);
+}
+
+.k-artifact-metadata dt {
+  color: var(--k-color-muted-foreground);
+}
+
+.k-artifact-metadata dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.k-artifact-source .k-source-line {
+  color: inherit;
+}
+
+.k-artifact-pair {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 2fr) minmax(16rem, 1fr);
+  gap: var(--k-dimension-space4);
+  align-items: start;
+}
+
+.k-dashboard {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: var(--k-dimension-sidebar) minmax(0, 1fr);
+  background: var(--k-color-canvas);
+}
+
+.k-dashboard-sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  border-right: 1px solid var(--k-color-border);
+  background: var(--k-color-surface);
+}
+
+.k-dashboard-brand {
+  display: grid;
+  min-height: var(--k-dimension-app-bar);
+  align-content: center;
+  gap: var(--k-dimension-space1);
+  border-bottom: 1px solid var(--k-color-border);
+  padding-inline: var(--k-dimension-space3);
+  font-family: var(--k-font-family-mono);
+  font-size: var(--k-font-size-small);
+}
+
+.k-dashboard-brand span {
+  color: var(--k-color-muted-foreground);
+}
+
+.k-dashboard-menu {
+  display: none;
+}
+
+.k-dashboard-nav {
+  display: grid;
+  gap: var(--k-dimension-space1);
+  padding: var(--k-dimension-space2);
+}
+
+.k-dashboard-nav a {
+  min-height: var(--k-dimension-control-height);
+  display: flex;
+  align-items: center;
+  border-left: 2px solid transparent;
+  color: var(--k-color-muted-foreground);
+  padding-inline: var(--k-dimension-space2);
+  text-decoration: none;
+}
+
+.k-dashboard-nav a[aria-current="page"],
+.k-dashboard-nav a:hover {
+  border-left-color: var(--k-color-primary);
+  color: var(--k-color-foreground);
+}
+
+.k-dashboard-main {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: var(--k-dimension-space4);
+  padding: var(--k-dimension-space4);
+}
+
+.k-dashboard-header {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: calc(var(--k-dimension-space4) * 2);
+  border-bottom: 1px solid var(--k-color-border);
+  padding-bottom: var(--k-dimension-space3);
+}
+
+.k-dashboard-heading {
+  display: grid;
+  min-width: 0;
+  gap: var(--k-dimension-space1);
+}
+
+.k-dashboard-eyebrow,
+.k-dashboard-section-header span,
+.k-dashboard-decision span,
+.k-dashboard-decision small,
+.k-dashboard-brief p,
+.k-dashboard-brief li {
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.k-dashboard-eyebrow {
+  font-family: var(--k-font-family-mono);
+  letter-spacing: 0.04em;
+}
+
+.k-dashboard-title {
+  margin: 0;
+  font-size: var(--k-font-size-title);
+  line-height: 1.15;
+}
+
+.k-dashboard-decision {
+  display: grid;
+  min-width: 17rem;
+  gap: var(--k-dimension-space1);
+  border-left: var(--k-dimension-space1) solid var(--k-color-primary);
+  padding-left: var(--k-dimension-space3);
+}
+
+.k-dashboard-decision strong {
+  font-size: var(--k-font-size-body);
+}
+
+.k-dashboard-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-top: 1px solid var(--k-color-border);
+  border-bottom: 1px solid var(--k-color-border);
+}
+
+.k-dashboard-metrics .k-metric {
+  border-right: 1px solid var(--k-color-border);
+  border-bottom: 0;
+  padding-inline: var(--k-dimension-space3);
+}
+
+.k-dashboard-metrics .k-metric:last-child {
+  border-right: 0;
+}
+
+.k-dashboard-grid {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
+  gap: var(--k-dimension-space4);
+  align-items: start;
+}
+
+.k-dashboard-brief {
+  display: grid;
+  min-width: 0;
+  gap: var(--k-dimension-space2);
+  border-top: 1px solid var(--k-color-border);
+  padding-block: var(--k-dimension-space2);
+}
+
+.k-dashboard-brief h2,
+.k-dashboard-section-header h2 {
+  margin: 0;
+  font-size: var(--k-font-size-body);
+}
+
+.k-dashboard-brief ul {
+  display: grid;
+  gap: var(--k-dimension-space2);
+  margin: 0;
+  padding-left: var(--k-dimension-space4);
+}
+
+.k-dashboard-brief strong {
+  color: var(--k-color-foreground);
+}
+
+.k-dashboard-section {
+  display: grid;
+  min-width: 0;
+  gap: var(--k-dimension-space2);
+}
+
+.k-dashboard-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--k-dimension-space3);
+}
+
+@media (max-width: 60rem) {
+  .k-chart-grid,
+  .k-artifact-pair,
+  .k-dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .k-artifact-pair > :first-child {
+    order: 0;
+  }
+
+  .k-dashboard-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .k-dashboard-metrics .k-metric:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .k-dashboard-metrics .k-metric:nth-child(n + 3) {
+    border-top: 1px solid var(--k-color-border);
+  }
+}
+
+@media (max-width: 48rem) {
+  .k-dashboard {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .k-dashboard-sidebar {
+    position: sticky;
+    height: var(--k-dimension-app-bar);
+    flex-direction: row;
+    align-items: stretch;
+    border-right: 0;
+    border-bottom: 1px solid var(--k-color-border);
+  }
+
+  .k-dashboard-brand {
+    flex: 1 1 auto;
+    border-bottom: 0;
+  }
+
+  .k-dashboard-menu {
+    display: inline-flex;
+    min-width: var(--k-dimension-touch-target);
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-left: 1px solid var(--k-color-border);
+    background: var(--k-color-surface);
+    color: var(--k-color-foreground);
+    font: inherit;
+  }
+
+  .k-dashboard-nav {
+    position: absolute;
+    top: var(--k-dimension-app-bar);
+    right: 0;
+    left: 0;
+    display: none;
+    border-bottom: 1px solid var(--k-color-border);
+    background: var(--k-color-surface);
+  }
+
+  .k-dashboard-nav[data-open="true"] {
+    display: grid;
+  }
+
+  .k-dashboard-main {
+    padding: var(--k-dimension-space3);
+  }
+
+  .k-dashboard-header {
+    display: grid;
+    gap: var(--k-dimension-space3);
+  }
+
+  .k-dashboard-decision {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 24rem) {
+  .k-button,
+  .k-input,
+  .k-tabs-tab {
+    min-height: var(--k-dimension-touch-target);
+  }
+
+  .k-filter-count {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .k-chart-plot {
+    height: 190px;
+  }
+
+  .k-artifact-stage {
+    min-height: 14rem;
+  }
+
+  .k-artifact-metadata > div,
+  .k-dashboard-metrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .k-dashboard-metrics .k-metric {
+    border-right: 0;
+    border-top: 1px solid var(--k-color-border);
+  }
+
+  .k-dashboard-metrics .k-metric:first-child {
+    border-top: 0;
+  }
+}

--- a/assets/.kafka-design/kafka-globals.css
+++ b/assets/.kafka-design/kafka-globals.css
@@ -1,0 +1,63 @@
+* {
+  box-sizing: border-box;
+}
+
+html {
+  background: var(--k-color-canvas);
+  color: var(--k-color-foreground);
+  font-family: var(--k-font-family-sans);
+}
+
+body {
+  margin: 0;
+  min-width: 0;
+  min-height: 100vh;
+  background: var(--k-color-canvas);
+  color: var(--k-color-foreground);
+  font-size: var(--k-font-size-body);
+  line-height: 1.45;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+a {
+  color: var(--k-color-primary);
+}
+
+:focus-visible {
+  outline: 2px solid var(--k-color-focus);
+  outline-offset: 2px;
+}
+
+::selection {
+  background: var(--k-color-accent);
+  color: var(--k-color-foreground);
+}
+
+.page-container {
+  width: 100%;
+  margin-inline: auto;
+  padding: var(--k-dimension-space4);
+}
+
+@media (max-width: 48rem) {
+  .page-container {
+    padding: var(--k-dimension-space3);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/assets/.kafka-design/kafka-tokens.css
+++ b/assets/.kafka-design/kafka-tokens.css
@@ -1,0 +1,46 @@
+/* Generated from tokens/foundation.tokens.json. Do not edit. */
+:root {
+  --k-dimension-app-bar: 44px;
+  --k-dimension-control-height: 32px;
+  --k-dimension-radius: 2px;
+  --k-dimension-sidebar: 192px;
+  --k-dimension-sidebar-collapsed: 48px;
+  --k-dimension-space1: 4px;
+  --k-dimension-space2: 8px;
+  --k-dimension-space3: 12px;
+  --k-dimension-space4: 16px;
+  --k-dimension-table-row: 30px;
+  --k-dimension-touch-target: 44px;
+  --k-font-family-mono: "Roboto Mono", SFMono-Regular, Consolas, monospace;
+  --k-font-family-sans: Inter, "Noto Sans JP", system-ui, sans-serif;
+  --k-font-size-body: 14px;
+  --k-font-size-small: 12px;
+  --k-font-size-title: 20px;
+  --k-number-motion-fast-ms: 120;
+  --k-number-shadow-opacity: 0;
+  --k-color-accent: #7DD3FC;
+  --k-color-border: #D9D6CE;
+  --k-color-canvas: #F7F5EF;
+  --k-color-danger: #B91C1C;
+  --k-color-focus: #2563EB;
+  --k-color-foreground: #17233F;
+  --k-color-muted-foreground: #667085;
+  --k-color-primary: #2563EB;
+  --k-color-success: #15803D;
+  --k-color-surface: #FFFFFF;
+  --k-color-warning: #A16207;
+}
+
+[data-theme="dark"] {
+  --k-color-accent: #7DD3FC;
+  --k-color-border: #1E293B;
+  --k-color-canvas: #0B0F17;
+  --k-color-danger: #F87171;
+  --k-color-focus: #60A5FA;
+  --k-color-foreground: #F1F5F9;
+  --k-color-muted-foreground: #94A3B8;
+  --k-color-primary: #60A5FA;
+  --k-color-success: #4ADE80;
+  --k-color-surface: #111827;
+  --k-color-warning: #FBBF24;
+}

--- a/assets/.kafka-design/portable-conformance.mjs
+++ b/assets/.kafka-design/portable-conformance.mjs
@@ -1,0 +1,215 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { scanConformancePolicy } from './conformance-policy.mjs'
+
+const CONFIG_NAME = 'design.config.json'
+const LOCK_NAME = 'design.lock.json'
+const MANAGED_START = '/* kafka-design:managed-start */'
+const MANAGED_END = '/* kafka-design:managed-end */'
+const SHA40 = /^[0-9a-f]{40}$/
+const SHA64 = /^[0-9a-f]{64}$/
+const CONFIG_KEYS = new Set(['$schema', 'schemaVersion', 'designSha', 'preset', 'cssEntry', 'managedDir', 'logo'])
+const LOCK_KEYS = new Set(['schemaVersion', 'designSha', 'preset', 'configHash', 'manifestHash', 'logoHash', 'installedRegistryItems', 'managedFiles', 'integration'])
+const MANAGED_SOURCES = Object.freeze([
+  { source: 'styles/tokens.css', target: 'kafka-tokens.css', css: true },
+  { source: 'styles/globals.css', target: 'kafka-globals.css', css: true },
+  { source: 'styles/components.css', target: 'kafka-components.css', css: true },
+  { source: 'scripts/portable-conformance.mjs', target: 'portable-conformance.mjs', css: false },
+  { source: 'scripts/conformance-policy.mjs', target: 'conformance-policy.mjs', css: false },
+])
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function toPosix(relativePath) {
+  return relativePath.split(path.sep).join('/')
+}
+
+function push(errors, rule, filePath, message) {
+  errors.push({ rule, path: toPosix(filePath), message })
+}
+
+function assertPlainObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${label} must be a JSON object`)
+}
+
+function assertExactKeys(value, allowed, label) {
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${label} has unknown field: ${key}`)
+}
+
+function readJson(filePath, label) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    throw new Error(`${label} is missing or invalid JSON: ${filePath}\n${error.message}`)
+  }
+}
+
+function resolveWithin(root, relativePath, label) {
+  if (typeof relativePath !== 'string' || relativePath.length === 0) throw new Error(`${label} must be a non-empty relative path`)
+  if (path.isAbsolute(relativePath)) throw new Error(`${label} must be relative: ${relativePath}`)
+  const resolvedRoot = path.resolve(root)
+  const resolved = path.resolve(resolvedRoot, relativePath)
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) throw new Error(`${label} escapes consumer root: ${relativePath}`)
+  return resolved
+}
+
+function validateConfig(config) {
+  assertPlainObject(config, CONFIG_NAME)
+  assertExactKeys(config, CONFIG_KEYS, CONFIG_NAME)
+  if (config.schemaVersion !== 1) throw new Error(`${CONFIG_NAME}.schemaVersion must be 1`)
+  if (!SHA40.test(config.designSha ?? '')) throw new Error(`${CONFIG_NAME}.designSha must be a full 40-character lowercase Git SHA`)
+  if (!['base', 'financial-dashboard'].includes(config.preset)) throw new Error(`${CONFIG_NAME}.preset must be base or financial-dashboard`)
+  for (const key of ['cssEntry', 'managedDir']) if (typeof config[key] !== 'string' || config[key].length === 0) throw new Error(`${CONFIG_NAME}.${key} must be a non-empty string`)
+  if (config.logo !== undefined && (typeof config.logo !== 'string' || config.logo.length === 0)) throw new Error(`${CONFIG_NAME}.logo must be a non-empty string when present`)
+  return config
+}
+
+function validateLock(lock) {
+  assertPlainObject(lock, LOCK_NAME)
+  assertExactKeys(lock, LOCK_KEYS, LOCK_NAME)
+  if (lock.schemaVersion !== 1) throw new Error(`${LOCK_NAME}.schemaVersion must be 1`)
+  if (!SHA40.test(lock.designSha ?? '')) throw new Error(`${LOCK_NAME}.designSha must be a full Git SHA`)
+  if (!['base', 'financial-dashboard'].includes(lock.preset)) throw new Error(`${LOCK_NAME}.preset is invalid`)
+  for (const key of ['configHash', 'manifestHash']) if (!SHA64.test(lock[key] ?? '')) throw new Error(`${LOCK_NAME}.${key} must be sha256`)
+  if (lock.logoHash !== null && !SHA64.test(lock.logoHash ?? '')) throw new Error(`${LOCK_NAME}.logoHash must be sha256 or null`)
+  if (!Array.isArray(lock.installedRegistryItems) || lock.installedRegistryItems.some((item) => typeof item !== 'string')) throw new Error(`${LOCK_NAME}.installedRegistryItems must be a string array`)
+  if (!Array.isArray(lock.managedFiles)) throw new Error(`${LOCK_NAME}.managedFiles must be an array`)
+  for (const item of lock.managedFiles) {
+    assertPlainObject(item, `${LOCK_NAME}.managedFiles[]`)
+    assertExactKeys(item, new Set(['path', 'sha256']), `${LOCK_NAME}.managedFiles[]`)
+    if (typeof item.path !== 'string' || item.path.length === 0 || !SHA64.test(item.sha256 ?? '')) throw new Error(`${LOCK_NAME}.managedFiles[] has invalid path or sha256`)
+  }
+  assertPlainObject(lock.integration, `${LOCK_NAME}.integration`)
+  assertExactKeys(lock.integration, new Set(['cssEntry', 'blockHash']), `${LOCK_NAME}.integration`)
+  if (typeof lock.integration.cssEntry !== 'string' || lock.integration.cssEntry.length === 0 || !SHA64.test(lock.integration.blockHash ?? '')) throw new Error(`${LOCK_NAME}.integration is invalid`)
+  return lock
+}
+
+function expectedManagedPaths(config) {
+  return MANAGED_SOURCES.map((item) => ({
+    ...item,
+    consumerPath: toPosix(path.join(config.managedDir, item.target)),
+  }))
+}
+
+function buildIntegration(consumerRoot, config, managed) {
+  const cssEntryPath = resolveWithin(consumerRoot, config.cssEntry, `${CONFIG_NAME}.cssEntry`)
+  const cssDir = path.dirname(cssEntryPath)
+  const imports = managed.filter((item) => item.css).map((item) => {
+    const targetPath = resolveWithin(consumerRoot, item.consumerPath, `managed target ${item.target}`)
+    let relative = toPosix(path.relative(cssDir, targetPath))
+    if (!relative.startsWith('.')) relative = `./${relative}`
+    return `@import "${relative}";`
+  })
+  const block = `${MANAGED_START}\n${imports.join('\n')}\n${MANAGED_END}`
+  return { cssEntryPath, block, blockHash: sha256(block) }
+}
+
+function expectedLogoHash(consumerRoot, config) {
+  if (config.logo === undefined) return null
+  const logoPath = resolveWithin(consumerRoot, config.logo, `${CONFIG_NAME}.logo`)
+  if (!fs.existsSync(logoPath) || !fs.statSync(logoPath).isFile()) throw new Error(`Configured logo is missing: ${config.logo}`)
+  return sha256(fs.readFileSync(logoPath))
+}
+
+export function checkPortableConsumer(consumerPath) {
+  const consumerRoot = path.resolve(consumerPath)
+  if (!fs.existsSync(consumerRoot) || !fs.statSync(consumerRoot).isDirectory()) throw new Error(`Consumer directory does not exist: ${consumerRoot}`)
+
+  const config = validateConfig(readJson(path.join(consumerRoot, CONFIG_NAME), CONFIG_NAME))
+  resolveWithin(consumerRoot, config.cssEntry, `${CONFIG_NAME}.cssEntry`)
+  resolveWithin(consumerRoot, config.managedDir, `${CONFIG_NAME}.managedDir`)
+  if (config.logo !== undefined) resolveWithin(consumerRoot, config.logo, `${CONFIG_NAME}.logo`)
+
+  const errors = []
+  const lockPath = path.join(consumerRoot, LOCK_NAME)
+  let lock
+  try {
+    lock = validateLock(readJson(lockPath, LOCK_NAME))
+  } catch (error) {
+    push(errors, 'managed-file-drift', LOCK_NAME, error.message)
+    return [...errors, ...scanConformancePolicy(consumerRoot, config)]
+  }
+
+  if (lock.designSha !== config.designSha) push(errors, 'managed-file-drift', LOCK_NAME, 'design SHA does not match design.config.json')
+  if (lock.preset !== config.preset) push(errors, 'managed-file-drift', LOCK_NAME, 'preset does not match design.config.json')
+  if (lock.configHash !== sha256(stableStringify(config))) push(errors, 'managed-file-drift', LOCK_NAME, 'configHash does not match design.config.json')
+  if (lock.logoHash !== expectedLogoHash(consumerRoot, config)) push(errors, 'managed-file-drift', LOCK_NAME, 'logoHash does not match configured logo')
+  if (lock.installedRegistryItems.length !== 0) push(errors, 'managed-file-drift', LOCK_NAME, 'portable CSS adoption expects installedRegistryItems to be empty')
+
+  const expectedManaged = expectedManagedPaths(config)
+  const recorded = new Map(lock.managedFiles.map((item) => [toPosix(item.path), item.sha256]))
+  if (recorded.size !== lock.managedFiles.length) push(errors, 'managed-file-drift', LOCK_NAME, 'managedFiles contains duplicate paths')
+  const expectedPaths = new Set(expectedManaged.map((item) => item.consumerPath))
+  for (const recordedPath of recorded.keys()) if (!expectedPaths.has(recordedPath)) push(errors, 'managed-file-drift', LOCK_NAME, `unexpected managed file recorded: ${recordedPath}`)
+
+  const manifestAssets = []
+  for (const item of expectedManaged) {
+    const recordedHash = recorded.get(item.consumerPath)
+    if (!recordedHash) {
+      push(errors, 'managed-file-drift', item.consumerPath, 'managed file is missing from design.lock.json')
+      continue
+    }
+    const filePath = resolveWithin(consumerRoot, item.consumerPath, `managed file ${item.consumerPath}`)
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      push(errors, 'managed-file-drift', item.consumerPath, 'managed file is missing')
+    } else if (sha256(fs.readFileSync(filePath)) !== recordedHash) {
+      push(errors, 'managed-file-drift', item.consumerPath, 'managed file was edited or is stale')
+    }
+    manifestAssets.push({ source: item.source, target: item.consumerPath, sha256: recordedHash })
+  }
+
+  if (manifestAssets.length === expectedManaged.length) {
+    const manifest = { schemaVersion: 1, preset: config.preset, assets: manifestAssets }
+    if (lock.manifestHash !== sha256(stableStringify(manifest))) push(errors, 'managed-file-drift', LOCK_NAME, 'manifestHash does not match managed files')
+  }
+
+  const integration = buildIntegration(consumerRoot, config, expectedManaged)
+  if (lock.integration.cssEntry !== toPosix(config.cssEntry) || lock.integration.blockHash !== integration.blockHash) {
+    push(errors, 'managed-file-drift', LOCK_NAME, 'integration does not match canonical CSS import block')
+  }
+  if (!fs.existsSync(integration.cssEntryPath)) {
+    push(errors, 'managed-file-drift', config.cssEntry, 'configured CSS entry is missing')
+  } else {
+    const cssEntry = fs.readFileSync(integration.cssEntryPath, 'utf8')
+    const starts = cssEntry.split(MANAGED_START).length - 1
+    const ends = cssEntry.split(MANAGED_END).length - 1
+    if (starts !== 1 || ends !== 1 || !cssEntry.includes(integration.block)) push(errors, 'managed-file-drift', config.cssEntry, 'canonical managed import block is missing, duplicated, or edited')
+  }
+
+  return [...errors, ...scanConformancePolicy(consumerRoot, config)]
+}
+
+function parseConsumerArg(argv) {
+  const index = argv.indexOf('--consumer')
+  if (index === -1 || !argv[index + 1] || argv[index + 1].startsWith('--')) throw new Error(`Usage: node portable-conformance.mjs --consumer <path containing ${CONFIG_NAME}>`)
+  if (argv.length !== index + 2) throw new Error('Unexpected conformance arguments')
+  return argv[index + 1]
+}
+
+const isCli = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isCli) {
+  try {
+    const errors = checkPortableConsumer(parseConsumerArg(process.argv.slice(2)))
+    if (errors.length === 0) console.log('design conformance: ok')
+    else {
+      for (const error of errors) console.error(`[${error.rule}] ${error.path}: ${error.message}`)
+      process.exitCode = 1
+    }
+  } catch (error) {
+    console.error(`design conformance failed: ${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/assets/readiness-report.css
+++ b/assets/readiness-report.css
@@ -1,7 +1,7 @@
 /* kafka-design:managed-start */
-@import "./.kafka-design/kafka-tokens.css";
-@import "./.kafka-design/kafka-globals.css";
-@import "./.kafka-design/kafka-components.css";
+@import ".kafka-design/kafka-tokens.css";
+@import ".kafka-design/kafka-globals.css";
+@import ".kafka-design/kafka-components.css";
 /* kafka-design:managed-end */
 
 body {

--- a/assets/readiness-report.css
+++ b/assets/readiness-report.css
@@ -1,0 +1,112 @@
+/* kafka-design:managed-start */
+@import "./.kafka-design/kafka-tokens.css";
+@import "./.kafka-design/kafka-globals.css";
+@import "./.kafka-design/kafka-components.css";
+/* kafka-design:managed-end */
+
+body {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: calc(var(--k-dimension-space4) * 2) var(--k-dimension-space4);
+  background: var(--k-color-surface);
+}
+
+.audit-header {
+  display: grid;
+  gap: var(--k-dimension-space1);
+  margin-bottom: calc(var(--k-dimension-space4) * 2);
+  border-bottom: 1px solid var(--k-color-border);
+  padding-bottom: var(--k-dimension-space4);
+}
+
+.audit-kicker {
+  margin: 0;
+  color: var(--k-color-muted-foreground);
+  font-family: var(--k-font-family-mono);
+  font-size: var(--k-font-size-small);
+}
+
+h1 {
+  margin: 0;
+  color: var(--k-color-foreground);
+  font-size: var(--k-font-size-title);
+  line-height: 1.2;
+}
+
+.audit-asset {
+  margin: 0;
+  color: var(--k-color-muted-foreground);
+}
+
+.audit-asset strong {
+  color: var(--k-color-foreground);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  border-top: 1px solid var(--k-color-border);
+  font-variant-numeric: tabular-nums;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--k-color-border);
+  padding: var(--k-dimension-space3) var(--k-dimension-space2);
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  width: 48%;
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+  font-weight: 600;
+}
+
+td {
+  color: var(--k-color-foreground);
+  font-family: var(--k-font-family-mono);
+  overflow-wrap: anywhere;
+}
+
+.notice {
+  margin-top: calc(var(--k-dimension-space4) * 2);
+  border-left: var(--k-dimension-space1) solid var(--k-color-primary);
+  background: var(--k-color-canvas);
+  padding: var(--k-dimension-space4);
+}
+
+.notice strong {
+  color: var(--k-color-foreground);
+}
+
+.notice p {
+  margin: 0;
+  color: var(--k-color-muted-foreground);
+}
+
+.notice p + p {
+  margin-top: var(--k-dimension-space2);
+}
+
+@media (max-width: 36rem) {
+  body {
+    padding: var(--k-dimension-space4) var(--k-dimension-space3);
+  }
+
+  th,
+  td {
+    display: block;
+    width: 100%;
+  }
+
+  th {
+    border-bottom: 0;
+    padding-bottom: var(--k-dimension-space1);
+  }
+
+  td {
+    padding-top: 0;
+  }
+}

--- a/design.config.json
+++ b/design.config.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "designSha": "f39a0865cf0342f495bf49f547c7fdf112145d77",
+  "preset": "base",
+  "cssEntry": "assets/readiness-report.css",
+  "managedDir": "assets/.kafka-design"
+}

--- a/design.config.json
+++ b/design.config.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "designSha": "f39a0865cf0342f495bf49f547c7fdf112145d77",
+  "designSha": "6ef94b60a9fefcd7577ec25d2edd4bca06096314",
   "preset": "base",
   "cssEntry": "assets/readiness-report.css",
   "managedDir": "assets/.kafka-design"

--- a/design.lock.json
+++ b/design.lock.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": 1,
-  "designSha": "f39a0865cf0342f495bf49f547c7fdf112145d77",
+  "designSha": "6ef94b60a9fefcd7577ec25d2edd4bca06096314",
   "preset": "base",
-  "configHash": "c93642a4c3ed43326a054f29fabca94ed72954a3d170a9d81f6d1403ee88c745",
-  "manifestHash": "05d6b239c92006736451d5f22db95650086541895e5b48af1db361f924d1199f",
+  "configHash": "f8113d48771186df4ebc84276f51f6c6a6d8f8945767e59a4fa1c31badc8ea42",
+  "manifestHash": "a91274c2df6c98cd5aac9d4938f364fbffe9d752d886ef1f0a3e5505f32c25d5",
   "logoHash": null,
   "installedRegistryItems": [],
   "managedFiles": [
@@ -18,6 +18,14 @@
     {
       "path": "assets/.kafka-design/kafka-components.css",
       "sha256": "6236943bda6adc5bbd82f6fee9f600b1cffd1d25bc515b64843b5b7f51fd0cde"
+    },
+    {
+      "path": "assets/.kafka-design/portable-conformance.mjs",
+      "sha256": "5281b91caadee07e92b5876ad3547a6531229bb57107ba3bcff4be20ddc3e6d4"
+    },
+    {
+      "path": "assets/.kafka-design/conformance-policy.mjs",
+      "sha256": "1622dce9e752aa5b1fc700d1fa894da5f08a957fb088dad7a59be26529a8b54a"
     }
   ],
   "integration": {

--- a/design.lock.json
+++ b/design.lock.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "designSha": "f39a0865cf0342f495bf49f547c7fdf112145d77",
+  "preset": "base",
+  "configHash": "c93642a4c3ed43326a054f29fabca94ed72954a3d170a9d81f6d1403ee88c745",
+  "manifestHash": "05d6b239c92006736451d5f22db95650086541895e5b48af1db361f924d1199f",
+  "logoHash": null,
+  "installedRegistryItems": [],
+  "managedFiles": [
+    {
+      "path": "assets/.kafka-design/kafka-tokens.css",
+      "sha256": "897ef1dfb22bf1a9671ad96075104af78eca6d5e02427135cd7d0b6d647af6d8"
+    },
+    {
+      "path": "assets/.kafka-design/kafka-globals.css",
+      "sha256": "2304371a0c507131844c2fbaa8e9725dedc72ba3165226ba6f2d1862812256bc"
+    },
+    {
+      "path": "assets/.kafka-design/kafka-components.css",
+      "sha256": "6236943bda6adc5bbd82f6fee9f600b1cffd1d25bc515b64843b5b7f51fd0cde"
+    }
+  ],
+  "integration": {
+    "cssEntry": "assets/readiness-report.css",
+    "blockHash": "a22ccfc87e7ebb134ccac8bd2b5f5978fa63039a7a5cc23e30e70f3524865201"
+  }
+}

--- a/design.lock.json
+++ b/design.lock.json
@@ -30,6 +30,6 @@
   ],
   "integration": {
     "cssEntry": "assets/readiness-report.css",
-    "blockHash": "a22ccfc87e7ebb134ccac8bd2b5f5978fa63039a7a5cc23e30e70f3524865201"
+    "blockHash": "17f3ce126f165b8f41c25f87a57a6fa1272796478cd4a150ec085cdc36dcdec7"
   }
 }

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -17,6 +17,16 @@ REQUIRED_PROVENANCE_FIELDS = (
     "content_type",
 )
 
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_REPORT_CSS_ENTRY = _REPOSITORY_ROOT / "assets" / "readiness-report.css"
+_MANAGED_CSS_FILES = (
+    _REPOSITORY_ROOT / "assets" / ".kafka-design" / "kafka-tokens.css",
+    _REPOSITORY_ROOT / "assets" / ".kafka-design" / "kafka-globals.css",
+    _REPOSITORY_ROOT / "assets" / ".kafka-design" / "kafka-components.css",
+)
+_MANAGED_START = "/* kafka-design:managed-start */"
+_MANAGED_END = "/* kafka-design:managed-end */"
+
 
 def _read_manifest(path: Path) -> list[dict]:
     if not path.is_file():
@@ -91,6 +101,25 @@ def _backend_evidence(dataset: str, manifest_path: str | Path | None) -> dict:
     }
 
 
+def _report_css() -> str:
+    if not _REPORT_CSS_ENTRY.is_file():
+        raise FileNotFoundError(f"Report CSS entry does not exist: {_REPORT_CSS_ENTRY}")
+
+    entry = _REPORT_CSS_ENTRY.read_text(encoding="utf-8")
+    start = entry.find(_MANAGED_START)
+    end = entry.find(_MANAGED_END)
+    if start < 0 or end < 0 or end < start:
+        raise ValueError(f"Managed design import block is invalid: {_REPORT_CSS_ENTRY}")
+
+    local_css = (entry[:start] + entry[end + len(_MANAGED_END) :]).strip()
+    managed_parts: list[str] = []
+    for css_path in _MANAGED_CSS_FILES:
+        if not css_path.is_file():
+            raise FileNotFoundError(f"Managed design CSS does not exist: {css_path}")
+        managed_parts.append(css_path.read_text(encoding="utf-8").strip())
+    return "\n\n".join([*managed_parts, local_css])
+
+
 def _render_html(report: dict) -> str:
     reason_counts = report["selection"]["reason_counts"]
     dimensions = report["dimensions"]
@@ -113,6 +142,7 @@ def _render_html(report: dict) -> str:
         f"<tr><th>{html.escape(str(label))}</th><td>{html.escape(str(value))}</td></tr>"
         for label, value in rows
     )
+    report_css = _report_css()
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -120,20 +150,23 @@ def _render_html(report: dict) -> str:
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Photogrammetry input audit — {html.escape(report["asset_id"])}</title>
   <style>
-    body {{ font-family: system-ui, sans-serif; max-width: 880px; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }}
-    table {{ border-collapse: collapse; width: 100%; }}
-    th, td {{ border-bottom: 1px solid #ddd; padding: .6rem; text-align: left; }}
-    .notice {{ background: #f6f6f6; padding: 1rem; border-radius: .5rem; }}
+{report_css}
   </style>
 </head>
 <body>
-  <h1>Photogrammetry input audit</h1>
-  <p><strong>Asset:</strong> {html.escape(report["asset_id"])}</p>
-  <table><tbody>{table}</tbody></table>
-  <div class="notice">
-    <p>This report describes input selection and provenance only.</p>
-    <p>Registration rate, reprojection error, geometry completeness, and texture quality are not measured here, so this report does not guarantee 3D reconstruction quality.</p>
-  </div>
+  <header class="audit-header">
+    <p class="audit-kicker">AutoPhotogrammetry / input audit</p>
+    <h1>Photogrammetry input audit</h1>
+    <p class="audit-asset"><strong>Asset:</strong> {html.escape(report["asset_id"])}</p>
+  </header>
+  <main>
+    <table><tbody>{table}</tbody></table>
+    <div class="notice">
+      <p><strong>Scope boundary</strong></p>
+      <p>This report describes input selection and provenance only.</p>
+      <p>Registration rate, reprojection error, geometry completeness, and texture quality are not measured here, so this report does not guarantee 3D reconstruction quality.</p>
+    </div>
+  </main>
 </body>
 </html>
 """


### PR DESCRIPTION
## Summary
- pin canonical `KAFKA2306/design` at `6ef94b60a9fefcd7577ec25d2edd4bca06096314`
- add `design.config.json` / `design.lock.json` and the managed design CSS bundle
- replace standalone readiness-report raw visual CSS with canonical token authority
- sync the canonical portable conformance runner + shared policy from the pinned design SHA
- run conformance locally from the managed bundle, so this public repository does not require access to the private design repository

## Design boundary
- AutoPhotogrammetry keeps photogrammetry/data/business logic locally
- visual and conformance policy authority remains in `KAFKA2306/design`
- generated audit HTML remains standalone and embeds the pinned managed CSS
- no fallback or duplicate consumer-owned visual authority is introduced

## Verification
Exact PR head `1a568ad2e433e014e0230d2f13bee846f1bf859a`:
- `Test` #366: success
- existing `bash scripts/check`: success, including 227 unit tests
- managed portable design conformance: success
- `Artifact policy` #112: success

The earlier CI failure was the invalid public-consumer → private-design clone path; it was replaced upstream by the managed portable conformance bundle rather than a consumer-local checker.

## Merge acceptance
- squash merge this exact head
- verify `main` read-back pins the same full design SHA and five managed files
- verify main push CI after merge