### PR TITLE
Pin production console to current design authority

### DIFF
--- a/.github/workflows/design-conformance.yml
+++ b/.github/workflows/design-conformance.yml
@@ -1,0 +1,18 @@
+name: Design conformance
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify canonical design contract
+        run: node assets/.kafka-design/portable-conformance.mjs --consumer "$GITHUB_WORKSPACE"

--- a/design.config.json
+++ b/design.config.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "designSha": "6ef94b60a9fefcd7577ec25d2edd4bca06096314",
+  "designSha": "f2d5c85e196c0f92239de0607c8fce6bf1b20433",
   "preset": "base",
   "cssEntry": "assets/readiness-report.css",
   "managedDir": "assets/.kafka-design"

--- a/design.lock.json
+++ b/design.lock.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "designSha": "6ef94b60a9fefcd7577ec25d2edd4bca06096314",
+  "designSha": "f2d5c85e196c0f92239de0607c8fce6bf1b20433",
   "preset": "base",
-  "configHash": "f8113d48771186df4ebc84276f51f6c6a6d8f8945767e59a4fa1c31badc8ea42",
+  "configHash": "2f5eced48e5269f11d8e12eb03724d062969921c1ae8930f47a6b0717fda3a1e",
   "manifestHash": "a91274c2df6c98cd5aac9d4938f364fbffe9d752d886ef1f0a3e5505f32c25d5",
   "logoHash": null,
   "installedRegistryItems": [],


### PR DESCRIPTION
Advances #163 from the portable-conformance baseline to current `KAFKA2306/design` main `f2d5c85e196c0f92239de0607c8fce6bf1b20433`.

- updates the immutable design pin and lock hash
- keeps the already-synced canonical five-file managed bundle
- adds a dedicated PR/push conformance gate
- preserves reconstruction/training, quality measurement, artifact provenance, and GPU execution as consumer responsibilities

The managed bundle is unchanged between `6ef94b6` and `f2d5c85`; the newer pin establishes the authority revision containing canonical `EvidenceSurface` and `StatusSurface` before deeper readiness-console composition work.