### PR TITLE
ci: use canonical reusable design conformance

### DIFF
--- a/.github/workflows/design-conformance.yml
+++ b/.github/workflows/design-conformance.yml
@@ -11,8 +11,4 @@ permissions:
 
 jobs:
   conformance:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Verify canonical design contract
-        run: node assets/.kafka-design/portable-conformance.mjs --consumer "$GITHUB_WORKSPACE"
+    uses: KAFKA2306/design/.github/workflows/conformance.yml@a6e586bbbb9c755f96ef9f48c60481971ddf845c


### PR DESCRIPTION
Replaces the local orchestration steps with the canonical reusable workflow from KAFKA2306/design at exact SHA a6e586bbbb9c755f96ef9f48c60481971ddf845c. The consumer-owned managed portable verifier remains the actual conformance engine; this removes duplicate CI orchestration and provides cross-repository proof for KAFKA2306/design#18.