### PR TITLE
Turn readiness report into a decision surface

### DIFF
--- a/assets/readiness-report.css
+++ b/assets/readiness-report.css
@@ -5,36 +5,51 @@
 /* kafka-design:managed-end */
 
 body {
-  max-width: 880px;
+  max-width: 1040px;
   margin: 0 auto;
   padding: calc(var(--k-dimension-space4) * 2) var(--k-dimension-space4);
-  background: var(--k-color-surface);
+  background: var(--k-color-canvas);
 }
 
 .audit-header {
   display: grid;
-  gap: var(--k-dimension-space1);
-  margin-bottom: calc(var(--k-dimension-space4) * 2);
+  gap: var(--k-dimension-space2);
+  margin-bottom: var(--k-dimension-space3);
   border-bottom: 1px solid var(--k-color-border);
-  padding-bottom: var(--k-dimension-space4);
+  padding-bottom: var(--k-dimension-space3);
 }
 
-.audit-kicker {
+.audit-kicker,
+.surface-kicker {
   margin: 0;
   color: var(--k-color-muted-foreground);
   font-family: var(--k-font-family-mono);
   font-size: var(--k-font-size-small);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.audit-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--k-dimension-space4);
+}
+
+.audit-title-row > div {
+  min-width: 0;
 }
 
 h1 {
   margin: 0;
   color: var(--k-color-foreground);
-  font-size: var(--k-font-size-title);
-  line-height: 1.2;
+  font-size: clamp(var(--k-font-size-title), 3vw, 1.75rem);
+  line-height: 1.15;
 }
 
 .audit-asset {
-  margin: 0;
+  margin: var(--k-dimension-space1) 0 0;
   color: var(--k-color-muted-foreground);
 }
 
@@ -42,19 +57,149 @@ h1 {
   color: var(--k-color-foreground);
 }
 
+.audit-status {
+  flex: 0 0 auto;
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  color: var(--k-color-foreground);
+  padding: var(--k-dimension-space2) var(--k-dimension-space3);
+  font-family: var(--k-font-family-mono);
+  font-size: var(--k-font-size-small);
+}
+
+.audit-status[data-status="BLOCKED"] {
+  border-color: var(--k-color-danger);
+  color: var(--k-color-danger);
+}
+
+.audit-status[data-status="ACTION_REQUIRED"],
+.audit-status[data-status="REVIEW_REQUIRED"] {
+  border-color: var(--k-color-warning);
+  color: var(--k-color-warning);
+}
+
+.audit-status[data-status="READY_FOR_BACKEND"] {
+  border-color: var(--k-color-primary);
+  color: var(--k-color-primary);
+}
+
+.audit-status[data-status="REVIEW_READY"] {
+  border-color: var(--k-color-success);
+  color: var(--k-color-success);
+}
+
+.decision-surface {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+  gap: var(--k-dimension-space4);
+  border: 1px solid var(--k-color-border);
+  border-left: var(--k-dimension-space1) solid var(--k-color-primary);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  padding: var(--k-dimension-space4);
+}
+
+.decision-surface h2 {
+  margin: var(--k-dimension-space1) 0 0;
+  color: var(--k-color-foreground);
+  font-size: var(--k-font-size-title);
+  line-height: 1.3;
+}
+
+.next-action {
+  display: grid;
+  align-content: start;
+  gap: var(--k-dimension-space1);
+  border-left: 1px solid var(--k-color-border);
+  padding-left: var(--k-dimension-space4);
+}
+
+.next-action span {
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.next-action strong {
+  color: var(--k-color-foreground);
+  font-size: var(--k-font-size-body);
+  line-height: 1.45;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--k-dimension-space2);
+  margin-top: var(--k-dimension-space3);
+}
+
+.kpi {
+  min-width: 0;
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+  padding: var(--k-dimension-space3);
+}
+
+.kpi span,
+.kpi small {
+  display: block;
+  color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
+}
+
+.kpi span {
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.kpi strong {
+  display: block;
+  margin: var(--k-dimension-space1) 0;
+  overflow-wrap: anywhere;
+  color: var(--k-color-foreground);
+  font-family: var(--k-font-family-mono);
+  font-size: var(--k-font-size-title);
+  font-variant-numeric: tabular-nums;
+}
+
+.evidence-details {
+  margin-top: var(--k-dimension-space3);
+  border: 1px solid var(--k-color-border);
+  border-radius: var(--k-dimension-radius);
+  background: var(--k-color-surface);
+}
+
+.evidence-details summary {
+  cursor: pointer;
+  padding: var(--k-dimension-space3) var(--k-dimension-space4);
+  color: var(--k-color-foreground);
+  font-weight: 600;
+}
+
+.evidence-details[open] summary {
+  border-bottom: 1px solid var(--k-color-border);
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
-  border-top: 1px solid var(--k-color-border);
   font-variant-numeric: tabular-nums;
 }
 
 th,
 td {
   border-bottom: 1px solid var(--k-color-border);
-  padding: var(--k-dimension-space3) var(--k-dimension-space2);
+  padding: var(--k-dimension-space3) var(--k-dimension-space4);
   text-align: left;
   vertical-align: top;
+}
+
+tr:last-child th,
+tr:last-child td {
+  border-bottom: 0;
 }
 
 th {
@@ -71,10 +216,10 @@ td {
 }
 
 .notice {
-  margin-top: calc(var(--k-dimension-space4) * 2);
-  border-left: var(--k-dimension-space1) solid var(--k-color-primary);
-  background: var(--k-color-canvas);
-  padding: var(--k-dimension-space4);
+  margin-top: var(--k-dimension-space3);
+  border-left: var(--k-dimension-space1) solid var(--k-color-border);
+  background: var(--k-color-surface);
+  padding: var(--k-dimension-space3) var(--k-dimension-space4);
 }
 
 .notice strong {
@@ -84,15 +229,37 @@ td {
 .notice p {
   margin: 0;
   color: var(--k-color-muted-foreground);
+  font-size: var(--k-font-size-small);
 }
 
 .notice p + p {
-  margin-top: var(--k-dimension-space2);
+  margin-top: var(--k-dimension-space1);
 }
 
-@media (max-width: 36rem) {
+@media (max-width: 44rem) {
   body {
-    padding: var(--k-dimension-space4) var(--k-dimension-space3);
+    padding: var(--k-dimension-space3);
+  }
+
+  .audit-title-row,
+  .decision-surface {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .audit-status {
+    width: fit-content;
+  }
+
+  .next-action {
+    border-top: 1px solid var(--k-color-border);
+    border-left: 0;
+    padding-top: var(--k-dimension-space3);
+    padding-left: 0;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   th,

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -127,9 +127,7 @@ def _audit_decision(report: dict) -> dict[str, str]:
             ),
         }
 
-    if backend_status == "failed" or (
-        isinstance(return_code, int) and return_code != 0
-    ):
+    if backend_status == "failed" or (isinstance(return_code, int) and return_code != 0):
         return {
             "status": "BLOCKED",
             "reason": "The recorded reconstruction backend execution failed.",

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -101,7 +101,6 @@ def _backend_evidence(dataset: str, manifest_path: str | Path | None) -> dict:
     }
 
 
-
 def _audit_decision(report: dict) -> dict[str, str]:
     selected = report["selection"]["selected_count"]
     input_count = report["input"]["count"]
@@ -158,6 +157,7 @@ def _audit_decision(report: dict) -> dict[str, str]:
         "reason": f"Backend evidence is recorded with status {backend_status!r}, but success is not established.",
         "next_action": "Inspect the backend run manifest and establish an explicit success or failure state.",
     }
+
 
 def _report_css() -> str:
     if not _REPORT_CSS_ENTRY.is_file():

--- a/processing/readiness_report.py
+++ b/processing/readiness_report.py
@@ -101,6 +101,64 @@ def _backend_evidence(dataset: str, manifest_path: str | Path | None) -> dict:
     }
 
 
+
+def _audit_decision(report: dict) -> dict[str, str]:
+    selected = report["selection"]["selected_count"]
+    input_count = report["input"]["count"]
+    missing_provenance = report["selection"]["reason_counts"]["PROVENANCE_MISSING"]
+    backend = report["backend"]
+    backend_status = backend["status"]
+    return_code = backend["return_code"]
+
+    if selected <= 0:
+        return {
+            "status": "BLOCKED",
+            "reason": "No input image passed selection, so there is nothing to hand to a reconstruction backend.",
+            "next_action": "Review the sharpness and similarity thresholds, then rerun input selection.",
+        }
+
+    if missing_provenance > 0:
+        return {
+            "status": "ACTION_REQUIRED",
+            "reason": (
+                f"{missing_provenance} of {input_count} input images are missing required provenance fields."
+            ),
+            "next_action": (
+                "Complete source_page, image_url, sha256, width, height, and content_type in the input manifest."
+            ),
+        }
+
+    if backend_status == "failed" or (
+        isinstance(return_code, int) and return_code != 0
+    ):
+        return {
+            "status": "BLOCKED",
+            "reason": "The recorded reconstruction backend execution failed.",
+            "next_action": "Inspect the backend run manifest, resolve the failure, and rerun the backend.",
+        }
+
+    if backend_status == "not_run":
+        return {
+            "status": "READY_FOR_BACKEND",
+            "reason": "Input selection and provenance checks have evidence, but no reconstruction backend run is attached.",
+            "next_action": "Run a reconstruction backend and attach its run manifest to this audit.",
+        }
+
+    if backend_status == "success":
+        return {
+            "status": "REVIEW_READY",
+            "reason": "Input selection, provenance, and a successful backend run are recorded.",
+            "next_action": (
+                "Evaluate registration, reprojection, geometry completeness, and texture quality before claiming 3D quality."
+            ),
+        }
+
+    return {
+        "status": "REVIEW_REQUIRED",
+        "reason": f"Backend evidence is recorded with status {backend_status!r}, but success is not established.",
+        "next_action": "Inspect the backend run manifest and establish an explicit success or failure state.",
+    }
+
 def _report_css() -> str:
     if not _REPORT_CSS_ENTRY.is_file():
         raise FileNotFoundError(f"Report CSS entry does not exist: {_REPORT_CSS_ENTRY}")
@@ -123,17 +181,18 @@ def _report_css() -> str:
 def _render_html(report: dict) -> str:
     reason_counts = report["selection"]["reason_counts"]
     dimensions = report["dimensions"]
+    decision = report["decision"]
+    selected = report["selection"]["selected_count"]
+    input_count = report["input"]["count"]
+    covered = report["provenance"]["covered_count"]
     rows = [
-        ("Input images", report["input"]["count"]),
-        ("Selected images", report["selection"]["selected_count"]),
+        ("Input images", input_count),
+        ("Selected images", selected),
         ("Low sharpness", reason_counts["LOW_SHARPNESS"]),
         ("Near duplicate", reason_counts["NEAR_DUPLICATE"]),
         ("Exact duplicate manifest rows", reason_counts["EXACT_DUPLICATE"]),
         ("Missing provenance", reason_counts["PROVENANCE_MISSING"]),
-        (
-            "Provenance coverage",
-            f"{report['provenance']['covered_count']}/{report['input']['count']}",
-        ),
+        ("Provenance coverage", f"{covered}/{input_count}"),
         ("Distinct image sizes", dimensions["distinct_size_count"]),
         ("Backend execution", report["backend"]["status"]),
         ("Backend manifest", report["backend"]["run_manifest_path"] or "not recorded"),
@@ -156,11 +215,54 @@ def _render_html(report: dict) -> str:
 <body>
   <header class="audit-header">
     <p class="audit-kicker">AutoPhotogrammetry / input audit</p>
-    <h1>Photogrammetry input audit</h1>
-    <p class="audit-asset"><strong>Asset:</strong> {html.escape(report["asset_id"])}</p>
+    <div class="audit-title-row">
+      <div>
+        <h1>Photogrammetry input audit</h1>
+        <p class="audit-asset"><strong>Asset:</strong> {html.escape(report["asset_id"])}</p>
+      </div>
+      <strong class="audit-status" data-status="{html.escape(decision["status"])}">{html.escape(decision["status"])}</strong>
+    </div>
   </header>
   <main>
-    <table><tbody>{table}</tbody></table>
+    <section class="decision-surface" aria-labelledby="decision-heading">
+      <div>
+        <p class="surface-kicker">Current decision</p>
+        <h2 id="decision-heading">{html.escape(decision["reason"])}</h2>
+      </div>
+      <div class="next-action">
+        <span>Next action</span>
+        <strong>{html.escape(decision["next_action"])}</strong>
+      </div>
+    </section>
+
+    <section class="kpi-grid" aria-label="Readiness summary">
+      <div class="kpi">
+        <span>Selected</span>
+        <strong>{selected}/{input_count}</strong>
+        <small>input images</small>
+      </div>
+      <div class="kpi">
+        <span>Provenance</span>
+        <strong>{covered}/{input_count}</strong>
+        <small>fully covered</small>
+      </div>
+      <div class="kpi">
+        <span>Backend</span>
+        <strong>{html.escape(str(report["backend"]["status"]))}</strong>
+        <small>execution evidence</small>
+      </div>
+      <div class="kpi">
+        <span>Image sizes</span>
+        <strong>{dimensions["distinct_size_count"]}</strong>
+        <small>distinct sizes</small>
+      </div>
+    </section>
+
+    <details class="evidence-details">
+      <summary>Evidence details</summary>
+      <table><tbody>{table}</tbody></table>
+    </details>
+
     <div class="notice">
       <p><strong>Scope boundary</strong></p>
       <p>This report describes input selection and provenance only.</p>
@@ -289,6 +391,7 @@ def build_readiness_report(
             "quality_guarantee": False,
         },
     }
+    report["decision"] = _audit_decision(report)
 
     selected_manifest = {
         "schema_version": 1,

--- a/tests/test_readiness_report.py
+++ b/tests/test_readiness_report.py
@@ -77,6 +77,9 @@ class ReadinessReportTests(unittest.TestCase):
             self.assertFalse(report["generated_views_used"])
             self.assertEqual(report["backend"]["status"], "not_run")
             self.assertIsNone(report["backend"]["run_manifest_path"])
+            self.assertEqual(report["decision"]["status"], "READY_FOR_BACKEND")
+            self.assertIn("no reconstruction backend run", report["decision"]["reason"])
+            self.assertIn("Run a reconstruction backend", report["decision"]["next_action"])
             self.assertFalse(report["quality_measurements"]["quality_guarantee"])
             self.assertIsNone(report["quality_measurements"]["registration_rate"])
             self.assertIsNone(report["quality_measurements"]["reprojection_error"])
@@ -84,6 +87,11 @@ class ReadinessReportTests(unittest.TestCase):
             self.assertEqual(selected_manifest["asset_id"], "artifact")
             self.assertEqual(len(selected_manifest["images"]), 1)
             self.assertIn("does not guarantee 3D reconstruction quality", report_html)
+            self.assertIn('class="decision-surface"', report_html)
+            self.assertIn('data-status="READY_FOR_BACKEND"', report_html)
+            self.assertIn("Next action", report_html)
+            self.assertIn("Evidence details", report_html)
+            self.assertLess(report_html.index("Next action"), report_html.index("Evidence details"))
 
     def test_report_links_existing_backend_manifest_by_asset_and_hash(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -115,6 +123,8 @@ class ReadinessReportTests(unittest.TestCase):
             self.assertEqual(report["backend"]["status"], "success")
             self.assertEqual(report["backend"]["return_code"], 0)
             self.assertEqual(report["backend"]["run_manifest_path"], str(backend_manifest))
+            self.assertEqual(report["decision"]["status"], "REVIEW_READY")
+            self.assertIn("successful backend run", report["decision"]["reason"])
             self.assertEqual(
                 report["backend"]["run_manifest_sha256"],
                 sha256_file(backend_manifest),
@@ -138,6 +148,31 @@ class ReadinessReportTests(unittest.TestCase):
                     output_root=root / "output",
                     backend_run_manifest=backend_manifest,
                 )
+
+    def test_missing_provenance_requires_action_before_backend_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            image_dir = self._write_input(root)
+            manifest_path = image_dir / "manifest.json"
+            records = json.loads(manifest_path.read_text(encoding="utf-8"))
+            records[0].pop("source_page")
+            write_json(manifest_path, records)
+
+            result = build_readiness_report(
+                "artifact",
+                input_root=root / "input",
+                output_root=root / "output",
+            )
+            report = json.loads(Path(result["report_json"]).read_text(encoding="utf-8"))
+            report_html = Path(result["report_html"]).read_text(encoding="utf-8")
+
+            self.assertEqual(
+                report["selection"]["reason_counts"]["PROVENANCE_MISSING"], 1
+            )
+            self.assertEqual(report["decision"]["status"], "ACTION_REQUIRED")
+            self.assertIn("missing required provenance", report["decision"]["reason"])
+            self.assertIn("source_page", report["decision"]["next_action"])
+            self.assertIn('data-status="ACTION_REQUIRED"', report_html)
 
     def test_report_ignores_stale_manifest_rows_when_counting_exact_duplicates(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_readiness_report.py
+++ b/tests/test_readiness_report.py
@@ -166,9 +166,7 @@ class ReadinessReportTests(unittest.TestCase):
             report = json.loads(Path(result["report_json"]).read_text(encoding="utf-8"))
             report_html = Path(result["report_html"]).read_text(encoding="utf-8")
 
-            self.assertEqual(
-                report["selection"]["reason_counts"]["PROVENANCE_MISSING"], 1
-            )
+            self.assertEqual(report["selection"]["reason_counts"]["PROVENANCE_MISSING"], 1)
             self.assertEqual(report["decision"]["status"], "ACTION_REQUIRED")
             self.assertIn("missing required provenance", report["decision"]["reason"])
             self.assertIn("source_page", report["decision"]["next_action"])


### PR DESCRIPTION
Implements the screenshot-driven readiness-report findings from KAFKA2306/design#18.

- derives an audit-level status without claiming reconstruction quality
- adds reason + next action above evidence
- summarizes selected/input, provenance, backend evidence, and image-size count as key measures
- collapses the detailed audit table into supporting Evidence
- keeps the explicit scope boundary that registration/reprojection/geometry/texture quality are not measured
- adds tests for READY_FOR_BACKEND, REVIEW_READY, and ACTION_REQUIRED semantics

Status semantics are intentionally audit-scoped:
- BLOCKED: no selected input or failed backend
- ACTION_REQUIRED: required provenance is incomplete
- READY_FOR_BACKEND: selection/provenance ready, backend not run
- REVIEW_READY: successful backend evidence recorded, downstream quality still unverified
- REVIEW_REQUIRED: backend evidence is ambiguous

Acceptance:
- exact-head Test + Artifact policy green
- canonical portable conformance green
- squash merge exact head
- main read-back and main CI green
- render desktop/mobile readiness HTML and visually confirm status/action/KPI precede Evidence